### PR TITLE
Upgrade sext to latest version 1.5.0

### DIFF
--- a/apps/vmq_server/rebar.config
+++ b/apps/vmq_server/rebar.config
@@ -13,8 +13,8 @@
 
         {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
 
-        %% we use sext to transform the keys for the default leveldb backed message store 
-        {sext, {git, "git://github.com/uwiger/sext.git", {tag, "1.3"}}},
+        %% we use sext to transform the keys for the default leveldb backed message store
+        {sext, "1.5.0"},
 
         %% efficient counters
         {mzmetrics, {git, "git://github.com/erlio/mzmetrics.git", {branch, "master"}}},

--- a/apps_opt/vmq_swc/rebar.config
+++ b/apps_opt/vmq_swc/rebar.config
@@ -2,10 +2,8 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 {deps, [
         lager,
-        sext,
-
         {swc, {git, "git://github.com/dergraf/ServerWideClocks.git", {branch, "use-maps-instead-of-orddict"}}},
-        {sext, "1.4.1"},
+        {sext, "1.5.0"},
         {rocksdb, "0.23.1"},
 
         %% plumtree related

--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
   `plumtree.drop_i_have_threshold` hidden option. The default is 1000000. This
   work was kindly contributed by ADB (https://www.adbglobal.com).
 - Add new `vmq-admin retain` commands to inspect the retained message store.
+- Upgraded dependency `sext` to 1.5.0 (required for better OSX compilation).
 
 ## VerneMQ 1.6.0
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -89,10 +89,7 @@
        {ref,"f7981d4ad7407ddc085f133f204dd71bf9d50c56"}},
   1},
  {<<"riak_sysmon">>,{pkg,<<"riak_sysmon">>,<<"2.1.2">>},0},
- {<<"sext">>,
-  {git,"git://github.com/uwiger/sext.git",
-       {ref,"35520daea8ddc48569249ad19637f4cc75fbd03d"}},
-  0},
+ {<<"sext">>,{pkg,<<"sext">>,<<"1.5.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},1},
  {<<"syslog">>,
   {git,"git://github.com/Vagabond/erlang-syslog",
@@ -123,6 +120,7 @@
  {<<"ranch">>, <<"A6FB992C10F2187B46FFD17CE398DDF8A54F691B81768F9EF5F461EA7E28C762">>},
  {<<"recon">>, <<"4444C879BE323B1B133EEC5241CB84BD3821EA194C740D75617E106BE4744318">>},
  {<<"riak_sysmon">>, <<"24F804606D65DE1F020138F5E6E3E17BE4C5A41567D5170306378253E3705BAE">>},
+ {<<"sext">>, <<"07D5D516DAA4C437B2F7DB99F6B2728C8AF939313479B1BEDC1995BB15936236">>},
  {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>},
  {<<"unicode_util_compat">>, <<"DBBCCF6781821B1C0701845EAF966C9B6D83D7C3BFC65CA2B78B88B8678BFA35">>}]}
 ].


### PR DESCRIPTION
Previous to this, I was having issues in OSX, after upgrading sext things are working fine on both OTP 19.x and 20.x.

Details of the error i was getting:

```erlang
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
{"Kernel pid terminated",application_controller,"{application_start_failure,vmq_server,{{shutdown,{failed_to_start_child,vmq_lvldb_store_sup,{'EXIT',{{badmatch,{error,{{{undef,[{sext,encode,[{{vmq,config},{'VerneMQ@127.0.0.1',vmq_server,msg_store_opts}}],[]},{plumtree_metadata_leveldb_instance,handle_call,3,[{file,\"/Users/codeadict/dev/vernemq/_build/default/lib/plumtree/src/plumtree_metadata_leveldb_instance.erl\"},{line,155}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,636}]},{gen_server,handle_msg,6,[{file,\"gen_server.erl\"},{line,665}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,247}]}]},{gen_server,call,[plmtrlvld_6,{get,{{vmq,config},{'VerneMQ@127.0.0.1',vmq_server,msg_store_opts}}},infinity]}},{child,undefined,{vmq_lvldb_store_bucket,1},{vmq_lvldb_store,start_link,[1]},permanent,5000,worker,[vmq_lvldb_store]}}}},[{vmq_lvldb_store_sup,'-start_link/0-lc$^0/1-0-',2,[{file,\"/Users/codeadict/dev/vernemq/_build/default/lib/vmq_server/src/vmq_lvldb_store_sup.erl\"},{line,38}]},{vmq_lvldb_store_sup,start_link,0,[{file,\"/Users/codeadict/dev/vernemq/_build/default/lib/vmq_server/src/vmq_lvldb_store_sup.erl\"},{line,37}]},{supervisor,do_start_child,2,[{file,\"supervisor.erl\"},{line,365}]},{supervisor,start_children,3,[{file,\"supervisor.erl\"},{line,348}]},{supervisor,init_children,2,[{file,\"supervisor.erl\"},{line,314}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,365}]},{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,333}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,247}]}]}}}},{vmq_server_app,start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,vmq_server,{{shutdown,{failed_to_start_child,vmq_lvldb_store_sup,{'EXIT',{{badmatch,{error,{{{undef,[{sext,encode,[{{vmq,conf
```

**Note:** I think plumtree needs to be upgraded also. Isn't it?