### PR TITLE
Make the message store configurable

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1696,3 +1696,28 @@
          true;
     (Name) -> vmq_schema_util:file_is_readable(Name)
  end}.
+
+%% @doc Select the message store backend.
+{mapping, "message_store", "vmq_server.message_store", [
+                                                        {default, leveldb},
+                                                        {datatype, {enum, [leveldb, none]}},
+                                                        hidden
+                                                       ]}.
+
+{translation,
+ "vmq_server.message_store",
+ fun(Conf) ->
+         Backend = cuttlefish:conf_get("message_store", Conf),
+         case Backend of
+             leveldb ->
+                 [{child_specs, [{vmq_lvldb_store_sup,
+                                  {vmq_lvldb_store_sup, start_link, []},
+                                  permanent, 5000, supervisor, [vmq_lvldb_store_sup]}]},
+                  {opts, [{store_dir, "./data/msgstore"},
+                          {open_retries, 30},
+                          {open_retry_delay, 2000}
+                         ]}];
+             none ->
+                 []
+         end
+ end}.

--- a/apps/vmq_server/src/vmq_lvldb_store.erl
+++ b/apps/vmq_server/src/vmq_lvldb_store.erl
@@ -138,7 +138,8 @@ init([InstanceId]) ->
     %% Initialize random seed
     rand:seed(exsplus, os:timestamp()),
 
-    Opts = vmq_config:get_env(msg_store_opts, []),
+    {ok, Backend} = application:get_env(vmq_server, message_store),
+    Opts = proplists:get_value(opts, Backend, []),
     DataDir1 = proplists:get_value(store_dir, Opts, "data/msgstore"),
     DataDir2 = filename:join(DataDir1, integer_to_list(InstanceId)),
 

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -98,15 +98,13 @@
         ]},
 
       % default message store opts
-      {msg_store_childspecs, [{vmq_lvldb_store_sup,
-                               {vmq_lvldb_store_sup, start_link, []},
-                               permanent, 5000, supervisor, [vmq_lvldb_store_sup]}]},
-      {msg_store_opts, [
-                        {store_dir, "./data/msgstore"},
-                        {open_retries, 30},
-                        {open_retry_delay, 2000}
-                       ]},
-
+      {message_store, [{child_specs, [{vmq_lvldb_store_sup,
+                                       {vmq_lvldb_store_sup, start_link, []},
+                                       permanent, 5000, supervisor, [vmq_lvldb_store_sup]}]},
+                       {opts, [{store_dir, "./data/msgstore"},
+                               {open_retries, 30},
+                               {open_retry_delay, 2000}
+                              ]}]},
 
       % Graphite
       {graphite_enabled, false},

--- a/apps/vmq_server/src/vmq_server_sup.erl
+++ b/apps/vmq_server/src/vmq_server_sup.erl
@@ -41,7 +41,8 @@ start_link() ->
                          [{atom(), {atom(), atom(), list()},
                            permanent, pos_integer(), worker, [atom()]}]}}.
 init([]) ->
-    {ok, MsgStoreChildSpecs} = application:get_env(vmq_server, msg_store_childspecs),
+    {ok, Backend} = application:get_env(vmq_server, message_store),
+    MsgStoreChildSpecs = proplists:get_value(child_specs, Backend, []),
 
     maybe_change_nodename(),
 

--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,8 @@
 - Fix error when tracing clients connecting with a LWT.
 - Add file validation to check if files in the `vernemq.conf` exist and are
   readable.
+- Add new hidden configuration `message_store` which makes it possible to select
+  the message store backend. Possible values are `leveldb` and `none`.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
So, this is a quick WIP I threw together to make it possible to decide which kind of message store one would like to use. Currently only two are supported, namely: `leveldb` and `none`.

I'm not completely sure about the `none` backend yet - it simply doesn't register any hooks for the backend, which means anything calling `vmq_plugin:only(msg_store_xxxx, ...` gets a `{error,no_matching_hook_found}` error back which effectively means no backend is present. We should probably look at all code paths touching the message store to verify they can handle that situation correctly. Another way would be to actually implement a `none` backend which would return proper answers and just ok any messages written into it. I'm not sure that's a good idea, as the code would then not be able to differentiate between persisted/not persisted...

Of course, the actual goal of this is to, somewhere down the road, be able to offer other message store backends than `leveldb` or `none`.

What it doesn't handle yet -  if is one wants to combine a layer on top of a backed. For example, some caching layer or a layer causing writes to be delayed. One could imagine that such a layer could be combined with any actual backend. I suppose that might be solved by being able to specify the layer as the backend and then configure the layer independently to use leveldb...

This PR would partially address #554