### PR TITLE
Mqtt5 property modifiers rework

### DIFF
--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
@@ -44,31 +44,33 @@ auth_on_register_m5(Peer,SubscriberId,Username,Password,CleanStart,Properties) -
 
 auth_on_register_m5_(_Peer,_SubscriberId,<<"quota_exceeded">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?QUOTA_EXCEEDED,
-              reason_string => <<"You have exceeded your quota">>}};
+              properties => #{?P_REASON_STRING => <<"You have exceeded your quota">>}}};
 auth_on_register_m5_(_Peer,_SubscriberId,<<"use_another_server">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?USE_ANOTHER_SERVER,
-              server_ref => <<"server_ref">>}};
+              properties => #{?P_SERVER_REF => <<"server_ref">>}}};
 auth_on_register_m5_(_Peer,_SubscriberId,<<"server_moved">>,_Password,_CleanStart,_Properties) ->
     {error, #{reason_code => ?SERVER_MOVED,
-              server_ref => <<"server_ref">>}};
+              properties => #{?P_SERVER_REF => <<"server_ref">>}}};
 auth_on_register_m5_(_Peer,_SubscriberId,<<"broker_capabilities">>,_Password,_CleanStart,_Properties) ->
+    Props =
+        #{
+          ?P_MAX_QOS => 0,
+          ?P_RETAIN_AVAILABLE => false,
+          ?P_WILDCARD_SUBS_AVAILABLE => false,
+          ?P_SUB_IDS_AVAILABLE => false,
+          ?P_SHARED_SUBS_AVAILABLE => false
+          %% TODO: verify if the properties below can be
+          %% controlled from plugins.
+          %%
+          %%topic_alias_max => 100,
+          %%receive_max => 100,
+          %%server_keep_alive => 4000,
+          %%session_expiry_interval => 3600
+         },
     {ok, #{reason_code => ?SUCCESS,
-           max_qos => 0,
-           retain_available => false,
-           wildcard_subscriptions_available => false,
-           subscription_identifiers_available => false,
-           shared_subscriptions_available => false
            %% TODO: See vmq_mqtt5_fsm:auth_on_register/4
            %%max_packet_size => 1024
-
-           %% TODO: verify if the properties below can be
-           %% controlled from plugins.
-           %%
-           %%topic_alias_max => 100,
-           %%receive_max => 100,
-           %%server_keep_alive => 4000,
-           %%session_expiry_interval => 3600
-          }};
+           properties => Props}};
 auth_on_register_m5_(_Peer,_SubscriberId,_Username,_Password,_CleanStart,_Properties) ->
     ok.
 
@@ -83,9 +85,21 @@ auth_on_publish_m5(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties) 
     ?LOG([auth_on_publish_m5,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
     auth_on_publish_m5_(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties).
 
-auth_on_publish_m5_(<<"modify_props">>,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,#{p_user_property := UserProperties}) ->
-    {ok, #{user_property => [{<<"added">>, <<"user_property">>}|
-                             UserProperties]}};
+auth_on_publish_m5_(<<"remove_props">>,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,
+                    #{?P_USER_PROPERTY := _,
+                      ?P_CORRELATION_DATA := _,
+                      ?P_RESPONSE_TOPIC := _}) ->
+    NewProps = #{},
+    {ok, #{properties => NewProps}};
+auth_on_publish_m5_(<<"modify_props">>,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,
+                    #{?P_USER_PROPERTY := UserProperties,
+                      ?P_CORRELATION_DATA := CorrelationData,
+                      ?P_RESPONSE_TOPIC := <<"response/topic">> = RT}) ->
+    NewProps = #{?P_USER_PROPERTY => [{<<"added">>, <<"user_property">>}|
+                                      UserProperties],
+                 ?P_CORRELATION_DATA => <<"modified_", CorrelationData/binary>>,
+                 ?P_RESPONSE_TOPIC => <<"modified_",  RT/binary>>},
+    {ok, #{properties => NewProps}};
 auth_on_publish_m5_(_Username,_SubscriberId,_QoS,[<<"invalid">>, <<"topic">>],_Payload,_IsRetain,_Properties) ->
     {error, #{reason_code => ?TOPIC_NAME_INVALID,
               reason_string => <<"Invalid topic name">>}};
@@ -106,9 +120,10 @@ auth_on_subscribe_m5(Username,SubscriberId,Topics,Properties) ->
 auth_on_subscribe_m5_(_Username,_SubscriberId,
                       [{[<<"suback">>,<<"withprops">>], _}] = Topics,
                       _Properties) ->
+    Props = #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
+              ?P_REASON_STRING => <<"successful subscribe">>},
     {ok, #{topics => Topics,
-           user_property => [{<<"key">>, <<"val">>}],
-           reason_string => <<"successful subscribe">>}};
+           properties => Props}};
 auth_on_subscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
