### PR TITLE
Coordinated registrations config value

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -52,12 +52,14 @@
          end
  end}.
 
-
-{mapping, "coordinated_registration", "vmq_server.coordinated_registration",
+%% @doc Client registrations can be either happen in a coordinated or
+%% uncoordinated fashion. Uncoordinated registrations are faster and
+%% will cause other clients with the same client-id to be eventually
+%% disconnected, while coordinated ensures that any other client with
+%% the same client-id will be immediately disconnected.
+{mapping, "coordinate_client_registrations", "vmq_server.coordinate_client_registrations",
  [{default, on},
   {datatype, flag}]}.
-
-
 
 %% @doc If allow_multiple_sessions is enabled 'queue_deliver_mode' will specify
 %% how the messages are delivered to multiple sessions. Default is 'fanout' which

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -34,12 +34,30 @@
                                                                                                 {datatype, flag}
                                                                                                ]}.
 
-%% @doc Allows a client to logon multiple times using the same client id
-%% (non-standard behaviour!).
+%% @doc Allows a client to logon multiple times using the same client
+%% id (non-standard behaviour!). This feature is DEPRECATED and will
+%% be removed in VerneMQ 2.0.
 {mapping, "allow_multiple_sessions", "vmq_server.allow_multiple_sessions", [
                                                                {default, off},
                                                                {datatype, flag}
                                                               ]}.
+
+{translation, "vmq_server.allow_multiple_sessions",
+ fun(Conf) ->
+         case cuttlefish:conf_get("allow_multiple_sessions", Conf) of
+             true ->
+                 cuttlefish:warn("allow_multiple_sessions is deprecated and will be removed in VerneMQ 2.0"),
+                 true;
+             false -> false
+         end
+ end}.
+
+
+{mapping, "coordinated_registration", "vmq_server.coordinated_registration",
+ [{default, on},
+  {datatype, flag}]}.
+
+
 
 %% @doc If allow_multiple_sessions is enabled 'queue_deliver_mode' will specify
 %% how the messages are delivered to multiple sessions. Default is 'fanout' which

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -20,8 +20,8 @@
          %% used in mqtt fsm handling
          subscribe/3,
          unsubscribe/3,
-         register_subscriber/4,
-         register_subscriber/5, %% used during testing
+         register_subscriber/5,
+         register_subscriber_/5, %% used during testing
          replace_dead_queue/3,
          delete_subscriptions/1,
          %% used in mqtt fsm handling
@@ -106,26 +106,30 @@ unsubscribe_op(SubscriberId, Topics) ->
 delete_subscriptions(SubscriberId) ->
     del_subscriber(SubscriberId).
 
--spec register_subscriber(flag(), subscriber_id(), boolean(), map()) ->
+-spec register_subscriber(flag(), flag(), subscriber_id(), boolean(), map()) ->
     {ok, boolean(), pid()} | {error, _}.
