### PR TITLE
Make MySQL password hashing method configurable in vmq-diversity

### DIFF
--- a/apps/vmq_diversity/priv/auth/mysql.lua
+++ b/apps/vmq_diversity/priv/auth/mysql.lua
@@ -31,6 +31,11 @@ require "auth/auth_commons"
    )
   ]] --
 -- To insert a client ACL use a similar SQL statement:
+-- NOTE THAT `PASSWORD()` NEEDS TO BE SUBSTITUTED ACCORDING TO THE HASHING METHOD
+-- CONFIGURED IN `vmq_diversity.mysql.password_hash_method`. CHECK THE MYSQL DOCS TO 
+-- FIND THE MATCHING ONE AT https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html.
+--
+-- 
 --[[
 --
    INSERT INTO vmq_auth_acl 
@@ -52,16 +57,15 @@ require "auth/auth_commons"
 -- FOLLOWING SCRIPT.
 function auth_on_register(reg)
     if reg.username ~= nil and reg.password ~= nil then
-        results = mysql.execute(pool, 
+        results = mysql.execute(pool,
             [[SELECT publish_acl, subscribe_acl
               FROM vmq_auth_acl
-              WHERE 
+              WHERE
                 mountpoint=? AND
                 client_id=? AND
                 username=? AND
-                password=PASSWORD(?)
-            ]], 
-            reg.mountpoint, 
+                password=]]..mysql.hash_method(),
+            reg.mountpoint,
             reg.client_id,
             reg.username,
             reg.password)

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -94,7 +94,7 @@
   {default, "root"},
   {commented, "root"}]}.
 
-{mapping, "vmq_diversity.mysql.password", "vmq_diversity.db_config.mysql.password", 
+{mapping, "vmq_diversity.mysql.password", "vmq_diversity.db_config.mysql.password",
  [{datatype, string},
   {default, "password"},
   {commented, "password"}]}.
@@ -109,6 +109,21 @@
   {default, 5},
   hidden]}.
 
+%% @doc The password hashing method to use in MySQL:
+%% password: Default for compatibility, deprecated since MySQL 5.7.6 and not
+%%           usable with MySQL 8.0.11+.
+%%           Docs: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
+%%      md5: Calculates an MD5 128-bit checksum of the password.
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
+%%     sha1: Calculates the SHA-1 160-bit checksum for the password.
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
+%%   sha256: Calculates the SHA-2 hash of the password, using 256 bits. 
+%%           Works only if MySQL has been configured with SSL support.
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
+{mapping, "vmq_diversity.mysql.password_hash_method", "vmq_diversity.db_config.mysql.password_hash_method",
+ [{datatype, {enum, [password, md5, sha1, sha256]}},
+  {default, password}
+ ]}.
 
 {mapping, "vmq_diversity.auth_mongodb.enabled", "vmq_diversity.auth_cache.mongodb.enabled",
  [{datatype, flag},

--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -45,7 +45,8 @@
                           {password, "password"},
                           {database, "vernemq_db"},
                           {pool_size, 5},
-                          {encoding, utf8}
+                          {encoding, utf8},
+                          {password_hash_method, password}
                          ]},
               {mongodb, [
                           {host, "localhost"},

--- a/apps/vmq_diversity/src/vmq_diversity_mysql.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mysql.erl
@@ -25,7 +25,8 @@ install(St) ->
 table() ->
     [
      {<<"execute">>, {function, fun execute/2}},
-     {<<"ensure_pool">>, {function, fun ensure_pool/2}}
+     {<<"ensure_pool">>, {function, fun ensure_pool/2}},
+     {<<"hash_method">>, {function, fun hash_method/2}}
     ].
 
 execute(As, St) ->
@@ -40,7 +41,6 @@ execute(As, St) ->
                     lager:error("unknown pool ~p", [BPoolId]),
                     badarg_error(unknown_pool, As, St)
             end,
-
             try emysql:execute(PoolId, BQuery, Args) of
                 #result_packet{} = Result ->
                     {Table, NewSt} = luerl:encode(emysql:as_proplist(Result), St),
@@ -116,7 +116,14 @@ ensure_pool(As, St) ->
             badarg_error(execute_parse, As, St)
     end.
 
-
-
-
-
+hash_method(_, St) ->
+    {ok, DBConfigs} = application:get_env(vmq_diversity, db_config),
+    DefaultConf = proplists:get_value(mysql, DBConfigs),
+    HashMethod = proplists:get_value(password_hash_method, DefaultConf),
+    MysqlFunc = case HashMethod of
+        password -> <<"PASSWORD(?)">>;
+        md5 -> <<"MD5(?)">>;
+        sha1 -> <<"SHA1(?)">>;
+        sha256 -> <<"SHA2(?, 256)">>
+    end, 
+    {[MysqlFunc], St}.

--- a/apps/vmq_diversity/test/mysql_test.lua
+++ b/apps/vmq_diversity/test/mysql_test.lua
@@ -70,3 +70,6 @@ results = mysql.execute("mysql_test",
         user_name=?]], 'my_mp', 'client_c', 'user_c')
 
 assert(#results == 1, "error in select")
+
+-- Test the default hashing method
+assert(mysql.hash_method() == "PASSWORD(?)")

--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,10 @@
   `plumtree.drop_i_have_threshold` hidden option. The default is 1000000. This
   work was kindly contributed by ADB (https://www.adbglobal.com).
 - Add new `vmq-admin retain` commands to inspect the retained message store.
+- Support for different MySQL password hashing methods in `vmq_diversity`,
+  ensuring compatibility with MySQL 8.0.11+. The method is configurable via the
+  `vmq_diversity.mysql.password_hash_method` option which allows:
+  `password` (default for compatibility), `md5`, `sha1` or `sha256`.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Support for different MySQL password hashing methods in `vmq_diversity`,
ensuring compatibility with MySQL 8.0.11+. The method is configurable
via the `vmq_diversity.mysql.password_hash_method` option which
supports: `password` (default for compatibility), `md5`, `sha1` or
`sha256`.

Closes #930

TODO:

- [x] Update documentation to mention the use of the same hashing
function as the configured method when creating AUTH/ACL records and put
a note about the default user authentication in MySQL8.x being
https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html and how to change it.