### PR TITLE
Fix `vmq_diversity` cache invalidation timing issue (#996).

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_cache.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_cache.erl
@@ -18,6 +18,8 @@
 -dialyzer(no_undefined_callbacks).
 -behaviour(gen_server2).
 
+-include_lib("stdlib/include/ms_transform.hrl").
+
 %% API
 -export([start_link/0,
          install/1,
@@ -40,7 +42,11 @@
 
 -import(luerl_lib, [badarg_error/3]).
 
--record(state, {}).
+-record(state,
+        {
+         %% logical timestamp
+         lts = 0 :: non_neg_integer()
+        }).
 
 
 -record(publish_acl, {
@@ -55,6 +61,13 @@
           max_qos = 2,
           modifiers
          }).
+
+-define(ms(Key),
+        %% Key = {<<>>, <<"clientid">>},
+        %% ets:fun2ms(fun({{AKey, '_'}, '_', '_'}=A) when AKey =:= Key -> A end).
+        [{{{'$1','_'},'_','_'},
+          [{'=:=','$1',{const,Key}}],
+          ['$_']}]).
 
 %%%===================================================================
 %%% API
@@ -89,15 +102,17 @@ clear_cache() ->
 
 clear_cache(MP, ClientId) ->
     Key = key(MP, ClientId),
-    case ets:lookup(table(cache), Key) of
-        [] -> ok;
-        [{_, PubAclHashes, SubAclHashes}] ->
-            gen_server2:call(?MODULE, {delete_cache, Key, PubAclHashes, SubAclHashes})
+    case ets:select(table(cache), ?ms(Key), 1) of
+        '$end_of_table' ->
+            ok;
+        {[{{Key,Lts}, PubAclHashes, SubAclHashes}|_],_} ->
+            %% first entry is the oldest which we'll delete
+            gen_server2:call(?MODULE, {delete_cache, {Key,Lts}, PubAclHashes, SubAclHashes})
     end.
 
 entries(MP, ClientId) when is_binary(MP) ->
     Key = key(MP, ClientId),
-    case ets:lookup(table(cache), Key) of
+    case ets:select(table(cache), ?ms(Key)) of
         [] -> [];
         [{_, PubAclHashes, SubAclHashes}] ->
             [{publish, entries_(publish, PubAclHashes)},
@@ -220,18 +235,21 @@ match_publish(As, St) ->
 %%%===================================================================
 init([]) ->
     _ = [ets:new(table(T), [public, named_table,
-                        {read_concurrency, true},
-                        {write_concurrency, true}])
-         || T <- [cache, publish, subscribe]],
+                            {read_concurrency, true},
+                            {write_concurrency, true}])
+         || T <- [publish, subscribe]],
+    _ = ets:new(table(cache), [public, named_table,
+                               {read_concurrency, true},
+                               {write_concurrency, true}, ordered_set]),
     {ok, #state{}}.
 
-handle_call({insert_cache, Key, PubAcls, SubAcls}, _From, State) ->
-    insert_cache(Key, PubAcls, SubAcls),
-    {reply, ok, State};
-handle_call({delete_cache, Key, PubAclHashes, SubAclHashes}, _From, State) ->
+handle_call({insert_cache, Key, PubAcls, SubAcls}, _From, #state{lts=Lts} = State) ->
+    insert_cache(Key, Lts+1, PubAcls, SubAcls),
+    {reply, ok, State#state{lts=Lts+1}};
+handle_call({delete_cache, {Key,Lts}, PubAclHashes, SubAclHashes}, _From, State) ->
     delete_cache_(table(publish), PubAclHashes),
     delete_cache_(table(subscribe), SubAclHashes),
-    ets:delete(table(cache), Key),
+    ets:delete(table(cache), {Key,Lts}),
     {reply, ok, State}.
 
 handle_cast(_Msg, State) ->
@@ -346,12 +364,22 @@ key(MP, ClientId) when is_binary(MP)
 
 match(Key, Input) ->
     Type = type(Input),
-    case ets:lookup(table(cache), Key) of
+    case ets:select(table(cache), ?ms(Key)) of
         [] -> no_cache;
         [{_, PubAclHashes, _}] when Type == publish ->
             match_(table(Type), Input, PubAclHashes);
         [{_, _, SubAclHashes}] when Type == subscribe ->
-            match_(table(Type), Input, SubAclHashes)
+            match_(table(Type), Input, SubAclHashes);
+        Elems ->
+            %% in rare cases we may have more elements, then always
+            %% use the most recently added acl rules it must be the
+            %% most relevant.
+            case lists:reverse(Elems) of
+                [{_, PubAclHashes, _}|_] when Type == publish ->
+                    match_(table(Type), Input, PubAclHashes);
+                [{_, _, SubAclHashes}|_] when Type == subscribe ->
+                    match_(table(Type), Input, SubAclHashes)
+            end
     end.
 
 match_(Table, Input, [AclHash|Rest]) ->
@@ -402,10 +430,10 @@ match_input_with_acl(#subscribe_acl{pattern=InputTopic, max_qos=InputQoS},
     end;
 match_input_with_acl(_, _) -> false.
 
-insert_cache(Key, PubAcls, SubAcls) ->
+insert_cache(Key, Lts, PubAcls, SubAcls) ->
     PubAclHashes = insert_cache_(table(publish), PubAcls, []),
     SubAclHashes = insert_cache_(table(subscribe), SubAcls, []),
-    ets:insert(table(cache), {Key, PubAclHashes, SubAclHashes}).
+    ets:insert(table(cache), {{Key, Lts}, PubAclHashes, SubAclHashes}).
 
 insert_cache_(Table, [Rec|Rest], Acc) ->
     AclHash = erlang:phash2(Rec),

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
   update bug.
 - Set queue expiration (`persistent_client_expiration`) timer on queues after a
   broker restart (#1071).
+- Fix `vmq_diversity` cache invalidation timing issue when a client reconnects
+  right after a disconnect (#996).
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
This should fix #996 

The tradeoff is that the cache table is now an `ordered_set` table and lookups are now `ets:select` based on `{SubscriberId, '_'}` which is proportional to the number of entries with that subscriber id modulo the O factor from the ordered set. So basically O(log n) where n is the number of different subscribers.