### PR TITLE
Fix error when tracing clients with a LWT

### DIFF
--- a/apps/vmq_server/src/vmq_tracer.erl
+++ b/apps/vmq_server/src/vmq_tracer.erl
@@ -575,9 +575,10 @@ format_lwt(Retain, _QoS, _Topic, _Msg, _Props, _Opts)
   when Retain =:= undefined ->
     [];
 format_lwt(Retain, QoS, Topic, Msg, Props, #{payload_limit := Limit} = Opts) ->
-    {"    with LWT(wr: ~p, wq: ~p, wt: ~s) with payload:~n"
+    [{"    with LWT(wr: ~p, wq: ~p, wt: ~s) with payload:~n"
      "    ~s~n",
-     [Retain, QoS, jtopic(Topic), trunc_payload(Msg, Limit), format_props(Props, Opts)]}.
+      [Retain, QoS, jtopic(Topic), trunc_payload(Msg, Limit)]},
+     format_props(Props, Opts)].
 
 format_frame_(#mqtt_pingreq{}, _) ->
     {"PINGREQ()~n", []};

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@
   - The `{ok, binary()}` return clause has been removed from the
     `auth_on_publish_m5` hook, use the modifier map (`{ok, Modifiers}`) instead.
   - Note, MQTT 5.0 support in VerneMQ is still in Beta.
+- Fix error when tracing clients connecting with a LWT.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
While investigating #1102 I came across this:

```
 Reason for termination == 
** {badarg,[{io,format,
                [<0.63.0>,
                 "~p MQTT RECV: CID: \"~s\" CONNECT(c: ~s, v: ~p, u: ~s, p: ~s, cs: ~p, ka: ~p)~n    with LWT(wr: ~p, wq: ~p, wt: ~s) with payload:~n    ~s~n",
                 [<8272.547.0>,<<"test-client">>,<<"test-client">>,4,
                  <<"test-user">>,<<"123">>,1,60,0,0,<<"a/b/c">>,
                  <<"willpayload">>,[]]],
                []},
            {vmq_tracer,handle_call,3,
                        [{file,"/home/lhc/dev/octavolabs/vernemq/_build/default/lib/vmq_server/src/vmq_tracer.erl"},
                         {line,173}]},
            {gen_server,try_handle_call,4,
                        [{file,"gen_server.erl"},{line,661}]},
            {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,690}]},
            {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
```