### PR TITLE
Delete cluster state on node which is leaving the cluster

### DIFF
--- a/apps/vmq_plumtree/src/vmq_plumtree.erl
+++ b/apps/vmq_plumtree/src/vmq_plumtree.erl
@@ -57,6 +57,7 @@ cluster_leave(Node) ->
             Local2List = riak_dt_orswot:value(Local2),
             case [P || P <- Local2List, P =:= Node] of
                 [] ->
+                    plumtree_peer_service_manager:delete_state(),
                     ok;
                 _ ->
                     cluster_leave(Node)

--- a/apps/vmq_swc/src/vmq_swc_plugin.erl
+++ b/apps/vmq_swc/src/vmq_swc_plugin.erl
@@ -60,6 +60,7 @@ cluster_leave(Node) ->
             Local2List = riak_dt_orswot:value(Local2),
             case [P || P <- Local2List, P =:= Node] of
                 [] ->
+                    vmq_swc_plumtree_peer_service_manager:delete_state(),
                     ok;
                 _ ->
                     cluster_leave(Node)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Cleanup cluster state information on a node which is being gracefully removed
+  from the cluster so if it is restarted it comes back up as a stand-alone node
+  and won't try to reconnect to the remaining nodes.
+
 ## VerneMQ 1.7.0
 
 - Fix `vmq_webhooks` issue where MQTTv5 hooks where not configurable in the


### PR DESCRIPTION
This ensures we don't end up in the node rename case in `vmq_server_sup` and also that the node won't try to reconnect with the remaining nodes. The subscriptions from other nodes are still there, of course, taking space - with swc that information would eventually be removed.