### PR TITLE
Improve queue migration speed on planned cluster leave

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -37,7 +37,7 @@
          stored/1,
          status/1,
 
-         migrate_offline_queues/1,
+         migrate_offline_queues/2,
          fix_dead_queues/2
         ]).
 
@@ -431,44 +431,42 @@ subscriptions_for_subscriber_id(SubscriberId) ->
     Default = [],
     vmq_subscriber_db:read(SubscriberId, Default).
 
-migrate_offline_queues([]) -> exit(no_target_available);
-migrate_offline_queues(Targets) ->
-    {_, NrOfQueues, TotalMsgs} = vmq_queue_sup_sup:fold_queues(fun migrate_offline_queue/3, {Targets, 0, 0}),
-    lager:info("migration summary: ~p queues migrated, ~p messages", [NrOfQueues, TotalMsgs]),
+migrate_offline_queues([], _) -> exit(no_target_available);
+migrate_offline_queues(Targets, MaxConcurrency) ->
+    Acc = #{offline_cnt => 0,
+            offline_queues => [],
+            draining_cnt => 0,
+            draining_queues => [],
+            targets => Targets},
+    MigrateState = vmq_queue_sup_sup:fold_queues(fun migration_candidate_filter/3,  Acc),
+    migrate(MigrateState,MaxConcurrency),
     ok.
 
-migrate_offline_queue(SubscriberId, QPid, {[Target|Targets], AccQs, AccMsgs} = Acc) ->
+migrate(#{offline_queues := [], draining_queues := []}, _) ->
+    ok;
+migrate(S0, MaxConcurrency) ->
+    S1 = update_state(S0),
+    S2 = trigger_migration(S1, MaxConcurrency),
+    timer:sleep(100), %% TODO: is this optimal?
+    migrate(S2, MaxConcurrency).
+
+
+migration_candidate_filter(SubscriberId, QPid, #{offline_cnt := OCnt,
+                                                 offline_queues := OQueues,
+                                                 draining_cnt := DCnt,
+                                                 draining_queues := DQueues,
+                                                 targets := Targets} = Acc) ->
+    Target = lists:nth(rand:uniform(length(Targets)), Targets),
     try vmq_queue:status(QPid) of
         {_, _, _, _, true} ->
             %% this is a queue belonging to a plugin.. ignore it.
             Acc;
-        {offline, _, TotalStoredMsgs, _, _} ->
-            OldNode = node(),
-            %% Remap Subscriptions, taking into account subscriptions
-            %% on other nodes by only remapping subscriptions on 'OldNode'
-            Subs = subscriptions_for_subscriber_id(SubscriberId),
-            NewSubs = vmq_subscriber:change_node(Subs, OldNode, Target, false),
-
-            %% writing the changed subscriptions will trigger
-            %% vmq_reg_mgr to initiate queue migration
-            Fun =
-                fun(Sid, TargetNode) ->
-                        case get_queue_pid(Sid) of
-                            not_found ->
-                                case rpc:call(TargetNode, ?MODULE, get_queue_pid, [Sid]) of
-                                    not_found ->
-                                        lager:error("couldn't migrate queue for ~p to target node ~p",
-                                                    [Sid, TargetNode]),
-                                        done;
-                                    LocalPid when is_pid(LocalPid) ->
-                                        done
-                                end;
-                            Pid when is_pid(Pid) ->
-                                block
-                        end
-                end,
-            block_until_migrated(SubscriberId, NewSubs, [Target], Fun),
-            {Targets ++ [Target], AccQs + 1, AccMsgs + TotalStoredMsgs};
+        {offline, _, Msgs, _, _} ->
+            Acc#{offline_cnt => OCnt + 1,
+                 offline_queues => [{SubscriberId,QPid,Msgs,Target}|OQueues]};
+        {drain, _, Msgs, _, _} ->
+            Acc#{draining_cnt => DCnt + 1,
+                 draining_queues => [{SubscriberId,QPid,Msgs,Target}|DQueues]};
         _ ->
             Acc
     catch
