### PR TITLE
Add a new metric to track queue initializations

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -61,6 +61,7 @@
          incr_mqtt_error_unsubscribe/0,
 
          incr_queue_setup/0,
+         incr_queue_init_from_storage/0,
          incr_queue_teardown/0,
          incr_queue_drop/0,
          incr_queue_msg_expired/1,
@@ -207,6 +208,9 @@ incr_mqtt_error_unsubscribe() ->
 
 incr_queue_setup() ->
     incr_item(queue_setup, 1).
+
+incr_queue_init_from_storage() ->
+    incr_item(queue_init_from_storage, 1).
 
 incr_queue_teardown() ->
     incr_item(queue_teardown, 1).
@@ -703,6 +707,7 @@ counter_entries_def() ->
      m(counter, [{mqtt_version,"5"}], ?MQTT5_UNSUBSCRIBE_RECEIVED, mqtt_unsubscribe_received, <<"The number of UNSUBSCRIBE packets received.">>),
 
      m(counter, [], queue_setup, queue_setup, <<"The number of times a MQTT queue process has been started.">>),
+     m(counter, [], queue_init_from_storage, queue_init_from_storage, <<"The number of times a MQTT queue process has been initialized from offline storage.">>),
      m(counter, [], queue_teardown, queue_teardown, <<"The number of times a MQTT queue process has been terminated.">>),
      m(counter, [], queue_message_drop, queue_message_drop, <<"The number of messages dropped due to full queues.">>),
      m(counter, [], queue_message_expired, queue_message_expired, <<"The number of messages which expired before delivery.">>),

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -61,7 +61,7 @@
          incr_mqtt_error_unsubscribe/0,
 
          incr_queue_setup/0,
-         incr_queue_init_from_storage/0,
+         incr_queue_initialized_from_storage/0,
          incr_queue_teardown/0,
          incr_queue_drop/0,
          incr_queue_msg_expired/1,
@@ -209,8 +209,8 @@ incr_mqtt_error_unsubscribe() ->
 incr_queue_setup() ->
     incr_item(queue_setup, 1).
 
-incr_queue_init_from_storage() ->
-    incr_item(queue_init_from_storage, 1).
+incr_queue_initialized_from_storage() ->
+    incr_item(queue_initialized_from_storage, 1).
 
 incr_queue_teardown() ->
     incr_item(queue_teardown, 1).
@@ -707,7 +707,7 @@ counter_entries_def() ->
      m(counter, [{mqtt_version,"5"}], ?MQTT5_UNSUBSCRIBE_RECEIVED, mqtt_unsubscribe_received, <<"The number of UNSUBSCRIBE packets received.">>),
 
      m(counter, [], queue_setup, queue_setup, <<"The number of times a MQTT queue process has been started.">>),
-     m(counter, [], queue_init_from_storage, queue_init_from_storage, <<"The number of times a MQTT queue process has been initialized from offline storage.">>),
+     m(counter, [], queue_initialized_from_storage, queue_initialized_from_storage, <<"The number of times a MQTT queue process has been initialized from offline storage.">>),
      m(counter, [], queue_teardown, queue_teardown, <<"The number of times a MQTT queue process has been terminated.">>),
      m(counter, [], queue_message_drop, queue_message_drop, <<"The number of messages dropped due to full queues.">>),
      m(counter, [], queue_message_expired, queue_message_expired, <<"The number of messages which expired before delivery.">>),

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -419,12 +419,12 @@ drain(Event, _From, State) ->
 offline(init_offline_queue, #state{id=SId} = State) ->
     case vmq_plugin:only(msg_store_find, [SId]) of
         {ok, MsgRefs} ->
-            _ = vmq_metrics:incr_queue_init_from_storage(),
+            _ = vmq_metrics:incr_queue_initialized_from_storage(),
             {next_state, offline,
              insert_many(MsgRefs, State)};
         {error, no_matching_hook_found} ->
             % that's ok
-            _ = vmq_metrics:incr_queue_init_from_storage(),
+            _ = vmq_metrics:incr_queue_initialized_from_storage(),
             {next_state, offline, State};
         {error, Reason} ->
             lager:error("can't initialize queue from offline storage due to ~p, retry in 1 sec", [Reason]),

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -419,10 +419,12 @@ drain(Event, _From, State) ->
 offline(init_offline_queue, #state{id=SId} = State) ->
     case vmq_plugin:only(msg_store_find, [SId]) of
         {ok, MsgRefs} ->
+            _ = vmq_metrics:incr_queue_init_from_storage(),
             {next_state, offline,
              insert_many(MsgRefs, State)};
         {error, no_matching_hook_found} ->
             % that's ok
+            _ = vmq_metrics:incr_queue_init_from_storage(),
             {next_state, offline, State};
         {error, Reason} ->
             lager:error("can't initialize queue from offline storage due to ~p, retry in 1 sec", [Reason]),

--- a/changelog.md
+++ b/changelog.md
@@ -81,7 +81,7 @@
   success(0) for MQTT 3.1.1.
 - Handle edge case with unknown task completion messages in `vmq_reg_sync` after
   a restart.
-- Add a new metric (queue_init_from_storage) to better monitor queue
+- Add a new metric (queue_initialized_from_storage) to better monitor queue
   initialization process after a node restart.
 
 ## VerneMQ 1.6.0

--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,8 @@
   success(0) for MQTT 3.1.1.
 - Handle edge case with unknown task completion messages in `vmq_reg_sync` after
   a restart.
+- Add a new metric (queue_init_from_storage) to better monitor queue
+  initialization process after a node restart.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
This PR adds a new queue_init_from_storage counter which is incremented whenever a queue is initialized with messages from the message store.

The use case for this is to monitor progress of queue initialization. Currently there is a queue_setup metric which is helpful but it only tracks the number of queue processes. If the message store is big enough, feeding queues with messages can take significant time. We ran into cases where we exposed the broker too early (when the queues were still being initialized) and as a result the broker's performance was degraded.

The "Queue Init" series in the graph below are derived from the new metric. They may be used to catch the moment when the queues are initialized. In this case it happened 6-7 minutes after the queue processes had been started.

![vernemq-queue-init-from-storage-1](https://user-images.githubusercontent.com/1737880/51601509-d9727d00-1f04-11e9-809b-8a5a01e5a017.png)