@@ -124,8 +139,9 @@ on_unsubscribe_m5_(_Username,_SubscriberId,
                    [[<<"unsuback">>,<<"withprops">>]] = Topics,
                    _Properties) ->
     {ok, #{topics => Topics,
-           user_property => [{<<"key">>, <<"val">>}],
-           reason_string => <<"Unsubscribe worked">>}};
+           properties =>
+               #{?P_USER_PROPERTY => [{<<"key">>, <<"val">>}],
+                 ?P_REASON_STRING => <<"Unsubscribe worked">>}}};
 on_unsubscribe_m5_(_Username,_SubscriberId,_Topics,_Properties) ->
     ok.
 
@@ -140,21 +156,23 @@ on_auth_m5(Username, SubscriberId, Properties) ->
 on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client1">>}) ->
+    Props = #{?P_AUTHENTICATION_METHOD => <<"method1">>,
+              ?P_AUTHENTICATION_DATA => <<"server1">>},
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           auth_method => <<"method1">>,
-           auth_data => <<"server1">>}};
+           properties => Props}};
 on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"client2">>}) ->
+    Props = #{?P_AUTHENTICATION_METHOD => <<"method1">>,
+              ?P_AUTHENTICATION_DATA => <<"server2">>},
     {ok, #{reason_code => ?SUCCESS,
-           auth_method => <<"method1">>,
-           auth_data => <<"server2">>}};
+           properties => Props}};
 on_auth_m5_(_Username, _SubscriberId,
             #{?P_AUTHENTICATION_METHOD := <<"method1">>,
               ?P_AUTHENTICATION_DATA := <<"baddata">>}) ->
     %% any other auth method we just reject.
     {error, #{reason_code => ?NOT_AUTHORIZED,
-              reason_string => <<"Bad authentication data: baddata">>}};
+              properties => #{?P_REASON_STRING => <<"Bad authentication data: baddata">>}}};
 on_auth_m5_(_Username, _SubscriberId, _Props) ->
     {error, unexpected_authentication_attempt}.
 
@@ -163,6 +181,31 @@ on_auth_m5_(_Username, _SubscriberId, _Props) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Delivery hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
-on_deliver_m5(Username,SubscriberId,Topic,Properties,Payload) ->
-    ?LOG([on_deliver_m5,Username,SubscriberId,Topic,Properties,Payload]),
+on_deliver_m5(Username,SubscriberId,Topic,Payload,Properties) ->
+    ?LOG([on_deliver_m5,Username,SubscriberId,Topic,Payload,Properties]),
+    on_deliver_m5_(Username,SubscriberId,Topic,Payload,Properties).
+
+on_deliver_m5_(<<"remove_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
+               #{?P_PAYLOAD_FORMAT_INDICATOR := _,
+                 ?P_CONTENT_TYPE := _,
+                 ?P_USER_PROPERTY := _,
+                 ?P_CORRELATION_DATA := _,
+                 ?P_RESPONSE_TOPIC := _}) ->
+    NewProps = #{},
+    {ok, #{properties => NewProps}};
+on_deliver_m5_(<<"modify_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
+               #{?P_PAYLOAD_FORMAT_INDICATOR := unspecified,
+                 ?P_CONTENT_TYPE := <<"type1">>,
+                 ?P_USER_PROPERTY := UserProperties,
+                 ?P_CORRELATION_DATA := CorrelationData,
+                 ?P_RESPONSE_TOPIC := <<"response/topic">> = RT}) ->
+    NewProps = #{?P_PAYLOAD_FORMAT_INDICATOR => utf8,
+                 ?P_CONTENT_TYPE => <<"type2">>,
+                 ?P_USER_PROPERTY => [{<<"added">>, <<"user_property">>}|
+                                      UserProperties],
+                 ?P_CORRELATION_DATA => <<"modified_", CorrelationData/binary>>,
+                 ?P_RESPONSE_TOPIC => <<"modified_",  RT/binary>>},
+    {ok, #{properties => NewProps}};
+
+on_deliver_m5_(_Username,_SubscriberId,_Topic,_Payload,_Properties) ->
     ok.

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -340,22 +340,22 @@ on_auth_bad_method_hook(_, _, #{p_authentication_method := _, p_authentication_d
 
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client1">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           auth_method => ?AUTH_METHOD,
-           auth_data => <<"Server1">>}};
+           properties => #{?P_AUTHENTICATION_METHOD => ?AUTH_METHOD,
+                           ?P_AUTHENTICATION_DATA =><<"Server1">>}}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client2">>}) ->
     {ok, #{reason_code => ?CONTINUE_AUTHENTICATION,
-           auth_method => ?AUTH_METHOD,
-           auth_data => <<"Server2">>}};
+           properties => #{?P_AUTHENTICATION_METHOD => ?AUTH_METHOD,
+                           ?P_AUTHENTICATION_DATA =><<"Server2">>}}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Client3">>}) ->
     %% return ok which will trigger the connack being sent to the
     %% client *or* an AUTH ok
     {ok, #{reason_code => ?SUCCESS,
-           auth_method => ?AUTH_METHOD,
-           auth_data => <<"ServerFinal">>}};
+           properties => #{?P_AUTHENTICATION_METHOD => ?AUTH_METHOD,
+                           ?P_AUTHENTICATION_DATA =><<"ServerFinal">>}}};
 on_auth_hook(_, _, #{p_authentication_method := ?AUTH_METHOD, p_authentication_data := <<"Reauth">>}) ->
     {ok, #{reason_code => ?SUCCESS,
-           auth_method => ?AUTH_METHOD,
-           auth_data => <<"ReauthOK">>}}.
+           properties => #{?P_AUTHENTICATION_METHOD => ?AUTH_METHOD,
+                           ?P_AUTHENTICATION_DATA =><<"ReauthOK">>}}}.
 
 auth_on_publish_after_reauth(undefined, _, 1, [<<"some">>, <<"topic">>], <<"some payload">>, false, _) ->
     ok.

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -181,9 +181,10 @@ auth_on_register_m5_test(_) ->
     WantUserProps = [{<<"key1">>, <<"val1">>},
                      {<<"key1">>, <<"val2">>},
                      {<<"key2">>, <<"val2">>}],