@@ -476,6 +474,56 @@ migrate_offline_queue(SubscriberId, QPid, {[Target|Targets], AccQs, AccMsgs} = A
             %% queue stopped in the meantime, that's ok.
             Acc
     end.
+
+update_state(#{draining_queues := DrainingQueues,
+               migrated_queue_cnt := MigratedQueueCnt,
+               migrated_message_cnt := MigratedMsgCnt} = S0) ->
+    lists:foldl(
+      fun({_, QPid, Msgs, _} = Q, #{offline_cnt := OCnt,
+                              offline_queues := OQueues,
+                              draining_cnt := DCnt,
+                              draining_queues := DQueues} = Acc) ->
+              try vmq_queue:status(QPid) of
+                  {offline, _, _, _, _} ->
+                      %% queue returned to offline state!
+                      Acc#{offline_cnt => OCnt + 1,
+                           offline_queues => [Q|OQueues]};
+                  {drain, _, _, _, _} ->
+                      %% still draining
+                      Acc#{draining_cnt => DCnt + 1,
+                                draining_queues => [Q|DQueues]}
+              catch
+                  _:_ ->
+                      %% queue stopped in the meantime, so draining
+                      %% finished.
+                      Acc#{migrated_queue_cnt := MigratedQueueCnt + 1,
+                           migrated_message_cnt := MigratedMsgCnt + Msgs}
+              end
+      end, S0#{draining_queues => [],
+               draining_cnt => 0}, DrainingQueues).
+
+trigger_migration(#{draining_cnt := DCnt} = S, MaxConcurrency) when DCnt >= MaxConcurrency->
+    %% all are still draining and we may even more than max
+    %% concurrency draining queues due to natural migration. Do
+    %% nothing.
+    S;
+trigger_migration(#{offline_queues := []} = S, _) ->
+    %% done for now
+    S;
+trigger_migration(#{draining_cnt := DCnt,
+                    draining_queues := DQueues,
+                    offline_cnt := OCnt,
+                    offline_queues := [{SubscriberId, _QPid, _Msgs, Target}=Q|OQueues]} = S,
+                  MaxConcurrency) ->
+    %% Remap Subscriptions, taking into account subscriptions
+    %% on other nodes by only remapping subscriptions on 'OldNode'
+    OldNode = node(),
+    Subs = subscriptions_for_subscriber_id(SubscriberId),
+    UpdatedSubs = vmq_subscriber:change_node(Subs, OldNode, Target, false),
+    vmq_subscriber_db:store(SubscriberId, UpdatedSubs),
+    S1 = S#{draining_queues => [Q|DQueues], draining_cnt => DCnt + 1,
+            offline_queues => OQueues, offline_cnt => OCnt - 1},
+    trigger_migration(S1, MaxConcurrency).
 
 fix_dead_queues(_, []) -> exit(no_target_available);
 fix_dead_queues(DeadNodes, AccTargets) ->

--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -274,7 +274,7 @@ vmq_cluster_leave_cmd() ->
                                                %% There is no guarantee that all clients will
                                                %% reconnect on time; we've to force migrate all
                                                %% offline queues.
-                                               vmq_reg:migrate_offline_queues(TargetNodes),
+                                               migrate_offline_queues(TargetNodes, 1000),
                                                %% node is online, we'll go the proper route
                                                %% instead of calling leave_cluster('Node')
                                                %% directly
@@ -315,6 +315,9 @@ vmq_cluster_leave_cmd() ->
                        [clique_status:text(Text)]
                end,
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
+
+migrate_offline_queues(TargetNodes, MaxConcurrency) ->
+    vmq_reg:migrate_offline_queues(TargetNodes, MaxConcurrency).
 
 leave_cluster(Node) ->
     case vmq_peer_service:leave(Node) of

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -397,7 +397,7 @@ cluster_leave_test(Config) ->
     ok = ensure_cluster(Config),
     {_, [{Node, Port}|RestNodes] = Nodes} = lists:keyfind(nodes, 1, Config),
     Topic = "cluster/leave/topic",
