### PR TITLE
Add server ref test

### DIFF
--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
@@ -45,8 +45,30 @@ auth_on_register_m5(Peer,SubscriberId,Username,Password,CleanStart,Properties) -
 auth_on_register_m5_(_Peer,_SubscriberId,<<"quota_exceeded">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?QUOTA_EXCEEDED,
               reason_string => <<"You have exceeded your quota">>}};
-auth_on_register_m5_(_Peer,_SubscriberId,<<"modify_props">>,_Password,_CleanStart, #{p_user_property := UP}) ->
-    {ok, #{user_property => [{<<"key">>, <<"val">>}|UP]}};
+auth_on_register_m5_(_Peer,_SubscriberId,<<"use_another_server">>,_Password,_CleanStart,_Properties) ->
+    {error, #{reason_code => ?USE_ANOTHER_SERVER,
+              server_ref => <<"server_ref">>}};
+auth_on_register_m5_(_Peer,_SubscriberId,<<"server_moved">>,_Password,_CleanStart,_Properties) ->
+    {error, #{reason_code => ?SERVER_MOVED,
+              server_ref => <<"server_ref">>}};
+auth_on_register_m5_(_Peer,_SubscriberId,<<"broker_capabilities">>,_Password,_CleanStart,_Properties) ->
+    {ok, #{reason_code => ?SUCCESS,
+           max_qos => 0,
+           retain_available => false,
+           wildcard_subscriptions_available => false,
+           subscription_identifiers_available => false,
+           shared_subscriptions_available => false
+           %% TODO: See vmq_mqtt5_fsm:auth_on_register/4
+           %%max_packet_size => 1024
+
+           %% TODO: verify if the properties below can be
+           %% controlled from plugins.
+           %%
+           %%topic_alias_max => 100,
+           %%receive_max => 100,
+           %%server_keep_alive => 4000,
+           %%session_expiry_interval => 3600
+          }};
 auth_on_register_m5_(_Peer,_SubscriberId,_Username,_Password,_CleanStart,_Properties) ->
     ok.
 

--- a/apps/vmq_server/test/vmq_mqtt5_demo_plugin_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_demo_plugin_SUITE.erl
@@ -35,6 +35,9 @@ groups() ->
     ConnectTests =
     [
      connack_error_with_reason_string,
+     connack_error_use_another_server,
+     connack_error_server_moved,
+     connack_broker_capabilities,
      publish_modify_props,
      puback_error_with_reason_string,
      pubrec_error_with_reason_string,
@@ -54,6 +57,41 @@ connack_error_with_reason_string(Cfg) ->
                    reason_code = ?M5_QUOTA_EXCEEDED,
                    properties = #{?P_REASON_STRING :=
                                       <<"You have exceeded your quota">>}}
+        = Connack,
+    ok = gen_tcp:close(Socket).
+
+connack_error_use_another_server(Cfg) ->
+    ClientId = vmq_cth:ustr(Cfg),
+    Connect = packetv5:gen_connect(ClientId, [{username, <<"use_another_server">>}]),
+    {ok, Socket, Connack, <<>>} = packetv5:do_client_connect(Connect, []),
+    #mqtt5_connack{session_present = 0,
+                   reason_code = ?M5_USE_ANOTHER_SERVER,
+                   properties = #{?P_SERVER_REF :=
+                                      <<"server_ref">>}}
+        = Connack,
+    ok = gen_tcp:close(Socket).
+
+connack_error_server_moved(Cfg) ->
+    ClientId = vmq_cth:ustr(Cfg),
+    Connect = packetv5:gen_connect(ClientId, [{username, <<"server_moved">>}]),
+    {ok, Socket, Connack, <<>>} = packetv5:do_client_connect(Connect, []),
+    #mqtt5_connack{session_present = 0,
+                   reason_code = ?M5_SERVER_MOVED,
+                   properties = #{?P_SERVER_REF :=
+                                      <<"server_ref">>}}
+        = Connack,
+    ok = gen_tcp:close(Socket).
+
+connack_broker_capabilities(Cfg) ->
+    ClientId = vmq_cth:ustr(Cfg),
+    Connect = packetv5:gen_connect(ClientId, [{username, <<"broker_capabilities">>}]),
+    {ok, Socket, Connack, <<>>} = packetv5:do_client_connect(Connect, []),
+    #mqtt5_connack{reason_code = ?M5_SUCCESS,
+                   properties = #{?P_MAX_QOS := 0,
+                                  ?P_RETAIN_AVAILABLE := false,
+                                  ?P_WILDCARD_SUBS_AVAILABLE := false,
+                                  ?P_SUB_IDS_AVAILABLE := false,
+                                  ?P_SHARED_SUBS_AVAILABLE := false}}
         = Connack,
     ok = gen_tcp:close(Socket).
 


### PR DESCRIPTION
Support some more MQTT 5.0 properties which can be sent to the client as a result of calling `auth_on_register_m5`.

If this is OK'ed I'll update/doc this on  the `auth_on_register_m5` hook in the `vernemq_dev` repo.