### PR TITLE
Make the VerneMQ status page prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If VerneMQ is running it is possible to check the status on
 `http://localhost:8888/status` and it should look something like:
 
 
-<img src="https://i.imgur.com/NAFZml1.png" width="75%">
+<img src="https://i.imgur.com/XajYjtb.png" width="75%">
 
 Note that the `$VERNEMQ/_build/default/rel/vernemq` directory is a complete, 
 self-contained instance of VerneMQ and Erlang. It is strongly suggested that you

--- a/apps/vmq_server/priv/static/css/vernemq.css
+++ b/apps/vmq_server/priv/static/css/vernemq.css
@@ -1,0 +1,112 @@
+*,
+*::before,
+*::after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  height: 100%;
+  font-size: 14px;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -ms-overflow-style: scrollbar;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+body {
+  min-height: 100%;
+}
+
+body {
+  font-family: Open Sans,Helvetica,Arial,sans-serif;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+}
+
+a {
+  color: #1E356A;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  margin-bottom: 0.715rem;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+  color: inherit;
+}
+
+h1, .h1 {
+  font-size: 2.5rem;
+}
+
+h2, .h2 {
+  font-size: 2rem;
+}
+
+h3, .h3 {
+  font-size: 1.75rem;
+}
+
+h4, .h4 {
+  font-size: 1.5rem;
+}
+
+h5, .h5 {
+  font-size: 1.2rem;
+}
+
+h6, .h6 {
+  font-size: 1rem;
+}
+
+.small, small {
+  font-size: 80%;
+  font-weight: 400;
+}
+
+.text-tiny {
+  color: #868e96 !important;
+}
+
+.table-responsive {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+table.table tfoot td, table.table tfoot th, table.table thead td, table.table thead th {
+  white-space: nowrap;
+}
+
+.table-bordered thead td, .table-bordered thead th {
+  border-bottom-width: 1px;
+}
+
+table.table td.max-width, table.table th.max-width {
+  width: 100%;
+}
+
+.table td, .table th {
+  padding: .5rem .85rem;
+  vertical-align: middle;
+  border-top: 1px solid #e9ecef;
+}
+
+.text-nowrap {
+  white-space: nowrap !important;
+}

--- a/apps/vmq_server/priv/static/index.html
+++ b/apps/vmq_server/priv/static/index.html
@@ -11,6 +11,7 @@
 
     <!-- Bootstrap core CSS -->
     <link href="status/css/bootstrap.min.css" rel="stylesheet">
+    <link href="status/css/vernemq.css" rel="stylesheet">
 
   </head>
 
@@ -27,11 +28,11 @@
           </button>
           <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
               <div class="navbar-nav">
-              <a class="p-2 text-dark" target="_blank" href="https://docs.vernemq.com">Docs</a>
-              <a class="p-2 text-dark" target="_blank" href="https://vernemq.com/contact.html">Support</a>
-              <a class="p-2 text-dark" target="_blank" href="https://github.com/erlio/vernemq">Github</a>
-              <a class="p-2 text-dark" target="_blank" href="https://twitter.com/vernemq">Twitter</a>
-              <a class="p-2 text-dark" target="_blank" href="https://slack-invite.vernemq.com/">Slack</a>
+              <a class="p-2" target="_blank" href="https://docs.vernemq.com">Docs</a>
+              <a class="p-2" target="_blank" href="https://vernemq.com/contact.html">Support</a>
+              <a class="p-2" target="_blank" href="https://github.com/erlio/vernemq">Github</a>
+              <a class="p-2" target="_blank" href="https://twitter.com/vernemq">Twitter</a>
+              <a class="p-2" target="_blank" href="https://slack-invite.vernemq.com/">Slack</a>
               </div>
           </div>
           </div>
@@ -48,28 +49,28 @@
           <script id="node_list_template" type="x-tmpl-mustache">
 <div class="container">
     <div class="row mt-5">
-        <div class="col-12">
+        <div class="col-md-12 mb-3">
 
         {{#cluster_issues.length}}
-        <h2>Issues</h2>
-        <table class="table table-striped table-bordered bg-light">
-            <thead>
-                <tr>
-                   <th scope="col">Type</th>
-                   <th scope="col">Node</th>
-                   <th scope="col">Message</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{#cluster_issues}}
-                <tr>
-                    <td><span class="badge badge-{{type}}">{{type}}</span></td>
-                    <td><strong>{{node}}</strong></td>
-                    <td>{{{message}}}</td>
-                </tr>
-                {{/cluster_issues}}
-            </tbody>
-        </table>
+        <h5>Issues</h5>
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered bg-light">
+                <thead>
+                    <tr>
+                    <th scope="col">Node</th>
+                    <th scope="col" class="max-width">Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#cluster_issues}}
+                    <tr>
+                        <td><strong>{{node}}</strong></td>
+                        <td class="text-nowrap"><span class="badge badge-{{type}}">{{type}}</span> {{{message}}}</td>
+                    </tr>
+                    {{/cluster_issues}}
+                </tbody>
+            </table>
+        </div>
         {{/cluster_issues.length}}
         {{^cluster_issues.length}}
         <div class="alert alert-success" role="alert">
@@ -78,95 +79,119 @@
         {{/cluster_issues.length}}
         </div>
     </div>
-    <div class="row mt-5">
-        <div class="col-12">
-
-        <h2>Cluster Overview</h2>
-        <table class="table table-striped table-bordered bg-light">
-            <thead>
-                <tr>
-                   <th scope="col">Cluster Size</th>
-                   <th scope="col">Clients online</th>
-                   <th scope="col">Clients offline</th>
-                   <th scope="col">Connect / Sec</th>
-                   <th scope="col">Publish In / Sec</th>
-                   <th scope="col">Publish Out / Sec</th>
-                   <th scope="col">Msg Drop / Sec</th>
-                   <th scope="col">Msg Queued</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>{{cluster_size}}</td>
-                    <td>{{total.clients_online}}</td>
-                    <td>{{total.clients_offline}}</td>
-                    <td>{{total.connect_rate}}</td>
-                    <td>{{total.msg_in_rate}}</td>
-                    <td>{{total.msg_out_rate}}</td>
-                    <td>{{total.msg_drop_rate}}</td>
-                    <td>{{total.msg_queued}}</td>
-                </tr>
-            </tbody>
-        </table>
+    <div class="row">
+        <div class="col-md-12 mb-3">
+            <h5>Cluster Overview</h5>
+            <div class="table-responsive">
+                <table class="table table-striped table-bordered bg-light">
+                    <thead>
+                        <tr>
+                        <th scope="col" class="text-center">Cluster Size</th>
+                        <th scope="col" class="text-center">Clients online</th>
+                        <th scope="col" class="text-center">Clients offline</th>
+                        <th scope="col" class="text-center">Connect Rate</th>
+                        <th scope="col" class="text-center">Publish Rate</th>
+                        <th scope="col" class="text-center">Publish Rate</th>
+                        <th scope="col" class="text-center">Msg Drop Rate</th>
+                        <th scope="col" class="text-center">Msg Queued</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="text-center">{{cluster_size}}</td>
+                            <td class="text-center">{{total.clients_online}}</td>
+                            <td class="text-center">{{total.clients_offline}}</td>
+                            <td class="text-center">
+                                {{total.connect_rate}} <small class="text-tiny">sec</small>
+                            </td>
+                            <td class="text-center">
+                                {{total.msg_in_rate}} <small class="text-tiny">sec</small>
+                            </td>
+                            <td class="text-center">
+                                {{total.msg_out_rate}} <small class="text-tiny">sec</small>
+                            </td>
+                            <td class="text-center">
+                                {{total.msg_drop_rate}} <small class="text-tiny">sec</small>
+                            </td>
+                            <td class="text-center">{{total.msg_queued}}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
-    <div class="row mt-5">
-        <div class="col-12">
+    <div class="row">
+        <div class="col-md-12 mb-3">
 
-        <h2>Node Status</h2>
-        <table class="table table-striped table-bordered bg-white">
-            <thead>
-                <tr>
-                   <th scope="col">Node</th>
-                   <th scope="col">Reachable peers</th>
-                   <th scope="col">Clients online</th>
-                   <th scope="col">Clients offline</th>
-                   <th scope="col">Connect / Sec</th>
-                   <th scope="col">Publish In / Sec</th>
-                   <th scope="col">Publish Out / Sec</th>
-                   <th scope="col">Msg Drop / Sec</th>
-                   <th scope="col">Msg Queued</th>
-                   <th scope="col">Subscriptions</th>
-                   <th scope="col">Retained</th>
-                   <th scope="col">Protocols</th>
-                   <th scope="col">Version</th>
-                </tr>
-            </thead>
-            <tbody>
-            {{#nodes}}
-                <tr>
-                    <th>{{node}}</th>
-                    <td>
-                        {{#cluster_view.not_ready}}
-                        <span class="badge badge-warning">{{cluster_view.ready.length}} of {{cluster_view.num_nodes}}</span>
-                        {{/cluster_view.not_ready}}
-                        {{^cluster_view.not_ready}}
-                        <span class="badge badge-success">{{cluster_view.ready.length}} of {{cluster_view.num_nodes}}</span>
-                        {{/cluster_view.not_ready}}
-
-                    </td>
-                    <td>{{clients_online}}</td>
-                    <td>{{clients_offline}}</td>
-                    <td>{{connect_rate}}</td>
-                    <td>{{msg_in_rate}}</td>
-                    <td>{{msg_out_rate}}</td>
-                    <td>{{msg_drop_rate}}</td>
-                    <td>{{msg_queued}}</td>
-                    <td>{{subscriptions}}</td>
-                    <td>{{retained}}</td>
-                    <td>
-                    {{#listeners}}
-                        <span class="badge badge-primary">{{.}}</span>
-                    {{/listeners}}
-                    {{^listeners}}
-                        <span class="badge badge-warning">No MQTT listener</span>
-                    {{/listeners}}
-                    </td>
-                    <td><span class="badge badge-secondary">{{version}}</span></td>
-                </tr>
-            {{/nodes}}
-            </tbody>
-        </table>
+        <h5>Node Status</h5>
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered bg-white">
+                <thead>
+                    <tr>
+                    <th scope="col" class="max-width">Node</th>
+                    <th scope="col" class="text-center">Clients</th>
+                    <th scope="col" class="text-center">Connect Rate</th>
+                    <th scope="col" class="text-center">Publish In Rate</th>
+                    <th scope="col" class="text-center">Publish Out Rate</th>
+                    <th scope="col" class="text-center">Msg Drop Rate</th>
+                    <th scope="col" class="text-center">Msg Queued</th>
+                    <th scope="col" class="text-center">Subscriptions</th>
+                    <th scope="col" class="text-center">Retained</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {{#nodes}}
+                    <tr>
+                        <td class="text-nowrap">
+                            <strong>
+                                {{node}} <span class="badge badge-secondary">{{version}}</span>
+                            </strong>
+                            <br/>
+                            <small class="text-tiny">
+                                Protocols:
+                                {{#listeners}}
+                                    <span class="badge badge-primary">{{.}}</span>
+                                {{/listeners}}
+                                {{^listeners}}
+                                    <span class="badge badge-warning">No MQTT listener</span>
+                                {{/listeners}}
+                            </small>
+                            <br/>
+                            <small class="text-tiny">
+                                Reachable peers:
+                                {{#cluster_view.not_ready}}
+                                <span class="badge badge-warning">{{cluster_view.ready.length}} of {{cluster_view.num_nodes}}</span>
+                                {{/cluster_view.not_ready}}
+                                {{^cluster_view.not_ready}}
+                                <span class="badge badge-success">{{cluster_view.ready.length}} of {{cluster_view.num_nodes}}</span>
+                                {{/cluster_view.not_ready}}
+                            </small>
+                        </td>
+                        <td class="text-center">
+                            {{clients_online}} <small class="text-tiny">online</small>
+                            <br/>
+                            {{clients_offline}} <small class="text-tiny">offline</small>
+                        </td>
+                        <td class="text-center">
+                            {{connect_rate}} <small class="text-tiny">sec</small>
+                        </td>
+                        <td class="text-center">
+                            {{msg_in_rate}} <small class="text-tiny">sec</small>
+                        </td>
+                        <td class="text-center">
+                            {{msg_out_rate}} <small class="text-tiny">sec</small>
+                        </td>
+                        <td class="text-center">
+                            {{msg_drop_rate}} <small class="text-tiny">sec</small>
+                        </td>
+                        <td class="text-center">{{msg_queued}}</td>
+                        <td class="text-center">{{subscriptions}}</td>
+                        <td class="text-center">{{retained}}</td>
+                    </tr>
+                {{/nodes}}
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </div>

--- a/changelog.md
+++ b/changelog.md
@@ -57,9 +57,6 @@
   `plumtree.drop_i_have_threshold` hidden option. The default is 1000000. This
   work was kindly contributed by ADB (https://www.adbglobal.com).
 - Add new `vmq-admin retain` commands to inspect the retained message store.
-<<<<<<< HEAD
-- Add improvements to VerneMQ status page to have nicer UI and be readable on smaller devices.
-=======
 - Support for different MySQL password hashing methods in `vmq_diversity`,
   ensuring compatibility with MySQL 8.0.11+. The method is configurable via the
   `vmq_diversity.mysql.password_hash_method` option which allows:
@@ -69,7 +66,7 @@
 - Fix crash in bridge when calling `vmq-admin session show` by fixing the
   `vmq_ql` row initializer to handle plugin sessions (the bridge starts a local
   plugin session).
->>>>>>> 93838e09778c8467768b4e5f33520d57740a03c8
+- Add improvements to VerneMQ status page to have nicer UI and be readable on smaller devices.
 
 ## VerneMQ 1.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
   `plumtree.drop_i_have_threshold` hidden option. The default is 1000000. This
   work was kindly contributed by ADB (https://www.adbglobal.com).
 - Add new `vmq-admin retain` commands to inspect the retained message store.
+- Add improvements to VerneMQ status page to have nicer UI and be readable on smaller devices.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
* Add nicer styles.
* Compact the information a little bit to see all in the page.
* Make it more responsive.

<img width="1392" alt="screen shot 2018-12-28 at 1 59 52 pm" src="https://user-images.githubusercontent.com/168440/50526052-7af4e300-0aad-11e9-9e92-34f6060a7ba2.png">
