### PR TITLE
fixed bug: retrie deliver_pubrel msg when client reconnect must increment next_msg_id

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1360,7 +1360,8 @@ handle_messages([{deliver_pubrel, {MsgId, #mqtt5_pubrel{} = Frame}}|Rest], Frame
     %% this is called when a pubrel is retried after a client reconnects
     #state{waiting_acks=WAcks} = State0,
     _ = vmq_metrics:incr(?MQTT5_PUBREL_SENT),
-    State1 = State0#state{waiting_acks=maps:put(MsgId, Frame, WAcks)},
+    State1 = State0#state{waiting_acks=maps:put(MsgId, Frame, WAcks),
+                         next_msg_id = MsgId + 1 },
     handle_messages(Rest, [serialise_frame(Frame)|Frames],
                     PubCnt, State1, Waiting);
 handle_messages([], [], _, State, Waiting) ->

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -316,7 +316,7 @@ connected(#mqtt_pubrec{message_id=MessageId}, State) ->
                waiting_acks=maps:update(MessageId, PubRelFrame, WAcks)},
             [PubRelFrame]};
         #mqtt_pubrel{} ->
-            lager:debug("Duplicate pubrel ~p ,ignore", [MessageId]),
+            lager:debug("Duplicate pubrec ~p ,ignore", [MessageId]),
             {State,[]};
         not_found ->
             lager:debug("stopped connected session, due to qos2 puback missing ~p", [MessageId]),

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -315,6 +315,9 @@ connected(#mqtt_pubrec{message_id=MessageId}, State) ->
                retry_queue=set_retry(pubrel, MessageId, RetryInterval, RetryQueue),
                waiting_acks=maps:update(MessageId, PubRelFrame, WAcks)},
             [PubRelFrame]};
+        #mqtt_pubrel{} ->
+            lager:debug("Duplicate pubrel ~p ,ignore", [MessageId]),
+            {State,[]};
         not_found ->
             lager:debug("stopped connected session, due to qos2 puback missing ~p", [MessageId]),
             _ = vmq_metrics:incr_mqtt_error_invalid_pubrec(),


### PR DESCRIPTION
https://github.com/vernemq/vernemq/issues/1045