### PR TITLE
Improve error for invalid `vmq_diversity` modifiers

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -476,6 +476,8 @@ all_till_ok([Pid|Rest], HookName, Args) ->
         Mods0 when is_list(Mods0) ->
             Mods1 = normalize_modifiers(HookName, Mods0),
             case vmq_plugin_util:check_modifiers(HookName, Mods1) of
+                error ->
+                    {error, {invalid_modifiers, Mods1}};
                 CheckedModifiers ->
                     {ok, CheckedModifiers}
             end;

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -78,7 +78,11 @@ function auth_on_publish_m5(pub)
     assert(pub.qos == 1)
     assert(pub.payload == "hello world")
     assert(pub.retain == false)
-    if pub.client_id ~= "changed-subscriber-id" then
+    if pub.client_id == "invalid_topic_mod" then
+       return {topic = 5}
+    elseif pub.client_id == "unknown_mod" then
+       return {unknown = 5}
+    elseif pub.client_id ~= "changed-subscriber-id" then
         print("auth_on_publish_m5 called")
         return validate_client_id(pub.client_id)
     else

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -50,7 +50,9 @@ all() ->
 
      auth_on_register_m5_test,
      auth_on_subscribe_m5_test,
-     auth_on_publish_m5_test
+     auth_on_publish_m5_test,
+
+     invalid_modifiers_test
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -98,6 +100,14 @@ auth_on_publish_m5_test(_) ->
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false, props()]),
     {ok, #{topic := [<<"hello">>, <<"world">>]}} = vmq_plugin:all_till_ok(auth_on_publish_m5,
                       [username(), changed_subscriber_id(), 1, topic(), payload(), false, props()]).
+
+invalid_modifiers_test(_) ->
+    {error,{invalid_modifiers,#{topic := 5}}} =
+        vmq_plugin:all_till_ok(auth_on_publish_m5,
+                               [username(), {"", <<"invalid_topic_mod">>}, 1, topic(), payload(), false, props()]),
+    {error,{invalid_modifiers,#{unknown := 5}}} =
+        vmq_plugin:all_till_ok(auth_on_publish_m5,
+                               [username(), {"", <<"unknown_mod">>}, 1, topic(), payload(), false, props()]).
 
 auth_on_subscribe_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,8 @@
   block the client with tools like Fail2ban (#931).
 - Fix issue which would crash the session if a client would resend a (valid)
   pubrec during a Qos2 flow (#926).
+- Fix `vmq_diversity` error message if invalid or unknown modifiers are returned
+  from a lua hook implementation.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Make the `vmq_diversity` errors more meaningful when returning an invalid or unknown modifier from a hook implementation