### PR TITLE
Handle incoming messages while websocket session is terminating

### DIFF
--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -69,6 +69,9 @@ init_(Type, Req, Opts) ->
     _ = vmq_metrics:incr_socket_open(),
     {ok, Req1, #st{fsm_state=FsmState, fsm_mod=FsmMod}}.
 
+websocket_handle(_, Req, #st{fsm_state=terminated}=State) ->
+    %% handle `terminated` state as in `websocket_info/3`.
+    {shutdown, Req, State};
 websocket_handle({binary, Data}, Req, State) ->
     #st{fsm_state=FsmState0,
         fsm_mod=FsmMod,

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,8 @@
   the CONNECT frame in `vmq_mqtt_pre_init` (#950, #962).
 - Fix issue which could cause `vmq-admin session show` to crash when using
   `--limit=X` to limit the number of returned results (#902).
+- Handle edge case in the websocket implementation which could cause warninigs
+  when the session was terminating.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Prevents function clause errors in `vmq_websocket:websocket_handle/3`.