### PR TITLE
Refactor property modifiers

### DIFF
--- a/apps/vmq_plugin/src/vmq_plugin_util.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_util.erl
@@ -65,38 +65,21 @@ to_internal_qos(128) ->
 to_internal_qos(V) when is_integer(V) ->
     V.
 
-
 modifiers(auth_on_register_m5) ->
-    [{properties, gen_property_validator([?P_SESSION_EXPIRY_INTERVAL,
-                                          ?P_AUTHENTICATION_METHOD,
-                                          ?P_AUTHENTICATION_DATA,
-                                          ?P_REQUEST_RESPONSE_INFO,
-                                          ?P_RECEIVE_MAX,
-                                          ?P_TOPIC_ALIAS_MAX,
-                                          ?P_USER_PROPERTY,
-                                          ?P_MAX_PACKET_SIZE])}|
+    [{user_property, fun user_property/1},
+     {session_expiry_interval, fun val_int/1}|
      modifiers(auth_on_register)];
 modifiers(auth_on_publish_m5) ->
-    [{properties, gen_property_validator([?P_PAYLOAD_FORMAT_INDICATOR,
-                                          ?P_MESSAGE_EXPIRY_INTERVAL,
-                                          ?P_CONTENT_TYPE,
-                                          ?P_RESPONSE_TOPIC,
-                                          ?P_CORRELATION_DATA,
-                                          ?P_SUBSCRIPTION_ID,
-                                          ?P_TOPIC_ALIAS,
-                                          ?P_USER_PROPERTY])}|
-                                          modifiers(auth_on_publish)];
+    [{user_property, fun user_property/1},
+     {message_expiry_interval, fun val_int/1}|
+     modifiers(auth_on_publish)];
 modifiers(auth_on_subscribe_m5) ->
-    [{topics, fun val_sub_topics/1},
-     {properties, gen_property_validator([?P_SUBSCRIPTION_ID,
-                                          ?P_USER_PROPERTY])}];
+    [{topics, fun val_sub_topics/1}];
 modifiers(on_unsubscribe_m5) ->
     [{topics, fun val_unsub_topics/1}];
 modifiers(on_auth_m5) ->
-    [{properties, gen_property_validator([?P_AUTHENTICATION_DATA,
-                                          ?P_AUTHENTICATION_METHOD,
-                                          ?P_REASON_STRING,
-                                          ?P_USER_PROPERTY])},
+    [{authentication_method, fun val_binary/1},
+     {authentication_data, fun val_binary/1},
      {reason_code, fun val_int/1}];
 modifiers(auth_on_register) ->
     [{allow_register, fun val_bool/1},
@@ -131,101 +114,6 @@ modifiers(on_deliver) ->
 modifiers(_) -> [].
 
 %% Validators For the Modifiers
-
--type property_name() :: atom().
--type validator() :: fun((any()) -> true | false | {ok, any()}).
-
--spec gen_property_validator([property_name()]) -> validator().
-gen_property_validator(AllowedProperties) ->
-    fun(Properties) ->
-            maps:fold(
-              fun(_,_, false) -> false;
-                 (Name, Val, {ok, Acc}) ->
-                      case lists:member(Name, AllowedProperties) of
-                          false ->
-                              false;
-                          true ->
-                              case val_property(Name, Val) of
-                                  false -> false;
-                                  true -> {ok, maps:put(Name,Val, Acc)};
-                                  {ok, Val1} ->
-                                      {ok, maps:put(Name, Val1, Acc)}
-                              end
-                      end
-              end,
-              {ok, #{}},
-              Properties)
-    end.
-
-val_property(?P_PAYLOAD_FORMAT_INDICATOR, Val) ->
-    case Val of
-        utf8 -> true;
-        unspecified -> true;
-        _ -> false
-    end;
-val_property(?P_MESSAGE_EXPIRY_INTERVAL, Val) ->
-    val_int(Val, 0, 4294967296);
-val_property(?P_CONTENT_TYPE, Val) ->
-    val_binary(Val);
-val_property(?P_RESPONSE_TOPIC, Val) ->
-    val_pub_topic(Val);
-val_property(?P_CORRELATION_DATA, Val) ->
-    val_binary(Val);
-val_property(?P_SUBSCRIPTION_ID, Vals) ->
-    lists:all(
-      fun(Id) when is_integer(Id) ->
-              true;
-         (_) -> false
-      end, Vals);
-val_property(?P_SESSION_EXPIRY_INTERVAL, Val) ->
-    val_int(Val, 0, 4294967296);
-val_property(?P_ASSIGNED_CLIENT_ID, Val) ->
-    val_binary(Val);
-val_property(?P_SERVER_KEEP_ALIVE, Val) ->
-    val_int(Val, 0, 65536);
-val_property(?P_AUTHENTICATION_METHOD, Val) ->
-    val_binary(Val);
-val_property(?P_AUTHENTICATION_DATA, Val) ->
-    val_binary(Val);
-val_property(?P_REQUEST_PROBLEM_INFO, Val) ->
-    val_bool(Val);
-val_property(?P_WILL_DELAY_INTERVAL, Val) ->
-    val_int(Val, 0, 4294967296);
-val_property(?P_REQUEST_RESPONSE_INFO, Val) ->
-    val_bool(Val);
-val_property(?P_RESPONSE_INFO, Val) ->
-    val_binary(Val);
-val_property(?P_SERVER_REF, Val) ->
-    val_binary(Val);
-val_property(?P_REASON_STRING, Val) ->
-    val_binary(Val);
-val_property(?P_RECEIVE_MAX, Val) ->
-    val_int(Val, 1, 65535);
-val_property(?P_TOPIC_ALIAS_MAX, Val) ->
-    val_int(Val, 1, 65535);
-val_property(?P_TOPIC_ALIAS, Val) ->
-    val_int(Val, 1, 65535);
-val_property(?P_MAX_QOS, Val) ->
-    val_int(Val, 0, 1);
-val_property(?P_RETAIN_AVAILABLE, Val) ->
-    val_bool(Val);
-val_property(?P_USER_PROPERTY, Vals) ->
-    %% check that val is a list of {binary(), binary()}.
-    lists:all(fun({K,V}) when is_binary(K), is_binary(V) ->
-                      true;
-                 (_) -> false
-              end, Vals);
-val_property(?P_MAX_PACKET_SIZE, Val) ->
-    val_int(Val, 1, 4294967296);
-val_property(?P_WILDCARD_SUBS_AVAILABLE, Val) ->
-    val_bool(Val);
-val_property(?P_SUB_IDS_AVAILABLE, Val) ->
-    val_bool(Val);
-val_property(?P_SHARED_SUBS_AVAILABLE, Val) ->
-    val_bool(Val);
-val_property(_, _) ->
-    false.
-
 val_bool(B) -> is_boolean(B).
 
 val_atom(B) when is_binary(B) -> {ok, binary_to_existing_atom(B, utf8)};
@@ -244,10 +132,6 @@ val_int(I) when is_integer(I) -> true;
 val_int(N) when is_number(N) -> {ok, round(N)};
 val_int(_) -> false.
 
-val_int(I, Min, Max) when is_integer(I), Min =< I, I =< Max ->
-    true;
-val_int(_,_,_) -> false.
-
 val_subscriber_id([{_, _}|_] = SubscriberIdModifier) ->
     case {lists:keyfind(client_id, 1, SubscriberIdModifier),
           lists:keyfind(mountpoint, 1, SubscriberIdModifier)} of
@@ -257,6 +141,13 @@ val_subscriber_id([{_, _}|_] = SubscriberIdModifier) ->
             false
     end;
 val_subscriber_id(_) -> false.
+
+user_property(Vals) ->
+    %% check that val is a list of {binary(), binary()}.
+    lists:all(fun({K,V}) when is_binary(K), is_binary(V) ->
+                      true;
+                 (_) -> false
+              end, Vals).
 
 val_pub_topic(B) when is_binary(B) ->
     case vmq_topic:validate_topic(publish, B) of

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1136,10 +1136,9 @@ auth_on_publish(User, SubscriberId, #vmq_msg{routing_key=Topic,
                 maps:fold(
                   fun(reason_string,V,A) -> maps:put(?P_REASON_STRING,V,A);
                      (user_property,V,A) -> maps:put(?P_USER_PROPERTY,V,A);
-                     (message_expiry,V,A) -> maps:put(?P_MESSAGE_EXPIRY_INTERVAL,V,A);
+                     (message_expiry_interval,V,A) -> maps:put(?P_MESSAGE_EXPIRY_INTERVAL,V,A);
                      (_,_,A) -> A
                   end,Properties,Args0),
-            ChangedProperties = maps:get(properties, Args0, Properties),
             HookArgs1 = [User, SubscriberId, ChangedQoS,
                          ChangedTopic, ChangedPayload,
                          ChangedIsRetain, ChangedProperties],

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -84,7 +84,7 @@ groups() ->
                    not_allowed_publish_qos0_mqtt_5,
                    not_allowed_publish_qos1_mqtt_5,
                    not_allowed_publish_qos2_mqtt_5,
-                   message_expiry,
+                   message_expiry_interval,
                    publish_c2b_topic_alias,
                    publish_b2c_topic_alias,
                    forward_properties,
@@ -670,7 +670,7 @@ shared_subscription_online_first(Cfg) ->
     disable_on_publish(),
     disable_on_subscribe().
 
-message_expiry(_) ->
+message_expiry_interval(_) ->
     %% If the Message Expiry Interval has passed and the Server has
     %% not managed to start onward delivery to a matching subscriber,
     %% then it MUST delete the copy of the message for that subscriber

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -684,79 +684,25 @@ atomize_keys(Mods) ->
       end, Mods).
 
 normalize_properties(Mods, Opts) ->
-    case lists:keyfind(properties, 1, Mods) of
-        {_, Props} ->
-            NProps = lists:foldl(
-                       fun({K,V}, Acc) ->
-                               [normalize_property(K,V,Opts)|Acc]
-                       end, [], Props),
-            lists:keyreplace(properties, 1, Mods, {properties, maps:from_list(NProps)});
-        false ->
-            Mods
-    end.
+    lists:map(
+      fun({K,V}) ->
+              normalize_property(K, V, Opts)
+      end, Mods).
 
-normalize_property(<<"payload_format_indicator">>, Val, _Opts) ->
-    NVal = try
-               binary_to_existing_atom(Val, utf8)
-           catch
-               error:badarg ->
-                   Val
-           end,
-    {?P_PAYLOAD_FORMAT_INDICATOR, NVal};
-normalize_property(<<"message_expiry_interval">>, Val, _Opts) ->
-    {?P_MESSAGE_EXPIRY_INTERVAL, Val};
-normalize_property(<<"content_type">>, Val, _Opts) ->
-    {?P_CONTENT_TYPE, Val};
-normalize_property(<<"response_topic">>, Val, _Opts) ->
-    {?P_RESPONSE_TOPIC, Val};
-normalize_property(<<"correlaton_data">>, Val, _Opts) ->
-    {?P_CORRELATION_DATA, base64:decode(Val)};
-normalize_property(<<"subscription_id">>, Vals, _Opts) ->
-    {?P_SUBSCRIPTION_ID, Vals};
-normalize_property(<<"session_expiry_interval">>, Val, _Opts) ->
-    {?P_SESSION_EXPIRY_INTERVAL, Val};
-normalize_property(<<"assigned_client_id">>, Val, _Opts) ->
-    {?P_ASSIGNED_CLIENT_ID, Val};
-normalize_property(<<"server_keep_alive">>, Val, _Opts) ->
-    {?P_SERVER_KEEP_ALIVE, Val};
-normalize_property(<<"authentication_method">>, Val, _Opts) ->
-    {?P_AUTHENTICATION_METHOD, Val};
-normalize_property(<<"authentication_data">>, Val, _Opts) ->
-    {?P_AUTHENTICATION_DATA, base64:decode(Val)};
-normalize_property(<<"request_problem_info">>, Val, _Opts) ->
-    {?P_REQUEST_PROBLEM_INFO, Val};
-normalize_property(<<"will_delay_interval">>, Val, _Opts) ->
-    {?P_WILL_DELAY_INTERVAL, Val};
-normalize_property(<<"request_response_info">>, Val, _Opts) ->
-    {?P_REQUEST_RESPONSE_INFO, Val};
-normalize_property(<<"response_info">>, Val, _Opts) ->
-    {?P_RESPONSE_INFO, Val};
-normalize_property(<<"server_reference">>, Val, _Opts) ->
-    {?P_SERVER_REF, Val};
-normalize_property(<<"reason_string">>, Val, _Opts) ->
-    {?P_REASON_STRING, Val};
-normalize_property(<<"receive_max">>, Val, _Opts) ->
-    {?P_RECEIVE_MAX, Val};
-normalize_property(<<"topic_alias_maximum">>, Val, _Opts) ->
-    {?P_TOPIC_ALIAS_MAX, Val};
-normalize_property(<<"topic_alias">>, Val, _Opts) ->
-    {?P_TOPIC_ALIAS, Val};
-normalize_property(<<"max_qos">>, Val, _Opts) ->
-    {?P_MAX_QOS, Val};
-normalize_property(<<"retain_available">>, Val, _Opts) ->
-    {?P_RETAIN_AVAILABLE, Val};
-normalize_property(<<"user_property">>, Values, _Opts) ->
+normalize_property(user_property, Values, _Opts) ->
     NValues = [{K,V} || [{_,K},{_,V}] <- Values],
-    {?P_USER_PROPERTY, NValues};
-normalize_property(<<"max_packet_size">>, Val, _Opts) ->
-    {?P_MAX_PACKET_SIZE, Val};
-normalize_property(<<"wildcard_subscriptions_available">>, Val, _Opts) ->
-    {?P_WILDCARD_SUBS_AVAILABLE, Val};
-normalize_property(<<"subscription_identifiers_available">>, Val, _Opts) ->
-    {?P_SUB_IDS_AVAILABLE, Val};
-normalize_property(<<"shared_subscriptions_available">>, Val, _Opts) ->
-    {?P_SHARED_SUBS_AVAILABLE, Val}.
-
+    {user_property, NValues};
+normalize_property(message_expiry_interval, Val, _Opts) ->
+    {message_expiry_interval, Val};
+normalize_property(session_expiry_interval, Val, _Opts) ->
+    {session_expiry_interval, Val};
+normalize_property(authentication_method, Val, _Opts) ->
+    {authentication_method, Val};
+normalize_property(authentication_data, Val, _Opts) ->
+    {authentication_data, base64:decode(Val)};
+normalize_property(K,V, _Opts) ->
+    %% let through unmodified.
+    {K,V}.
 
 normalize_modifiers(Hook, Mods, Opts)
   when Hook =:= auth_on_register_m5;

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -181,7 +181,7 @@ auth_on_register_m5_test(_) ->
     WantUserProps = [{<<"key1">>, <<"val1">>},
                      {<<"key1">>, <<"val2">>},
                      {<<"key2">>, <<"val2">>}],
-    {ok, #{properties := #{p_user_property := GotUserProps}}}
+    {ok, #{user_property := GotUserProps}}
         = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [?PEER, {?MOUNTPOINT, ?WITH_PROPERTIES}, ?USERNAME, ?PASSWORD, true, #{p_user_property => WantUserProps}]),
     [] = WantUserProps -- GotUserProps,
@@ -324,9 +324,8 @@ on_deliver_m5_test(_) ->
 on_auth_m5_test(_) ->
     register_hook(on_auth_m5, ?ENDPOINT),
     {ok,
-     #{properties :=
-           #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,
-             ?P_AUTHENTICATION_DATA := <<"AUTH_DATA1">>}}}
+     #{authentication_method := <<"AUTH_METHOD">>,
+       authentication_data := <<"AUTH_DATA1">>}}
         = vmq_plugin:all_till_ok(on_auth_m5,
                                  [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID},
                                   #{?P_AUTHENTICATION_METHOD => <<"AUTH_METHOD">>,

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -127,10 +127,9 @@ auth_on_register_m5(#{client_id := ?CHANGED_CLIENT_ID}) ->
 
 auth_on_register_m5(#{client_id := ?WITH_PROPERTIES}) ->
     {200, #{result => <<"ok">>,
-            modifiers => #{properties => #{user_property => [[key(<<"key1">>), val(<<"val1">>)],
-                                                             [key(<<"key1">>), val(<<"val2">>)],
-                                                             [key(<<"key2">>), val(<<"val2">>)]]
-                                          }
+            modifiers => #{user_property => [[key(<<"key1">>), val(<<"val1">>)],
+                                             [key(<<"key1">>), val(<<"val2">>)],
+                                             [key(<<"key2">>), val(<<"val2">>)]]
                           }
            }
     };
@@ -363,9 +362,8 @@ on_auth_m5(#{properties :=
              client_id := ?ALLOWED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             modifiers =>
-                #{properties =>
-                      #{authentication_method => <<"AUTH_METHOD">>,
-                        authentication_data => base64:encode(<<"AUTH_DATA1">>)},
+                #{authentication_method => <<"AUTH_METHOD">>,
+                  authentication_data => base64:encode(<<"AUTH_DATA1">>),
                   reason_code => 0}}}.
 
 terminate(_Reason, _Req, _State) ->

--- a/rebar.lock
+++ b/rebar.lock
@@ -101,7 +101,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/erlio/vernemq_dev.git",
-       {ref,"6e41cce7d8a1dfd414782536e0c71bee0f04f5e3"}},
+       {ref,"ccc09cb57cbb80f943895c9e40ac112603bc804d"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
- Make webhook property modifiers behave as the native hook property modifiers. That is, properties passed via the arguments cannot be modified and returned directly, but each modifier has to be passed explicitly. We did this change in the internal modifiers to make it more explicit what it means when modifying a property.

Fortunately we hadn't yet documented modifying properties in webhooks, so no harm done here (though it's of course all still in BETA, but still).