-register_subscriber(CAPAllowRegister, SubscriberId, StartClean, #{allow_multiple_sessions := false} = QueueOpts) ->
+register_subscriber(AllowRegister, CoordinateRegs, SubscriberId, StartClean, #{allow_multiple_sessions := false} = QueueOpts) ->
+    Netsplit = not vmq_cluster:is_ready(),
     %% we don't allow multiple sessions using same subscriber id
     %% allow_multiple_sessions is needed for session balancing
     SessionPid = self(),
-    case vmq_cluster:is_ready() of
-        true ->
+    case {Netsplit, AllowRegister, CoordinateRegs} of
+        {false, _, true} ->
+            %% no netsplit, but coordinated registrations required.
             vmq_reg_sync:sync(SubscriberId,
                               fun() ->
-                                      register_subscriber(SessionPid, SubscriberId, StartClean,
+                                      register_subscriber_(SessionPid, SubscriberId, StartClean,
                                                           QueueOpts, ?NR_OF_REG_RETRIES)
                               end, 60000);
-        false when CAPAllowRegister ->
-            register_subscriber(SessionPid, SubscriberId, StartClean,
-                                QueueOpts, ?NR_OF_REG_RETRIES);
-        false ->
-            {error, not_ready}
+        {true, false, _} ->
+            %% netsplit, registrations during netsplits not allowed.
+            {error, not_ready};
+        _ ->
+            %% all other cases we allow registrations but unsynced.
+            register_subscriber_(SessionPid, SubscriberId, StartClean,
+                                 QueueOpts, ?NR_OF_REG_RETRIES)
     end;
-register_subscriber(CAPAllowRegister, SubscriberId, _StartClean, #{allow_multiple_sessions := true} = QueueOpts) ->
+register_subscriber(CAPAllowRegister, _, SubscriberId, _StartClean, #{allow_multiple_sessions := true} = QueueOpts) ->
     %% we allow multiple sessions using same subscriber id
     %%
     %% !!! CleanSession is disabled if multiple sessions are in use
@@ -137,11 +141,11 @@ register_subscriber(CAPAllowRegister, SubscriberId, _StartClean, #{allow_multipl
             {error, not_ready}
     end.
 
--spec register_subscriber(pid() | undefined, subscriber_id(), boolean(), map(), non_neg_integer()) ->
+-spec register_subscriber_(pid() | undefined, subscriber_id(), boolean(), map(), non_neg_integer()) ->
     {'ok', boolean(), pid()} | {error, any()}.
-register_subscriber(_, _, _, _, 0) ->
+register_subscriber_(_, _, _, _, 0) ->
     {error, register_subscriber_retry_exhausted};
-register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N) ->
+register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N) ->
     % wont create new queue in case it already exists
     {ok, QueuePresent, QPid} =
     case vmq_queue_sup_sup:start_queue(SubscriberId) of
@@ -184,11 +188,11 @@ register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N) ->
     case catch vmq_queue:add_session(QPid, SessionPid, QueueOpts) of
         {'EXIT', {normal, _}} ->
             %% queue went down in the meantime, retry
-            register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
+            register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
         {'EXIT', {noproc, _}} ->
             timer:sleep(100),
             %% queue was stopped in the meantime, retry
-            register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
+            register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
         {'EXIT', Reason} ->
             {error, Reason};
         {error, draining} ->
@@ -196,11 +200,11 @@ register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N) ->
             %% remote queue. This can happen if a client hops around
             %% different nodes very frequently... adjust load balancing!!
             timer:sleep(100),
-            register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
+            register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
         {error, {cleanup, _Reason}} ->
             %% queue is still cleaning up.
             timer:sleep(100),
-            register_subscriber(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
+            register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
         ok ->
             {ok, SessionPresent2, QPid}
     end.
@@ -675,8 +679,8 @@ direct_plugin_exports(Mod) when is_atom(Mod) ->
             QueueOpts = maps:merge(vmq_queue:default_opts(),
                                    #{cleanup_on_disconnect => true,
                                      is_plugin => true}),
-            {ok, _, _} = register_subscriber(PluginSessionPid, SubscriberId, true,
-                                             QueueOpts, ?NR_OF_REG_RETRIES),
+            {ok, _, _} = register_subscriber_(PluginSessionPid, SubscriberId, true,
+                                              QueueOpts, ?NR_OF_REG_RETRIES),
             ok
     end,
 

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -120,12 +120,8 @@ register_subscriber(CAPAllowRegister, SubscriberId, StartClean, #{allow_multiple
                                                           QueueOpts, ?NR_OF_REG_RETRIES)
                               end, 60000);
         false when CAPAllowRegister ->
-            %% synchronize action on this node
-            vmq_reg_sync:sync(SubscriberId,
-                              fun() ->
-                                      register_subscriber(SessionPid, SubscriberId, StartClean,
-                                                          QueueOpts, ?NR_OF_REG_RETRIES)
-                              end, node(), 60000);
+            register_subscriber(SessionPid, SubscriberId, StartClean,
+                                QueueOpts, ?NR_OF_REG_RETRIES);
         false ->
             {error, not_ready}
     end;

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -70,7 +70,7 @@ queue_crash_test(_) ->
     QueueOpts = maps:merge(#{cleanup_on_disconnect => false}, vmq_queue:default_opts()),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
 
-    {ok, false, QPid1} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid1} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId,
                                   [{[<<"test">>, <<"topic">>], 1}]),
     %% at this point we've a working subscription
@@ -97,7 +97,7 @@ queue_crash_test(_) ->
 
     %% reconnect
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, NewQPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, NewQPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
     receive_persisted_msg(NewQPid, 1, Msg),
     {online, fanout, 0, 1, false} = vmq_queue:status(NewQPid),
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
@@ -108,7 +108,7 @@ queue_fifo_test(_) ->
     QueueOpts = maps:merge(#{cleanup_on_disconnect => false}, vmq_queue:default_opts()),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
 
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId,
                            [{[<<"test">>, <<"fifo">>, <<"topic">>], 1}]),
     %% teardown session
@@ -118,7 +118,7 @@ queue_fifo_test(_) ->
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"fifo">>, <<"topic">>]),
 
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, QPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, QPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
 
     ok = receive_multi(QPid, 1, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
@@ -129,7 +129,7 @@ queue_lifo_test(_) ->
     QueueOpts = maps:merge(vmq_queue:default_opts(), #{cleanup_on_disconnect => false, queue_type => lifo}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
 
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"lifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
@@ -138,7 +138,7 @@ queue_lifo_test(_) ->
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"lifo">>, <<"topic">>]),
 
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, QPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, QPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
 
     ok = receive_multi(QPid, 1, lists:reverse(Msgs)), %% reverse list to get lifo
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
@@ -150,7 +150,7 @@ queue_fifo_offline_drop_test(_) ->
                                                        max_offline_messages => 10}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
 
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"fifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
@@ -160,7 +160,7 @@ queue_fifo_offline_drop_test(_) ->
     {offline, fanout, 10, 0, false} = vmq_queue:status(QPid),
 
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, QPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, QPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
     {KeptMsgs, _} = lists:split(10, Msgs),
     ok = receive_multi(QPid, 1, KeptMsgs),
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
@@ -174,7 +174,7 @@ queue_lifo_offline_drop_test(_) ->
                                                        queue_type => lifo}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
 
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId,
                            [{[<<"test">>, <<"lifo">>, <<"topic">>], 1}]),
     %% teardown session
