### PR TITLE
Use new #deliver{} record in the plugin receive loop

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -53,11 +53,11 @@ plugin_receive_loop(PluginPid, PluginMod) ->
             vmq_queue:active(QPid),
             plugin_receive_loop(PluginPid, PluginMod);
         {?TO_SESSION, {mail, QPid, Msgs, _, _}} ->
-            lists:foreach(fun({deliver, QoS, #vmq_msg{
-                                                routing_key=RoutingKey,
-                                                payload=Payload,
-                                                retain=IsRetain,
-                                                dup=IsDup}}) ->
+            lists:foreach(fun(#deliver{qos=QoS, msg=#vmq_msg{
+                                                       routing_key=RoutingKey,
+                                                       payload=Payload,
+                                                       retain=IsRetain,
+                                                       dup=IsDup}}) ->
                                   PluginPid ! {deliver, RoutingKey,
                                                Payload,
                                                QoS,

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -672,7 +672,6 @@ direct_plugin_exports(Mod) when is_atom(Mod) ->
                end,
     CallingPid = self(),
     SubscriberId = {MountPoint, ClientId(CallingPid)},
-    User = {plugin, Mod, CallingPid},
 
     RegisterFun =
     fun() ->
@@ -720,7 +719,6 @@ direct_plugin_exports(Mod) when is_atom(Mod) ->
     fun([W|_] = Topic) when is_binary(W) ->
             wait_til_ready(),
             CallingPid = self(),
-            User = {plugin, Mod, CallingPid},
             subscribe(CAPSubscribe, {MountPoint, ClientId(CallingPid)}, [{Topic, 0}]);
        (_) ->
             {error, invalid_topic}
@@ -730,7 +728,6 @@ direct_plugin_exports(Mod) when is_atom(Mod) ->
     fun([W|_] = Topic) when is_binary(W) ->
             wait_til_ready(),
             CallingPid = self(),
-            User = {plugin, Mod, CallingPid},
             unsubscribe(CAPUnsubscribe, {MountPoint, ClientId(CallingPid)}, [Topic]);
        (_) ->
             {error, invalid_topic}


### PR DESCRIPTION
Missed this one while refactoring for the qos2 message-id issue. This fixes the issue reported here: https://github.com/vernemq/vernemq/issues/1084#issuecomment-466602330

I'll added a test for the `direct_plugin_exports/1` api so we hopefully will catch changes like these next time.

Also removed a couple of unused lines from the `direct_plugin_exports/1` function (`User`)