-    {ok, #{user_property := GotUserProps}}
+    {ok, #{properties := #{?P_USER_PROPERTY := GotUserProps}}}
         = vmq_plugin:all_till_ok(auth_on_register_m5,
-                      [?PEER, {?MOUNTPOINT, ?WITH_PROPERTIES}, ?USERNAME, ?PASSWORD, true, #{p_user_property => WantUserProps}]),
+                      [?PEER, {?MOUNTPOINT, ?WITH_PROPERTIES}, ?USERNAME, ?PASSWORD, true,
+                       #{?P_USER_PROPERTY => WantUserProps}]),
     [] = WantUserProps -- GotUserProps,
     deregister_hook(auth_on_register_m5, ?ENDPOINT).
 
@@ -324,8 +325,8 @@ on_deliver_m5_test(_) ->
 on_auth_m5_test(_) ->
     register_hook(on_auth_m5, ?ENDPOINT),
     {ok,
-     #{authentication_method := <<"AUTH_METHOD">>,
-       authentication_data := <<"AUTH_DATA1">>}}
+     #{properties := #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,
+                       ?P_AUTHENTICATION_DATA := <<"AUTH_DATA1">>}}}
         = vmq_plugin:all_till_ok(on_auth_m5,
                                  [?USERNAME, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID},
                                   #{?P_AUTHENTICATION_METHOD => <<"AUTH_METHOD">>,

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,24 @@
   that 75% of the received MQTT publish frames were routed to local subscribers
   and 25% were forwarded to subscribers on different cluster nodes. The routing
   score can be used to detect imbalances in a VerneMQ cluster.
+- The MQTT 5.0 plugin hook definitions have been updated as follows:
+  - The `Payload` and `Properties` arguments to the `on_deliver_m5` hook have
+    been swapped to be consistent with all the other `_m5` hooks.
+  - property modifiers are now using the same names as the properties in the
+    incoming properties, for example the `user_property` is now
+    `p_user_property`.
+  - Property modifiers have been moved into a `properties` modifier map. So for
+    example instead of returning `{ok, #{p_user_property => ...}}` one now
+    returns `{ok, #{property => #{p_user_property => ...}}}`. This change makes
+    it possible to drop properties from a plugin hook.
+  - In the `vmq_webhooks` plugin property modifiers have been moved into a
+    separate JSON object with the key `properties` inside the modifiers JSON
+    object. The `vmq_webhooks`.
+  - The `{ok, binary()}` return clause has been removed from the `on_deliver_m5`
+    hook, use the modifier map (`{ok, Modifiers}`) instead.
+  - The `{ok, binary()}` return clause has been removed from the
+    `auth_on_publish_m5` hook, use the modifier map (`{ok, Modifiers}`) instead.
+  - Note, MQTT 5.0 support in VerneMQ is still in Beta.
 
 ## VerneMQ 1.7.0
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -98,7 +98,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.2.0">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/vernemq/vernemq_dev.git",
-       {ref,"01edaa7114e6306992804cf842a0568df5c946e1"}},
+       {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
This PR depends on vernemq/vernemq_dev#11 to be approved and merged first.

From the changelog:
- The MQTT 5.0 plugin hooks have been updated so:
  - The `Payload` and `Properties` arguments to the `on_deliver_m5` hook have
    been swapped to be consistent with all the other `_m5` hooks.
  - property modifiers are now using the same names as the properties in the
    incoming properties, for example the `user_property` is now
    `p_user_property`.
  - property modifiers have been moved into a `property` modifier map. So for
    example instead of returning `{ok, #{p_user_property => ...}}` one now
    returns `{ok, #{property => #{p_user_property => ...}}}`. This change makes
    it possible to omit enables the removal of properties from a plugin hook.