-    ToMigrate = 700,
+    ToMigrate = 8,
     %% create ToMigrate sessions
     [PubSocket|_] = Sockets =
     [begin
@@ -428,10 +428,7 @@ cluster_leave_test(Config) ->
     %% Pick a control node for initiating the cluster leave
     [{CtrlNode, _}|_] = RestNodes,
     io:format(user, "XXX: cluster leave, start migrations of ~p queues~n", [ToMigrate]),
-    TS1 = erlang:monotonic_time(millisecond),
     {ok, _} = rpc:call(CtrlNode, vmq_server_cmd, node_leave, [Node]),
-    TS2 = erlang:monotonic_time(millisecond),
-    io:format(user, "XXX: cluster leave migrated ~p queues in ~p seconds~n", [ToMigrate, (TS2 - TS1)/1000]),
     %% Leaving Node will disconnect all sessions and give away all messages
     %% The disconnected sessions are equally migrated to the rest of the nodes
     %% As the clients don't reconnect (in this test), their sessions are offline

--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -120,6 +120,13 @@ multiple_connect_test(Config) ->
     true = check_unique_client("connect-multiple", Nodes),
     Config.
 
+wait_until_converged_fold(Fun, Init, ExpectedResult, Nodes) ->
+    {NodeNames, _} = lists:unzip(Nodes),
+    vmq_cluster_test_utils:wait_until(
+      fun() ->
+              ExpectedResult =:= lists:foldl(Fun, Init, NodeNames)
+      end, 60*2, 500).
+
 wait_until_converged(Nodes, Fun, ExpectedReturn) ->
     {NodeNames, _} = lists:unzip(Nodes),
     vmq_cluster_test_utils:wait_until(
@@ -427,15 +434,18 @@ cluster_leave_test(Config) ->
            end, 60, 500),
     %% Pick a control node for initiating the cluster leave
     [{CtrlNode, _}|_] = RestNodes,
-    io:format(user, "XXX: cluster leave, start migrations of ~p queues~n", [ToMigrate]),
     {ok, _} = rpc:call(CtrlNode, vmq_server_cmd, node_leave, [Node]),
     %% Leaving Node will disconnect all sessions and give away all messages
     %% The disconnected sessions are equally migrated to the rest of the nodes
     %% As the clients don't reconnect (in this test), their sessions are offline
-    ok = wait_until_converged(RestNodes,
-                              fun(N) ->
-                                      rpc:call(N, vmq_queue_sup_sup, summary, [])
-                              end, {0, 0, 0, 4, 4}).
+    ok = wait_until_converged_fold(
+           fun(N, {AccQ, AccM}) ->
+                   {_,_,_,Queues,Messages} = rpc:call(N, vmq_queue_sup_sup, summary, []),
+                   {AccQ + Queues, AccM + Messages}
+           end,
+           {0, 0},
+           {ToMigrate, ToMigrate},
+           RestNodes).
 
 cluster_leave_myself_test(Config) ->
     ok = ensure_cluster(Config),

--- a/changelog.md
+++ b/changelog.md
@@ -93,6 +93,7 @@
   and `auth_on_subscribe_m5` hooks. This feature is exposed as a developer API in `vernemq_dev`, via
   the `vmq-admin session reauthorize` CLI command, and as a API for `vmq_diversity` Lua scripts. This
   work was kindly sponsored by AppModule AG (http://www.appmodule.net).
+- Improve planned cluster leave queue migration speed significantly (#766).
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
This is a reimplementation/factoring of the voluntary node leave queue migration logic, done mainly to improve speed of queue migration (before we could only do a few (max ~5 per second).

In a test migrating ~11k offline queues (no messages) I got a migration rate/second of ~820 (see below) - though it's not clear if that rate is sustainable.

Outstanding issues:
- [ ] figure out what 'good' values are for concurrency (currently max 1000 queues are draining simultaneously) and perhaps make these values configurable.
- [ ] Have to think a bit about the migration state - seems a bit messy to me.
- [ ] control the cli output rate (currently every ~100 ms, but depending on each migration loop)

```
$ time _build/dev2/rel/vernemq/bin/vmq-admin cluster leave node=dev1@127.0.0.1 -k -t 1
Migrated 0/11328 queues and 0/0 messages
Migrated 252/11328 queues and 0/0 messages
Migrated 632/11328 queues and 0/0 messages
Migrated 1018/11328 queues and 0/0 messages
Migrated 1387/11328 queues and 0/0 messages
Migrated 1822/11328 queues and 0/0 messages
Migrated 2351/11328 queues and 0/0 messages
Migrated 2864/11328 queues and 0/0 messages
Migrated 3351/11328 queues and 0/0 messages
Migrated 3728/11328 queues and 0/0 messages
Migrated 4125/11328 queues and 0/0 messages
Migrated 4510/11328 queues and 0/0 messages
Migrated 4979/11328 queues and 0/0 messages
Migrated 5391/11328 queues and 0/0 messages
Migrated 5861/11328 queues and 0/0 messages
Migrated 6314/11328 queues and 0/0 messages
Migrated 6835/11328 queues and 0/0 messages
Migrated 7375/11328 queues and 0/0 messages
Migrated 7922/11328 queues and 0/0 messages
Migrated 8375/11328 queues and 0/0 messages
Migrated 8662/11328 queues and 0/0 messages
Migrated 8951/11328 queues and 0/0 messages
Migrated 9331/11328 queues and 0/0 messages
Migrated 9702/11328 queues and 0/0 messages
Migrated 10080/11328 queues and 0/0 messages
Migrated 10453/11328 queues and 0/0 messages
Migrated 10827/11328 queues and 0/0 messages
Migrated 10944/11328 queues and 0/0 messages
Migrated 11096/11328 queues and 0/0 messages
Migrated 11160/11328 queues and 0/0 messages
Migrated 11274/11328 queues and 0/0 messages
Migrated 11328/11328 queues and 0/0 messages
Migrated 11328/11328 queues and 0/0 messages


real	0m13,800s
user	0m0,320s
sys	0m0,090s
```
fixes #766 