@@ -185,7 +185,7 @@ queue_lifo_offline_drop_test(_) ->
     {offline, fanout, 10, 0, false} = vmq_queue:status(QPid),
 
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, QPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, QPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
     {KeptMsgs, _} = lists:split(10, lists:reverse(Msgs)),
     ok = receive_multi(QPid, 1, KeptMsgs),
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
@@ -198,7 +198,7 @@ queue_offline_transition_test(_) ->
                                                        max_offline_messages => 1000,
                                                        queue_type => fifo}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
     timer:sleep(10), % give some time to plumtree
 
@@ -208,7 +208,7 @@ queue_offline_transition_test(_) ->
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"transition">>]), % publish 100
 
     SessionPid2 = spawn(fun() -> mock_session(Parent) end),
-    {ok, true, QPid} = vmq_reg:register_subscriber(SessionPid2, SubscriberId, false, QueueOpts, 10),
+    {ok, true, QPid} = vmq_reg:register_subscriber_(SessionPid2, SubscriberId, false, QueueOpts, 10),
     ok = receive_multi(QPid, 1, Msgs),
     {ok, []} = vmq_lvldb_store:msg_store_find(SubscriberId).
 
@@ -221,7 +221,7 @@ queue_persistent_client_expiration_test(_) ->
                                                        max_offline_messages => 1000,
                                                        queue_type => fifo}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
-    {ok, false, QPid} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
     timer:sleep(50), % give some time to plumtree
 
@@ -248,7 +248,7 @@ queue_force_disconnect_test(_) ->
                                                        max_offline_messages => 1000,
                                                        queue_type => fifo}),
     SessionPid1 = spawn(fun() -> mock_session(Parent) end),
-    {ok, false, QPid0} = vmq_reg:register_subscriber(SessionPid1, SubscriberId, false, QueueOpts, 10),
+    {ok, false, QPid0} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"disconnect">>], 1}]),
     timer:sleep(50), % give some time to plumtree
 
@@ -261,7 +261,7 @@ queue_force_disconnect_test(_) ->
     end,
 
     % Reconnect and ensure SessionPresent, and same QueuePid
-    {ok, true, QPid0} = vmq_reg:register_subscriber(Parent, SubscriberId, false, QueueOpts, 10).
+    {ok, true, QPid0} = vmq_reg:register_subscriber_(Parent, SubscriberId, false, QueueOpts, 10).
 
 
 queue_force_disconnect_cleanup_test(_) ->
@@ -271,7 +271,7 @@ queue_force_disconnect_cleanup_test(_) ->
                                                        max_offline_messages => 1000,
                                                        queue_type => fifo}),
     SessionPresent = false,
-    {ok, SessionPresent, QPid0} = vmq_reg:register_subscriber(NonConsumingSessionPid, SubscriberId, false, QueueOpts, 10),
+    {ok, SessionPresent, QPid0} = vmq_reg:register_subscriber_(NonConsumingSessionPid, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"discleanup">>], 1}]),
     timer:sleep(50), % give some time to plumtree
 
@@ -288,7 +288,7 @@ queue_force_disconnect_cleanup_test(_) ->
     [] = vmq_reg:subscriptions_for_subscriber_id(SubscriberId),
 
     % SessionPresent should be again `false` and we should get a new Queue Pid
-    {ok, SessionPresent, QPid1} = vmq_reg:register_subscriber(NonConsumingSessionPid, SubscriberId, false, QueueOpts, 10),
+    {ok, SessionPresent, QPid1} = vmq_reg:register_subscriber_(NonConsumingSessionPid, SubscriberId, false, QueueOpts, 10),
     true = (QPid0 =/= QPid1),
     false = is_process_alive(QPid0),
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
   and won't try to reconnect to the remaining nodes.
 - The `allow_multiple_sessions` option is deprecated and will be removed in
   VerneMQ 2.0.
+- Add new `coordinated_registrations` config option which allows for faster
+  uncoordinated registrations (replaces side-effect of
+  `allow_multiple_sessions`).
 
 ## VerneMQ 1.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 - Cleanup cluster state information on a node which is being gracefully removed
   from the cluster so if it is restarted it comes back up as a stand-alone node
   and won't try to reconnect to the remaining nodes.
+- The `allow_multiple_sessions` option is deprecated and will be removed in
+  VerneMQ 2.0.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
This PR:

- deprecates `allow_mulltiple_sessions`
- adds new `coordinated_registrations` config option to the vernemq.conf file
- removes coordinated registrations during netsplits (and register during netsplit is allowed) as we anyway will register on the local node.

Perhaps Missing:
- it's currently not possible to override the `coordinated_registrations` from the `auth_on_register*` hooks.

What I haven't figured out:
- How to meaningfully test this

Fixes #1067 