### PR TITLE
Fix indefinitely blocking queue cleanup code

### DIFF
--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -255,7 +255,7 @@ online({enqueue_many, Msgs, Opts}, _From, State) ->
 online({cleanup, Reason}, From, State)
   when State#state.waiting_call == undefined ->
     disconnect_sessions(Reason, State),
-    {next_state, state_change(cleanup, online, wait_for_offline),
+    {reply, ok, state_change(cleanup, online, wait_for_offline),
      State#state{waiting_call={{cleanup, Reason}, From}}};
 online(Event, _From, State) ->
     lager:error("got unknown sync event in online state ~p", [Event]),

--- a/changelog.md
+++ b/changelog.md
@@ -286,6 +286,8 @@
   fail. Also ensure to use the default mountpoint if no mountpoint was
   passed. (#714).
 - Upgraded vernemq_dev to include the `disconnect_by_subscriber_id/2` API.
+- Fix bug which could cause a queue cleanup to block indefinitely and cause the
+  `vmq_in_order_delivery_SUITE` tests to fail.
 
 ## VerneMQ 1.3.0
 


### PR DESCRIPTION
When trying to clean up an online queue the caller would never get a
reply and would hang indefinitely.