### PR TITLE
Add started_at timestamp information to the queue and session

### DIFF
--- a/apps/vmq_server/src/vmq_info_cli.erl
+++ b/apps/vmq_server/src/vmq_info_cli.erl
@@ -165,7 +165,6 @@ vmq_ql_callback(Table, DefaultFields, Opts) ->
                   end, [], QueryString, Opts),
             [clique_status:table(ResultTable)]
     end.
-
 v("true" = V) -> V;
 v("false" = V) -> V;
 v(V) ->

--- a/changelog.md
+++ b/changelog.md
@@ -99,6 +99,9 @@
 - Let Travis CI build the VerneMQ release packages.
 - Add new metric `system_process_count` which is a gauge representing the
   current number of Erlang processes.
+- Add `queue_started_at` and `session_started_at` information to the `vmq-admin
+  session show` command. Times are POSIX time in milliseconds and local to the
+  node where the session or queue was started.
 
 ## VerneMQ 1.6.0
 


### PR DESCRIPTION
Example for a client with two sessions:

```
vmq-admin session show --node --client_id --queue_started_at --session_started_at
+-----------+-----------------+-----------------------------+-----------------------------+
| client_id |      node       |      queue_started_at       |     session_started_at      |
+-----------+-----------------+-----------------------------+-----------------------------+
|test-client|VerneMQ@127.0.0.1|2019-01-30T11:01:26.879+01:00|2019-01-30T11:01:55.392+01:00|
|test-client|VerneMQ@127.0.0.1|2019-01-30T11:01:26.879+01:00|2019-01-30T11:02:00.927+01:00|
+-----------+-----------------+-----------------------------+-----------------------------+
```