### PR TITLE
Fix outgoing qos2 message id bug (#1045)

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -901,7 +901,8 @@ register_subscriber(#mqtt5_connect{username=User}=F, OutProps0,
     CoordinateRegs = maps:get(coordinate_registrations, DOpts, ?COORDINATE_REGISTRATIONS),
     case vmq_reg:register_subscriber(CAPSettings#cap_settings.allow_register, CoordinateRegs, SubscriberId, CleanStart, QueueOpts) of
         {ok, #{session_present := SessionPresent,
-               initial_msg_id := MsgId}, QPid} ->
+               initial_msg_id := MsgId,
+               queue_pid := QPid}} ->
             monitor(process, QPid),
             _ = vmq_plugin:all(on_register_m5, [Peer, SubscriberId,
                                                 User, OutProps0]),

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1376,19 +1376,11 @@ handle_messages([{deliver, QoS, Msg} = Obj|Rest], Frames, PubCnt, State, Waiting
             {Frame, NewState} = prepare_frame(QoS, Msg, State#state{fc_send_cnt=Cnt}),
             handle_messages(Rest, [Frame|Frames], PubCnt + 1, NewState, Waiting)
     end;
-handle_messages([{deliver_pubrel, {MsgId, #mqtt5_pubrel{} = Frame}}|Rest], Frames, PubCnt,
-                #state{next_msg_id = CurrNextMsgId} = State0, Waiting) ->
+handle_messages([{deliver_pubrel, {MsgId, #mqtt5_pubrel{} = Frame}}|Rest], Frames, PubCnt, State0, Waiting) ->
     %% this is called when a pubrel is retried after a client reconnects
     #state{waiting_acks=WAcks} = State0,
     _ = vmq_metrics:incr(?MQTT5_PUBREL_SENT),
-    %% Assumption: all `deliver_pubrel` messages are delivered from
-    %% the queue when a session is added *before* any other messages.
-    %% The pubrel messages has fixed message-ids and we therefore need
-    %% ensure the first message id assigned to a publish message is
-    %% larger than any of the pubrel messages to avoid conflicts.
-    NextMsgId = lists:max([MsgId + 1, CurrNextMsgId]),
-    State1 = State0#state{waiting_acks=maps:put(MsgId, Frame, WAcks),
-                          next_msg_id=NextMsgId},
+    State1 = State0#state{waiting_acks=maps:put(MsgId, Frame, WAcks)},
     handle_messages(Rest, [serialise_frame(Frame)|Frames],
                     PubCnt, State1, Waiting);
 handle_messages([], [], _, State, Waiting) ->

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -902,20 +902,12 @@ handle_messages([{deliver, QoS, Msg} = Obj|Rest], Frames, PubCnt, State, Waiting
             % only qos 1&2 are constrained by max_in_flight
             handle_messages(Rest, Frames, PubCnt, State, [Obj|Waiting])
     end;
-handle_messages([{deliver_pubrel, {MsgId, #mqtt_pubrel{} = Frame}}|Rest], Frames, PubCnt,
-                #state{next_msg_id = CurrNextMsgId} = State0, Waiting) ->
+handle_messages([{deliver_pubrel, {MsgId, #mqtt_pubrel{} = Frame}}|Rest], Frames, PubCnt, State0, Waiting) ->
     %% this is called when a pubrel is retried after a client reconnects
     #state{waiting_acks=WAcks, retry_interval=RetryInterval, retry_queue=RetryQueue} = State0,
     _ = vmq_metrics:incr_mqtt_pubrel_sent(),
-    %% Assumption: all `deliver_pubrel` messages are delivered from
-    %% the queue when a session is added *before* any other messages.
-    %% The pubrel messages has fixed message-ids and we therefore need
-    %% ensure the first message id assigned to a publish message is
-    %% larger than any of the pubrel messages to avoid conflicts.
-    NextMsgId = lists:max([MsgId + 1, CurrNextMsgId]),
     State1 = State0#state{retry_queue=set_retry(pubrel, MsgId, RetryInterval, RetryQueue),
-                          waiting_acks=maps:put(MsgId, Frame, WAcks),
-                          next_msg_id = NextMsgId},
+                          waiting_acks=maps:put(MsgId, Frame, WAcks)},
     handle_messages(Rest, [Frame|Frames], PubCnt, State1, Waiting);
 handle_messages([], [], _, State, Waiting) ->
     {State, [], Waiting};

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -543,7 +543,8 @@ check_user(#mqtt_connect{username=User, password=Password} = F, State) ->
                     CoordinateRegs = maps:get(coordinate_registrations, DOpts, ?COORDINATE_REGISTRATIONS),
                     case vmq_reg:register_subscriber(CAPSettings#cap_settings.allow_register, CoordinateRegs, SubscriberId, CleanSession, QueueOpts) of
                         {ok, #{session_present := SessionPresent,
-                               initial_msg_id := MsgId}, QPid} ->
+                               initial_msg_id := MsgId,
+                               queue_pid := QPid}} ->
                             monitor(process, QPid),
                             _ = vmq_plugin:all(on_register, [Peer, SubscriberId,
                                                              User]),
@@ -577,7 +578,8 @@ check_user(#mqtt_connect{username=User, password=Password} = F, State) ->
             CoordinateRegs = maps:get(coordinate_registrations, DOpts, ?COORDINATE_REGISTRATIONS),
             case vmq_reg:register_subscriber(CAPSettings#cap_settings.allow_register, CoordinateRegs, SubscriberId, CleanSession, queue_opts(State, [])) of
                 {ok, #{session_present := SessionPresent,
-                       initial_msg_id := MsgId}, QPid} ->
+                       initial_msg_id := MsgId,
+                       queue_pid := QPid}} ->
                     monitor(process, QPid),
                     _ = vmq_plugin:all(on_register, [Peer, SubscriberId, User]),
                     check_will(F, SessionPresent, State#state{queue_pid=QPid, username=User, next_msg_id=MsgId});

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -444,15 +444,15 @@ offline(init_offline_queue, #state{id=SId} = State) ->
             gen_fsm:send_event_after(1000, init_offline_queue),
             {next_state, offline, State}
     end;
-offline({enqueue, Msg}, #state{id=SId} = State) ->
-    NMsg = case Msg of
+offline({enqueue, Enq}, #state{id=SId} = State) ->
+    NMsg = case Enq of
         {deliver, QoS, #vmq_msg{routing_key=Topic,
                                 payload=Payload,
-                                retain=Retain}} ->
+                                retain=Retain}=Msg} ->
             _ = vmq_plugin:all(on_offline_message, [SId, QoS, Topic, Payload, Retain]),
             #deliver{qos=QoS, msg=Msg};
         _ ->
-            Msg
+            Enq
     end,
     %% storing the message in the offline queue
     _ = vmq_metrics:incr_queue_in(),

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -138,8 +138,7 @@ enqueue_many(Queue, Msgs, Opts) when is_pid(Queue), is_list(Msgs), is_map(Opts) 
     NMsgs = lists:map(fun to_internal/1, Msgs),
     gen_fsm:sync_send_event(Queue, {enqueue_many, NMsgs, Opts}, infinity).
 
--spec add_session(pid(), pid(), map()) -> {ok, #{session_present := flag(),
-                                                 initial_msg_id := msg_id()}} |
+-spec add_session(pid(), pid(), map()) -> {ok, #{initial_msg_id := msg_id()}} |
                                           {error, any()}.
 add_session(Queue, SessionPid, Opts) when is_pid(Queue) ->
     gen_fsm:sync_send_event(Queue, {add_session, SessionPid, Opts}, infinity).
@@ -239,9 +238,9 @@ online({set_opts, SessionPid, Opts}, _From, #state{opts=OldOpts} = State) ->
     {reply, ok, online, NewState2};
 online({add_session, SessionPid, #{allow_multiple_sessions := true} = Opts}, _From, State0) ->
     %% allow multiple sessions per queue
-    Opts = #{initial_msg_id => State0#state.initial_msg_id},
+    RetOpts = #{initial_msg_id => State0#state.initial_msg_id},
     State1 = unset_timers(add_session_(SessionPid, Opts, State0)),
-    {reply, {ok, Opts}, online, State1};
+    {reply, {ok, RetOpts}, online, State1};
 online({add_session, SessionPid, #{allow_multiple_sessions := false} = Opts}, From, State)
   when State#state.waiting_call == undefined ->
     %% forbid multiple sessions per queue,

--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -368,8 +368,8 @@ drain(drain_start, #state{id=SId, offline=#queue{queue=Q} = Queue,
             %% remote_enqueue triggers an enqueue_many inside the remote queue
             %% but forces the traffic to go over the distinct communication link
             %% instead of the erlang distribution link.
-
-            case vmq_cluster:remote_enqueue(node(RemoteQueue), {enqueue, RemoteQueue, Msgs}, false) of
+            ExtMsgs = lists:map(fun to_external/1, Msgs),
+            case vmq_cluster:remote_enqueue(node(RemoteQueue), {enqueue, RemoteQueue, ExtMsgs}, false) of
                 ok ->
                     cleanup_queue(SId, DrainQ),
                     _ = vmq_metrics:incr_queue_out(queue:len(DrainQ)),
@@ -1113,3 +1113,5 @@ maybe_expire_msgs(SId, Msgs) ->
 
 to_internal({deliver, QoS, Msg}) ->
     #deliver{qos=QoS, msg=Msg}.
+to_external(#deliver{qos=QoS, msg=Msg}) ->
+    {deliver, QoS, Msg}.

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -686,8 +686,8 @@ direct_plugin_exports(Mod) when is_atom(Mod) ->
             QueueOpts = maps:merge(vmq_queue:default_opts(),
                                    #{cleanup_on_disconnect => true,
                                      is_plugin => true}),
-            {ok, _, _} = register_subscriber_(PluginSessionPid, SubscriberId, true,
-                                              QueueOpts, ?NR_OF_REG_RETRIES),
+            {ok, _} = register_subscriber_(PluginSessionPid, SubscriberId, true,
+                                           QueueOpts, ?NR_OF_REG_RETRIES),
             ok
     end,
 

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -205,8 +205,8 @@ register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N) ->
             %% queue is still cleaning up.
             timer:sleep(100),
             register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N -1);
-        ok ->
-            {ok, SessionPresent2, QPid}
+        {ok, Opts} ->
+            {ok, Opts#{session_present => SessionPresent2}, QPid}
     end.
 
 

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -250,7 +250,8 @@ block_until_migrated(SubscriberId, UpdatedSubs, [Node|Rest] = ChangedNodes, Bloc
     end.
 
 -spec register_session(subscriber_id(), map()) -> {ok, #{initial_msg_id := msg_id(),
-                                                        session_present := flag()}, pid()}.
+                                                         session_present := flag(),
+                                                         queue_pid := pid()}}.
 register_session(SubscriberId, QueueOpts) ->
     %% register_session allows to have multiple subscribers connected
     %% with the same session_id (as oposed to register_subscriber)

--- a/apps/vmq_server/src/vmq_server.hrl
+++ b/apps/vmq_server/src/vmq_server.hrl
@@ -36,7 +36,18 @@
         }).
 -type retain_msg() :: #retain_msg{}.
 
+-record(deliver,
+        {
+         qos        :: qos(),
+         %% an undefined msg_id means this message has never been sent
+         %% to the client or that it is a qos0 message.
 
+         %% TODO use `msg_id()` type instead, but currently no in scope.
+         msg_id     :: undefined | non_neg_integer(),
+         msg        :: msg()
+        }).
+
+-type deliver() :: #deliver{}.
 
 -type subscription() :: {topic(), subinfo()}.
 -define(INTERNAL_CLIENT_ID, '$vmq_internal_client_id').

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -321,7 +321,7 @@ publish_multi(ClientId, Topic, Acc) when length(Acc) < 100 ->
 publish_multi(_, _, Acc) -> lists:reverse(Acc).
 
 receive_multi(QPid, QoS, Msgs) ->
-    PMsgs = [{deliver, QoS, Msg#vmq_msg{persisted=true, qos=1}} || Msg <- Msgs],
+    PMsgs = [#deliver{qos=QoS, msg=Msg#vmq_msg{persisted=true, qos=1}} || Msg <- Msgs],
     receive_multi(QPid, PMsgs).
 
 receive_multi(_, []) -> ok;
@@ -367,7 +367,7 @@ receive_msg(QPid, QoS, Msg) ->
     %% we'll set the persist flag
     PMsg = Msg#vmq_msg{persisted=true},
     receive
-        {received, QPid, [{deliver, QoS, PMsg}]} ->
+        {received, QPid, [#deliver{qos=QoS, msg=PMsg}]} ->
             ok;
         M ->
             exit({wrong_message, M})
@@ -380,7 +380,7 @@ receive_persisted_msg(QPid, QoS, Msg) ->
     %% to the one of the subscription
     PMsg = Msg#vmq_msg{persisted=true, qos=QoS},
     receive
-        {received, QPid, [{deliver, QoS, PMsg}]} ->
+        {received, QPid, [#deliver{qos=QoS, msg=PMsg}]} ->
             ok;
         M ->
             exit({wrong_message, M})

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 - Fix `vmq_diversity` cache invalidation timing issue when a client reconnects
   right after a disconnect (#996).
 - Fix retry of MQTT publish frame in `vmq_bridge` (#1084).
+- Fix outgoing qos2 message id bug (#1045).
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
Fixes #1045 

@dergraf note my assumption about `pub_rel`s being send to the session before any normal publishes (without message ids) - I hope this is correct.