### PR TITLE
Handle `info_req` message correctly

### DIFF
--- a/apps/vmq_server/src/vmq_info.erl
+++ b/apps/vmq_server/src/vmq_info.erl
@@ -137,12 +137,16 @@ session_row_init(Row) ->
         error ->
             [Row];
         {ok, SessionPid} ->
-            {ok, InfoItems} = vmq_mqtt_fsm:info(SessionPid, [user,
-                                                             peer_host,
-                                                             peer_port,
-                                                             protocol,
-                                                             waiting_acks]),
-            [maps:merge(Row, maps:from_list(InfoItems))]
+            case vmq_mqtt_fsm:info(SessionPid, [user,
+                                                peer_host,
+                                                peer_port,
+                                                protocol,
+                                                waiting_acks]) of
+                {ok, InfoItems} ->
+                    [maps:merge(Row, maps:from_list(InfoItems))];
+                {error, i_am_a_plugin} ->
+                    [Row]
+            end
     end.
 
 subscription_row_init(Row) ->

--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -69,7 +69,7 @@ plugin_receive_loop(PluginPid, PluginMod) ->
                           end, Msgs),
             vmq_queue:notify(QPid),
             plugin_receive_loop(PluginPid, PluginMod);
-        {info_req, {Ref, CallerPid}, _} ->
+        {?TO_SESSION, {info_req, {Ref, CallerPid}, _}} ->
             CallerPid ! {Ref, {error, i_am_a_plugin}},
             plugin_receive_loop(PluginPid, PluginMod);
         disconnect ->

--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,9 @@
 - Add new `vmq-admin retain` commands to inspect the retained message store.
 - Fix the HTTP `/status.json` endpoint to have a valid JSON output (#786).
 - Fix bug where internal application plugins where shown as normal plugins.
+- Fix crash in bridge when calling `vmq-admin session show` by fixing the
+  `vmq_ql` row initializer to handle plugin sessions (the bridge starts a local
+  plugin session).
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Before we would get a crash as we would end up in the `Other` clause
in `vmq_mqtt_fsm_util:plugin_receive_loop/2` which throws an
exception when doing `vmq-admin session show`

With this we instead get:

```
  $ _build/default/rel/vernemq/bin/vmq-admin session show
  +------------+---------+----------+---------+---------+----+
  | client_id  |is_online|mountpoint|peer_host|peer_port|user|
  +------------+---------+----------+---------+---------+----+
  |Njc4Njk0Nzg=|  true   |          |  null   |  null   |null|
  +------------+---------+----------+---------+---------+----+
```

Of course it also reveals itself as a plugin:

```
  $ _build/default/rel/vernemq/bin/vmq-admin session show --client_id --is_plugin
  +------------+---------+
  | client_id  |is_plugin|
  +------------+---------+
  |Njc4Njk0Nzg=|  true   |
  +------------+---------+
```