### PR TITLE
Fix queue start timing issue

### DIFF
--- a/apps/vmq_server/src/vmq_reg_mgr.erl
+++ b/apps/vmq_server/src/vmq_reg_mgr.erl
@@ -178,8 +178,9 @@ handle_new_sub_event(SubscriberId, Subs) ->
     Sessions = vmq_subscriber:get_sessions(Subs),
     case lists:keymember(node(), 1, Sessions) of
         true ->
-            %% we have to ensure that we have a local queue for this subscriber
-            vmq_queue_sup_sup:start_queue(SubscriberId);
+            %% The local queue will have been started directly via
+            %% `vmq_reg:register_subscriber` in the fsm.
+            ignore;
         false ->
             %% we may migrate an existing queue to a remote queue
             %% Do we have a local queue to migrate?

--- a/apps/vmq_server/test/vmq_upgrade_SUITE.erl
+++ b/apps/vmq_server/test/vmq_upgrade_SUITE.erl
@@ -36,6 +36,7 @@ v0_to_v1_subscriber_format_test(_) ->
     SubscriberId = {"", <<"test-client">>},
     V0Subs = [{Topic, 1, node()}],
     vmq_metadata:put({vmq, subscriber}, SubscriberId, V0Subs),
+    {ok, _, _} = vmq_queue_sup_sup:start_queue(SubscriberId, false),
     true = wait_until_true(
       fun() ->
               %% this should setup a queue

--- a/apps/vmq_swc/src/vmq_churney.erl
+++ b/apps/vmq_swc/src/vmq_churney.erl
@@ -129,7 +129,7 @@ client_id(A, B, Suffix) ->
                    ++ "-"
                    ++ atom_to_list(B)
                    ++ "-"
-                   ++ integer_to_list(erlang:phash2({self(), os:timestamp()}))
+                   ++ integer_to_list(erlang:phash2({node(), self(), os:timestamp()}))
                    ++ "-"
                    ++ Suffix
                   ).

--- a/changelog.md
+++ b/changelog.md
@@ -85,6 +85,9 @@
   `vmq_in_order_delivery_SUITE` tests to fail.
 - Add a new metric (queue_initialized_from_storage) to better monitor queue
   initialization process after a node restart.
+- Fix edge case where an extra queue process could be started when metadata
+  events arrive late. Now local queue processes are only started when triggered
+  via a new local MQTT session.
 
 ## VerneMQ 1.6.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -88,6 +88,7 @@
 - Fix edge case where an extra queue process could be started when metadata
   events arrive late. Now local queue processes are only started when triggered
   via a new local MQTT session.
+- Reimplement dead queue repair mechanism.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
- switch to only starting new queues when clients connect or when queues are (forcefully) migrated or dead queues fixed.