### PR TITLE
Increment MQTT4_CONNACK_SENT metric

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -579,6 +579,7 @@ check_user(#mqtt_connect{username=User, password=Password} = F, State) ->
     end.
 
 check_will(#mqtt_connect{will_topic=undefined, will_msg=undefined}, SessionPresent, State) ->
+    _ = vmq_metrics:incr({?MQTT4_CONNACK_SENT, ?CONNACK_ACCEPT}),
     {State, [#mqtt_connack{session_present=SessionPresent, return_code=?CONNACK_ACCEPT}]};
 check_will(#mqtt_connect{will_topic=Topic, will_msg=Payload, will_qos=Qos, will_retain=IsRetain},
            SessionPresent, State) ->
@@ -593,6 +594,7 @@ check_will(#mqtt_connect{will_topic=Topic, will_msg=Payload, will_qos=Qos, will_
                                  },
                          fun(Msg, _, SessCtrl) -> {ok, Msg, SessCtrl} end) of
         {ok, Msg, SessCtrl} ->
+            _ = vmq_metrics:incr({?MQTT4_CONNACK_SENT, ?CONNACK_ACCEPT}),
             {State#state{will_msg=Msg},
              [#mqtt_connack{session_present=SessionPresent,
                             return_code=?CONNACK_ACCEPT}],

--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,8 @@
 - Add the `vmq_swc` metadata plugin (using the already existing LevelDB backend) to
   the default VerneMQ release. To use `vmq_swc` instead of `vmq_plumtree` set
   `metadata_plugin = vmq_swc` in `vernemq.conf`. `vmq_swc` is still in Beta.
+- Add missing increments of the `mqtt_connack_sent` metric for CONNACK
+  success(0) for MQTT 3.1.1.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Hello VerneMQ Team,

VerneMQ seems not to be reporting CONNACK SENT metric correctly for MQTT < 5. This patch fixes it for me. Do you think it is good enough and can be merged?