### PR TITLE
Start metrics worker before setting up queues

### DIFF
--- a/apps/vmq_server/src/vmq_server_sup.erl
+++ b/apps/vmq_server/src/vmq_server_sup.erl
@@ -49,11 +49,11 @@ init([]) ->
            [?CHILD(vmq_config, worker, []) | MsgStoreChildSpecs]
            ++ [
                ?CHILD(vmq_crl_srv, worker, []),
+               ?CHILD(vmq_metrics_sup, supervisor, []),
                ?CHILD(vmq_queue_sup_sup, supervisor, [infinity, 5, 10]),
                ?CHILD(vmq_reg_sup, supervisor, []),
                ?CHILD(vmq_cluster_node_sup, supervisor, []),
                ?CHILD(vmq_sysmon, worker, []),
-               ?CHILD(vmq_metrics_sup, supervisor, []),
                ?CHILD(vmq_ranch_sup, supervisor, [])
               ]} }.
 

--- a/changelog.md
+++ b/changelog.md
@@ -94,6 +94,8 @@
   the `vmq-admin session reauthorize` CLI command, and as a API for `vmq_diversity` Lua scripts. This
   work was kindly sponsored by AppModule AG (http://www.appmodule.net).
 - Improve planned cluster leave queue migration speed significantly (#766).
+- Start metrics server before setting up queues to ensure queue metric counts
+  are correct when restarting VerneMQ.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
To ensure queue metrics come out correctly.