### PR TITLE
WIP: Coalesce metadata

### DIFF
--- a/apps/vmq_server/src/vmq_coalesce.erl
+++ b/apps/vmq_server/src/vmq_coalesce.erl
@@ -66,10 +66,12 @@ put(FullPrefix, SId, NewMD) ->
 get(FullPrefix, SId) ->
     case ets:lookup(?DATA_TBL, {FullPrefix, SId}) of
         [] -> undefined;
-        [Val] -> Val
+        [{_Key, Val}] -> Val
     end.
 
 delete(FullPrefix, SId) ->
+    %% TODO: this only works because the tombstone is the same at the
+    %% metadata level...
     put(FullPrefix, SId, ?TOMBSTONE).
 
 -spec take(integer()) -> [{integer(), {{any(), sid()}, md()}}].

--- a/apps/vmq_server/src/vmq_coalesce.erl
+++ b/apps/vmq_server/src/vmq_coalesce.erl
@@ -1,0 +1,246 @@
+%% Copyright 2018 Octavo Labs AG Basel Switzerland (http://octavolabs.com)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(vmq_coalesce).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+
+-export([put/3,
+         get/2,
+         delete/2,
+         take/1,
+         info/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+               }).
+-define(TOMBSTONE, '$deleted').
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+-type sid() :: any().
+-type md() :: any().
+
+-define(DATA_TBL, vmq_coalesce_data_table).
+-define(IDX_TBL, vmq_coalesce_timeindex_table).
+-define(STATS_TBL, vmq_coalesce_stats).
+
+-spec put(any(), sid(), md()) -> true.
+put(FullPrefix, SId, NewMD) ->
+    Key = {FullPrefix, SId},
+    ets:insert(?DATA_TBL, {Key, NewMD}),
+    case ets:last(?IDX_TBL) of
+        '$end_of_table' ->
+            ets:insert(?IDX_TBL, {0, Key}),
+            %% wake up writer, there's work to do
+            ?SERVER ! wakeup,
+            true;
+        Last ->
+            ets:insert(?IDX_TBL, {Last+1, Key})
+    end,
+    ets:update_counter(?STATS_TBL, writes_logical, 1, {writes_logical,0}).
+
+get(FullPrefix, SId) ->
+    case ets:lookup(?DATA_TBL, {FullPrefix, SId}) of
+        [] -> undefined;
+        [Val] -> Val
+    end.
+
+delete(FullPrefix, SId) ->
+    put(FullPrefix, SId, ?TOMBSTONE).
+
+-spec take(integer()) -> [{integer(), {{any(), sid()}, md()}}].
+take(N) ->
+    {Count, MD} =
+        try
+            ets:foldl(
+              fun({LTs, Key}, {Ctr, Acc}) when Ctr < N ->
+                      ets:delete(?IDX_TBL, LTs),
+                      case ets:take(?DATA_TBL, Key) of
+                          [] ->
+                              {Ctr, Acc};
+                          [E] ->
+                              io:format(user, "XXX removed ~p from ~p~n", [E, ets:tab2list(?DATA_TBL)]),
+                              {Ctr+1, [E|Acc]}
+                      end;
+                 (_, {_, _}=Res) ->
+                      throw(Res)
+              end, {0, []}, ?IDX_TBL)
+        catch
+            throw:{_,_}=Res ->
+                Res
+        end,
+    {Count, lists:reverse(MD)}.
+
+info() ->
+    gen_server:call(?SERVER, info).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link() -> {ok, Pid :: pid()} |
+                      {error, Error :: {already_started, pid()}} |
+                      {error, Error :: term()} |
+                      ignore.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%% @end
+%%--------------------------------------------------------------------
+
+-spec init(Args :: term()) -> {ok, State :: term()} |
+                              {ok, State :: term(), Timeout :: timeout()} |
+                              {ok, State :: term(), hibernate} |
+                              {stop, Reason :: term()} |
+                              ignore.
+init([]) ->
+    %% entries are on the form {SId, Metadata}
+    ets:new(?DATA_TBL, [named_table,  public]),
+    ets:new(?IDX_TBL, [named_table, ordered_set, public]),
+    ets:new(?STATS_TBL, [named_table, public]),
+    {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_call(Request :: term(), From :: {pid(), term()}, State :: term()) ->
+                         {reply, Reply :: term(), NewState :: term()} |
+                         {reply, Reply :: term(), NewState :: term(), Timeout :: timeout()} |
+                         {reply, Reply :: term(), NewState :: term(), hibernate} |
+                         {noreply, NewState :: term()} |
+                         {noreply, NewState :: term(), Timeout :: timeout()} |
+                         {noreply, NewState :: term(), hibernate} |
+                         {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
+                         {stop, Reason :: term(), NewState :: term()}.
+handle_call(info, _From, State) ->
+    Reply = maps:from_list(ets:tab2list(?STATS_TBL)),
+    {reply, Reply, State};
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_cast(Request :: term(), State :: term()) ->
+                         {noreply, NewState :: term()} |
+                         {noreply, NewState :: term(), Timeout :: timeout()} |
+                         {noreply, NewState :: term(), hibernate} |
+                         {stop, Reason :: term(), NewState :: term()}.
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_info(Info :: timeout() | term(), State :: term()) ->
+                         {noreply, NewState :: term()} |
+                         {noreply, NewState :: term(), Timeout :: timeout()} |
+                         {noreply, NewState :: term(), hibernate} |
+                         {stop, Reason :: normal | term(), NewState :: term()}.
+handle_info(wakeup, State) ->
+    case take(1000) of
+        {0, []} ->
+            ok;
+        {Count, Values} ->
+            lists:map(
+              fun({{FullPrefix,SubscriberId}, Value}) ->
+                      %% TODO: factor this out - shouldn't be visible here..
+                       vmq_plugin:only(metadata_put, [FullPrefix, SubscriberId, Value])
+              end, Values),
+            case Count of
+                1000 ->
+                    %% TODO: Optimize this to be exact and avoid
+                    %% sending more than the necessary amount of
+                    %% `wakeup` messages.
+                    ?SERVER ! wakeup;
+                _ -> ok
+            end,
+            ets:update_counter(?STATS_TBL, writes_real, Count, {writes_real, 0})
+    end,
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%% @end
+%%--------------------------------------------------------------------
+-spec terminate(Reason :: normal | shutdown | {shutdown, term()} | term(),
+                State :: term()) -> any().
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%% @end
+%%--------------------------------------------------------------------
+-spec code_change(OldVsn :: term() | {down, term()},
+                  State :: term(),
+                  Extra :: term()) -> {ok, NewState :: term()} |
+                                      {error, Reason :: term()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called for changing the form and appearance
+%% of gen_server status when it is returned from sys:get_status/1,2
+%% or when it appears in termination error logs.
+%% @end
+%%--------------------------------------------------------------------
+-spec format_status(Opt :: normal | terminate,
+                    Status :: list()) -> Status :: term().
+format_status(_Opt, Status) ->
+    Status.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/apps/vmq_server/src/vmq_metadata.erl
+++ b/apps/vmq_server/src/vmq_metadata.erl
@@ -45,23 +45,15 @@ stop() ->
     ok.
 
 put(FullPrefix, Key, Value) ->
-    vmq_coalesce:put({FullPrefix, Key}, Value).
-%%vmq_plugin:only(metadata_put, [FullPrefix, Key, Value]).
+    vmq_plugin:only(metadata_put, [FullPrefix, Key, Value]).
 
 get(FullPrefix, Key) ->
-    case vmq_coalesce:get({FullPrefix, Key}) of
-        undefined ->
-            vmq_plugin:only(metadata_get, [FullPrefix, Key]);
-        Value -> Value
-    end.
+    vmq_plugin:only(metadata_get, [FullPrefix, Key]).
 
 delete(FullPrefix, Key) ->
-    %% How to handle deletes - we should always execute this!
-    vmq_coalesce:delete({FullPrefix, Key}).
-%%    vmq_plugin:only(metadata_delete, [FullPrefix, Key]).
+    vmq_plugin:only(metadata_delete, [FullPrefix, Key]).
 
 fold(FullPrefix, Fun, Acc) ->
-    %% folds do not look up in the metadata folder
     vmq_plugin:only(metadata_fold, [FullPrefix, Fun, Acc]).
 
 subscribe(FullPrefix) ->

--- a/apps/vmq_server/src/vmq_metadata.erl
+++ b/apps/vmq_server/src/vmq_metadata.erl
@@ -45,15 +45,23 @@ stop() ->
     ok.
 
 put(FullPrefix, Key, Value) ->
-    vmq_plugin:only(metadata_put, [FullPrefix, Key, Value]).
+    vmq_coalesce:put({FullPrefix, Key}, Value).
+%%vmq_plugin:only(metadata_put, [FullPrefix, Key, Value]).
 
 get(FullPrefix, Key) ->
-    vmq_plugin:only(metadata_get, [FullPrefix, Key]).
+    case vmq_coalesce:get({FullPrefix, Key}) of
+        undefined ->
+            vmq_plugin:only(metadata_get, [FullPrefix, Key]);
+        Value -> Value
+    end.
 
 delete(FullPrefix, Key) ->
-    vmq_plugin:only(metadata_delete, [FullPrefix, Key]).
+    %% How to handle deletes - we should always execute this!
+    vmq_coalesce:delete({FullPrefix, Key}).
+%%    vmq_plugin:only(metadata_delete, [FullPrefix, Key]).
 
 fold(FullPrefix, Fun, Acc) ->
+    %% folds do not look up in the metadata folder
     vmq_plugin:only(metadata_fold, [FullPrefix, Fun, Acc]).
 
 subscribe(FullPrefix) ->

--- a/apps/vmq_server/src/vmq_server_sup.erl
+++ b/apps/vmq_server/src/vmq_server_sup.erl
@@ -48,6 +48,7 @@ init([]) ->
     {ok, { {one_for_one, 5, 10},
            [?CHILD(vmq_config, worker, []) | MsgStoreChildSpecs]
            ++ [
+               ?CHILD(vmq_coalesce, worker, []),
                ?CHILD(vmq_crl_srv, worker, []),
                ?CHILD(vmq_queue_sup_sup, supervisor, [infinity, 5, 10]),
                ?CHILD(vmq_reg_sup, supervisor, []),

--- a/apps/vmq_server/test/vmq_coalesce_SUITE.erl
+++ b/apps/vmq_server/test/vmq_coalesce_SUITE.erl
@@ -119,9 +119,10 @@ simple() ->
 %% @end
 %%--------------------------------------------------------------------
 simple(_Config) ->
+    %% TODO clean up this test
     WriteFun =
-        fun(FullPrefix, Key, Value) ->
-                io:format(user, "XXX writefun: ~p -> ~p~n", [{FullPrefix,Key}, Value]),
+        fun(_FullPrefix, _Key, _Value) ->
+                %%io:format(user, "XXX writefun: ~p -> ~p~n", [{FullPrefix,Key}, Value]),
                 timer:sleep(4)
         end,
     {ok, _Pid} = vmq_coalesce:start_link([{write_fun, WriteFun}]),
@@ -130,19 +131,14 @@ simple(_Config) ->
            timer:sleep(2)
      end|| X <- lists:seq(1,1000)],
     vmq_coalesce:put(foo, baz, baz),
-    %%io:format(user, "XXX data ~p~n", [ets:tab2list(vmq_coalesce_data_table)]),
-    %%io:format(user, "XXX indx ~p~n", [ets:tab2list(vmq_coalesce_timeindex_table)]),
-    io:format(user, "XXX info: ~p~n", [vmq_coalesce:info()]),
-    %%#{writes := 2} = vmq_coalesce:info(),
-    timer:sleep(1000),
-     %% {2, [{{foo, bar1}, [d,e,f]},
-     %%    {{foo, baz}, baz}]} = vmq_coalesce:take(2),
+
     wait_until_written(),
     #{data_objects := 0,
-      timeindexes := 0} = vmq_coalesce:info(),
+      time_indexes := 0} = vmq_coalesce:info(),
     io:format(user, "XXX data ~p~n", [ets:tab2list(vmq_coalesce_data_table)]),
     io:format(user, "XXX indx ~p~n", [ets:tab2list(vmq_coalesce_timeindex_table)]),
-    #{writes_logical := 1002, writes_actual := 0} = vmq_coalesce:info(),
+    io:format(user, "XXX info: ~p~n", [vmq_coalesce:info()]),
+    #{writes_logical := 1002, writes_actual := _} = vmq_coalesce:info(),
     ok.
 
 wait_until_written() ->
@@ -150,4 +146,4 @@ wait_until_written() ->
       fun() ->
               #{data_objects := Unwritten} = vmq_coalesce:info(),
               0 == Unwritten
-      end, 10, 10).
+      end, 100, 1).

--- a/apps/vmq_server/test/vmq_coalesce_SUITE.erl
+++ b/apps/vmq_server/test/vmq_coalesce_SUITE.erl
@@ -1,0 +1,132 @@
+-module(vmq_coalesce_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%--------------------------------------------------------------------
+%% @spec suite() -> Info
+%% Info = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{seconds,30}}].
+
+%%--------------------------------------------------------------------
+%% @spec init_per_suite(Config0) ->
+%%     Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_suite(Config0) -> term() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_group(_GroupName, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_group(GroupName, Config0) ->
+%%               term() | {save_config,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+end_per_group(_GroupName, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+%%--------------------------------------------------------------------
+%% @spec end_per_testcase(TestCase, Config0) ->
+%%               term() | {save_config,Config1} | {fail,Reason}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @spec groups() -> [Group]
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%% N = integer() | forever
+%% @end
+%%--------------------------------------------------------------------
+groups() ->
+    [].
+
+%%--------------------------------------------------------------------
+%% @spec all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%% @end
+%%--------------------------------------------------------------------
+all() ->
+    [simple].
+
+%%--------------------------------------------------------------------
+%% @spec TestCase() -> Info
+%% Info = [tuple()]
+%% @end
+%%--------------------------------------------------------------------
+simple() ->
+    [].
+
+%%--------------------------------------------------------------------
+%% @spec TestCase(Config0) ->
+%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% Comment = term()
+%% @end
+%%--------------------------------------------------------------------
+simple(_Config) ->
+    {ok, _Pid} = vmq_coalesce:start_link(),
+    vmq_coalesce:put(foo, bar, [a,b,c]),
+    [vmq_coalesce:put(foo, bar, X) || X <- lists:seq(1,1000)],
+    vmq_coalesce:put(foo, baz, baz),
+    io:format(user, "XXX data ~p~n", [ets:tab2list(vmq_coalesce_data_table)]),
+    io:format(user, "XXX indx ~p~n", [ets:tab2list(vmq_coalesce_timeindex_table)]),
+    io:format(user, "XXX info: ~p~n", [vmq_coalesce:info()]),
+    #{writes := 2} = vmq_coalesce:info(),
+     %% {2, [{{foo, bar1}, [d,e,f]},
+     %%    {{foo, baz}, baz}]} = vmq_coalesce:take(2),
+    ok.

--- a/apps/vmq_server/test/vmq_coalesce_SUITE.erl
+++ b/apps/vmq_server/test/vmq_coalesce_SUITE.erl
@@ -133,10 +133,8 @@ simple(_Config) ->
     vmq_coalesce:put(foo, baz, baz),
 
     wait_until_written(),
-    #{data_objects := 0,
-      time_indexes := 0} = vmq_coalesce:info(),
+    #{data_objects := 0} = vmq_coalesce:info(),
     io:format(user, "XXX data ~p~n", [ets:tab2list(vmq_coalesce_data_table)]),
-    io:format(user, "XXX indx ~p~n", [ets:tab2list(vmq_coalesce_timeindex_table)]),
     io:format(user, "XXX info: ~p~n", [vmq_coalesce:info()]),
     #{writes_logical := 1002, writes_actual := _} = vmq_coalesce:info(),
     ok.


### PR DESCRIPTION
this is a WIP which is able to merge writes for the same subscriber to the metadata store when the logical writes happen temporally near each other.

The big outstanding issue is that this breaks a lot of tests since subscriptions, which are already handled in an eventually consistent manner, now are written slightly later which is just enough to make the tests break.

So there are two approaches: 
- fix the tests (most of them publish to a topic which hasn't been inserted into the local routing table yet) by waiting for the relevant data to have been propagated.
- insert the subscriptions directly into the local routing table which would mean locally you will start receiving publishes matching the subscriptions as soon as the SUBACK is returned.

The latter seems to me the best approach, but it's not clear how to best implement this. Currently the routing table `vmq_reg_trie` is manipulated by sending it a set of old subscriptions and a set of new subscriptions and then calculating what is to be removed and what is to be added. The optimizer currently only has access to the latest value, not the old one. Two options presents itself: the optimizer can keep track of added/removed topics (SUB/UNSUB) somehow or keep track of the old (where to get this without extra cost?) and new value....
