### PR TITLE
use rebar3_cuttlefish master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             {platform_define, "^(R|1|20)", fun_stacktrace}]}.
 {project_plugins, [
                    {rebar3_cuttlefish, {git, "git://github.com/vernemq/rebar3_cuttlefish",
-                                        {branch, "otp21-compatibility"}}}]}.
+                                        {ref, "417560a"}}}]}.
 {dialyzer, [{exclude_mods, [vmq_plugin]},
             {plt_location, "plts"},
             {base_plt_location, "plts_base"}]}.


### PR DESCRIPTION
I got our changes merged to `tsloughter/rebar3_cuttlefish` master, and fixed the plugin at the latest commit.

When we've merged this then the `vernemq/rebar3_cuttlefish` and `tsloughter/rebar3_cuttlefish` master branches are the same and we can take over Tristans version and move it into the `vernemq` org.