### PR TITLE
Expose disconnect api to lua

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_script_state.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script_state.erl
@@ -226,7 +226,8 @@ load_script(Id, Script) ->
             {vmq_diversity_ets,         <<"kv">>},
             {vmq_diversity_lager,       <<"log">>},
             {vmq_diversity_memcached,   <<"memcached">>},
-            {vmq_diversity_cache,       <<"auth_cache">>}
+            {vmq_diversity_cache,       <<"auth_cache">>},
+            {vmq_diversity_vmq_api,     <<"vmq_api">>}
            ],
 
     {ok, ScriptsDir} = application:get_env(vmq_diversity, script_dir),

--- a/apps/vmq_diversity/src/vmq_diversity_vmq_api.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_vmq_api.erl
@@ -1,0 +1,63 @@
+%% Copyright 2018 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_diversity_vmq_api).
+
+-export([install/1]).
+
+
+install(St) ->
+    luerl_emul:alloc_table(table(), St).
+
+table() ->
+    [
+     {<<"disconnect_by_subscriber_id">>, {function, fun disconnect/2}}
+    ].
+
+disconnect([LuaSubId, LuaOpts], St) ->
+    SubId = luerl:decode(LuaSubId, St),
+    %% mountpoints from lua are restricted to the list/string type.
+    MP = to_list(mp, proplists:get_value(<<"mountpoint">>, SubId)),
+    ClientId = proplists:get_value(<<"client_id">>, SubId),
+    case ClientId of
+        undefined -> throw({missing_parameter, client_id});
+        _ -> ok
+    end,
+
+    Opts = conv_opts(luerl:decode(LuaOpts, St)),
+    Res =
+        %% wrap it in a try-catch to make it possible to verify in
+        %% tests, syntactically, that we can call the function. To
+        %% test this for real, we'd need a running `vmq_server`.
+        try
+            vernemq_dev_api:disconnect_by_subscriber_id({MP, ClientId}, Opts)
+        catch
+            _:_ ->
+                not_found
+        end,
+    {[atom_to_binary(Res, utf8)], St}.
+
+conv_opts(Opts) ->
+    lists:map(
+      fun({<<"do_cleanup">>, true}) ->
+              do_cleanup;
+         ({<<"do_cleanup">>, false}) ->
+              {do_cleanup, false};
+         (E) -> E
+      end, Opts).
+
+to_list(Name, undefined) ->
+    throw({missing_parameter, Name});
+to_list(_, Binary) ->
+    binary_to_list(Binary).

--- a/apps/vmq_diversity/test/vmq_api_test.lua
+++ b/apps/vmq_diversity/test/vmq_api_test.lua
@@ -1,0 +1,3 @@
+ret = vmq_api.disconnect_by_subscriber_id({mountpoint = "mp",
+                                           client_id = "client-id"}, {do_cleanup = true})
+assert(ret == "not_found")

--- a/apps/vmq_diversity/test/vmq_diversity_provider_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_provider_SUITE.erl
@@ -20,7 +20,8 @@
          bcrypt_test/1,
          logger_test/1,
          memcached_test/1,
-         auth_cache_test/1]).
+         auth_cache_test/1,
+         vmq_api_test/1]).
 
 %% ===================================================================
 %% common_test callbacks
@@ -67,7 +68,8 @@ all() ->
              json_test,
              bcrypt_test,
              logger_test,
-             auth_cache_test]
+             auth_cache_test,
+             vmq_api_test]
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -117,3 +119,6 @@ memcached_test(_) ->
 
 auth_cache_test(_) ->
     {ok, _} = vmq_diversity:load_script(test_script("cache_test.lua")).
+
+vmq_api_test(_) ->
+    {ok, _} = vmq_diversity:load_script(test_script("vmq_api_test.lua")).

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,10 @@
   `--limit=X` to limit the number of returned results (#902).
 - Handle edge case in the websocket implementation which could cause warninigs
   when the session was terminating.
+- Expose `vernemq_dev_api:disconnect_by_subscriber_id/2` in lua
+  `vmq_api.disconnect_by_subscriber_id/2`, an example looks like:
+  `vmq_api.disconnect_by_subscriber_id({mountpoint = "", client_id =
+  "client-id"}, {do_cleanup = true})`.
 
 ## VerneMQ 1.6.0
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -101,7 +101,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/erlio/vernemq_dev.git",
-       {ref,"ccc09cb57cbb80f943895c9e40ac112603bc804d"}},
+       {ref,"12e00f7cfc17f067470f3c690e2536b0c68ecf21"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
Expose disconnect client api in lua as mentioned in #974 

Biggest annoyance here is that we can't well test the functionality as we don't have access to a running `vmq_server` from `vmq_diversity` tests. I ad-hoc tested this and added a `syntax` test.

Note I discovered a bug in the dev api: https://github.com/vernemq/vernemq_dev/pull/9 