### PR TITLE
Validate configured files

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -179,10 +179,12 @@
 %% @doc The cafile is used to define the path to a file containing
 %% the PEM encoded CA certificates that are trusted. 
 {mapping, "vmq_bridge.ssl.$name.cafile", "vmq_bridge.config", [
-                                                              {default, ""},
-                                                              {datatype, file},
-                                                              {include_default, "sbr0"},
-                                                              {commented, "{{platform_etc_dir}}/cacerts.pem"}
+                                                               {default, ""},
+                                                               {datatype, file},
+                                                               {include_default, "sbr0"},
+                                                               {commented, "{{platform_etc_dir}}/cacerts.pem"},
+                                                               {validators, ["file-exists", "file-is-readable"]}
+
                                                              ]}. 
 
 %% @doc Define the path to a folder containing 
@@ -194,22 +196,24 @@
                                                                {include_default, "sbr0"},
                                                                {commented, "{{platform_etc_dir}}/cacerts"},
                                                                hidden
-                                                             ]}. 
+                                                              ]}.
 
 %% @doc Set the path to the PEM encoded server certificate.
 {mapping, "vmq_bridge.ssl.$name.certfile", "vmq_bridge.config", [
+                                                                 {default, ""},
+                                                                 {datatype, file},
+                                                                 {include_default, "sbr0"},
+                                                                 {commented, "{{platform_etc_dir}}/cert.pem"},
+                                                                 {validators, ["file-exists", "file-is-readable"]}
+                                                                ]}.
+%% @doc Set the path to the PEM encoded key file.
+{mapping, "vmq_bridge.ssl.$name.keyfile", "vmq_bridge.config", [
                                                                 {default, ""},
                                                                 {datatype, file},
                                                                 {include_default, "sbr0"},
-                                                                {commented, "{{platform_etc_dir}}/cert.pem"}
-                                                               ]}. 
-%% @doc Set the path to the PEM encoded key file. 
-{mapping, "vmq_bridge.ssl.$name.keyfile", "vmq_bridge.config", [
-                                                               {default, ""},
-                                                               {datatype, file},
-                                                               {include_default, "sbr0"},
-                                                               {commented, "{{platform_etc_dir}}/key.pem"}
-                                                              ]}. 
+                                                                {commented, "{{platform_etc_dir}}/key.pem"},
+                                                                {validators, ["file-exists", "file-is-readable"]}
+                                                               ]}.
 %% @doc When using certificate based TLS, the bridge will attempt to verify the 
 %% hostname provided in the remote certificate matches the host/address being 
 %% connected to. This may cause problems in testing scenarios, so this option 
@@ -435,6 +439,21 @@
          {DropUndef(TCP), DropUndef(SSL)}
  end
 }.
+
+{validator, "file-exists", "file does not exist",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_exists(Name)
+ end}.
+{validator, "file-is-readable", "file is not readable, check permissions",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_is_readable(Name)
+ end}.
 
 {mapping, "vmq_bridge.clique_lead_line", "vmq_bridge.clique_lead_line",
  [{datatype, string},

--- a/apps/vmq_commons/src/vmq_schema_util.erl
+++ b/apps/vmq_commons/src/vmq_schema_util.erl
@@ -1,0 +1,21 @@
+-module(vmq_schema_util).
+
+-export([file_exists/1, file_is_readable/1]).
+
+-include_lib("kernel/include/file.hrl").
+
+file_exists(Filename) ->
+    case file:read_file_info(Filename) of
+        {error, enonent} ->
+            false;
+        _ -> true
+    end.
+
+file_is_readable(Filename) ->
+    case file:read_file_info(Filename) of
+        {ok, #file_info{access=Access}} when Access =:= read; Access =:= read_write ->
+            %% we can read the file
+            true;
+        _ ->
+            false
+    end.

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -915,39 +915,47 @@
 {mapping, "listener.ssl.cafile", "vmq_server.listeners", [
                                                           {default, ""},
                                                           {datatype, file},
-                                                          {commented, "{{platform_etc_dir}}/cacerts.pem"}
-                                                         ]}. 
+                                                          {commented, "{{platform_etc_dir}}/cacerts.pem"},
+                                                          {validators, ["file-exists", "file-is-readable"]}
+                                                         ]}.
 
 {mapping, "listener.ssl.$name.cafile", "vmq_server.listeners", [
-                                                                {datatype, string},
+                                                                {datatype, file},
+                                                                {validators, ["file-exists", "file-is-readable"]},
                                                                 hidden
-                                                               ]}. 
+                                                               ]}.
 {mapping, "listener.wss.cafile", "vmq_server.listeners", [
                                                           {default, ""},
                                                           {datatype, file},
+                                                          {validators, ["file-exists", "file-is-readable"]},
                                                           hidden
                                                          ]}. 
 {mapping, "listener.wss.$name.cafile", "vmq_server.listeners", [
-                                                                {datatype, string},
+                                                                {datatype, file},
+                                                                {validators, ["file-exists", "file-is-readable"]},
                                                                 hidden
                                                                ]}. 
 {mapping, "listener.vmqs.cafile", "vmq_server.listeners", [
                                                            {default, ""},
                                                            {datatype, file},
+                                                           {validators, ["file-exists", "file-is-readable"]},
                                                            hidden
                                                           ]}. 
 {mapping, "listener.vmqs.$name.cafile", "vmq_server.listeners", [
-                                                                {datatype, string},
+                                                                {datatype, file},
+                                                                {validators, ["file-exists", "file-is-readable"]},
                                                                 hidden
                                                                ]}. 
 {mapping, "listener.https.cafile", "vmq_server.listeners", [
                                                             {default, ""},
                                                             {datatype, file},
+                                                            {validators, ["file-exists", "file-is-readable"]},
                                                             {commented, "{{platform_etc_dir}}/cacerts.pem"}
                                                            ]}. 
 
 {mapping, "listener.https.$name.cafile", "vmq_server.listeners", [
-                                                                {datatype, string},
+                                                                {datatype, file},
+                                                                {validators, ["file-exists", "file-is-readable"]},
                                                                 hidden
                                                                ]}. 
 
@@ -1017,38 +1025,46 @@
 {mapping, "listener.ssl.certfile", "vmq_server.listeners", [
                                                             {default, ""},
                                                             {datatype, file},
+                                                            {validators, ["file-exists", "file-is-readable"]},
                                                             {commented, "{{platform_etc_dir}}/cert.pem"}
                                                            ]}. 
 {mapping, "listener.ssl.$name.certfile", "vmq_server.listeners", [
                                                                   {datatype, file},
+                                                                  {validators, ["file-exists", "file-is-readable"]},
                                                                   hidden
                                                                  ]}. 
 {mapping, "listener.wss.certfile", "vmq_server.listeners", [
                                                             {default, ""},
                                                             {datatype, file},
+                                                            {validators, ["file-exists", "file-is-readable"]},
                                                             hidden
                                                            ]}. 
 {mapping, "listener.wss.$name.certfile", "vmq_server.listeners", [
                                                                   {datatype, file},
+                                                                  {validators, ["file-exists", "file-is-readable"]},
                                                                   hidden
                                                                  ]}. 
 {mapping, "listener.vmqs.certfile", "vmq_server.listeners", [
                                                              {default, ""},
                                                              {datatype, file},
+                                                             {validators, ["file-exists", "file-is-readable"]},
                                                              hidden
                                                             ]}. 
 {mapping, "listener.vmqs.$name.certfile", "vmq_server.listeners", [
-                                                                  {datatype, file},
-                                                                  hidden
-                                                                 ]}. 
+                                                                   {datatype, file},
+                                                                   {validators, ["file-exists", "file-is-readable"]},
+                                                                   hidden
+                                                                  ]}.
 {mapping, "listener.https.certfile", "vmq_server.listeners", [
                                                               {default, ""},
                                                               {datatype, file},
+                                                              {validators, ["file-exists", "file-is-readable"]},
                                                               {commented, "{{platform_etc_dir}}/cert.pem"}
                                                              ]}. 
 {mapping, "listener.https.$name.certfile", "vmq_server.listeners", [
-                                                                  {datatype, file},
-                                                                  hidden
+                                                                    {datatype, file},
+                                                                    {validators, ["file-exists", "file-is-readable"]},
+                                                                    hidden
                                                                  ]}. 
 %% @doc Set the path to the PEM encoded key file on the protocol 
 %% level or on the listener level:
@@ -1063,37 +1079,45 @@
 {mapping, "listener.ssl.keyfile", "vmq_server.listeners", [
                                                            {default, ""},
                                                            {datatype, file},
+                                                           {validators, ["file-exists", "file-is-readable"]},
                                                            {commented, "{{platform_etc_dir}}/key.pem"}
                                                           ]}. 
 {mapping, "listener.ssl.$name.keyfile", "vmq_server.listeners", [
                                                                  {datatype, file},
+                                                                 {validators, ["file-exists", "file-is-readable"]},
                                                                  hidden
                                                                 ]}. 
 {mapping, "listener.wss.keyfile", "vmq_server.listeners", [
                                                            {default, ""},
                                                            {datatype, file},
+                                                           {validators, ["file-exists", "file-is-readable"]},
                                                            hidden
                                                           ]}. 
 {mapping, "listener.wss.$name.keyfile", "vmq_server.listeners", [
                                                                  {datatype, file},
+                                                                 {validators, ["file-exists", "file-is-readable"]},
                                                                  hidden
                                                                 ]}. 
 {mapping, "listener.vmqs.keyfile", "vmq_server.listeners", [
                                                             {default, ""},
                                                             {datatype, file},
+                                                            {validators, ["file-exists", "file-is-readable"]},
                                                             {commented, "{{platform_etc_dir}}/key.pem"}
                                                            ]}. 
 {mapping, "listener.vmqs.$name.keyfile", "vmq_server.listeners", [
                                                                   {datatype, file},
+                                                                  {validators, ["file-exists", "file-is-readable"]},
                                                                   hidden
                                                                 ]}. 
 {mapping, "listener.https.keyfile", "vmq_server.listeners", [
                                                              {default, ""},
                                                              {datatype, file},
+                                                             {validators, ["file-exists", "file-is-readable"]},
                                                              {commented, "{{platform_etc_dir}}/key.pem"}
                                                             ]}. 
 {mapping, "listener.https.$name.keyfile", "vmq_server.listeners", [
                                                                    {datatype, file},
+                                                                   {validators, ["file-exists", "file-is-readable"]},
                                                                    hidden
                                                                   ]}. 
 %% @doc Set the list of allowed ciphers (each separated with a colon,
@@ -1159,38 +1183,46 @@
 %%     - listener.wss.my_wss_listener.crlfile
 {mapping, "listener.ssl.crlfile", "vmq_server.listeners", [
                                                            {default, ""},
-                                                           {datatype, string},
+                                                           {datatype, file},
+                                                           {validators, ["file-exists", "file-is-readable"]},
                                                            {commented, ""}
                                                           ]}. 
 {mapping, "listener.ssl.$name.crlfile", "vmq_server.listeners", [
-                                                                 {datatype, string},
+                                                                 {datatype, file},
+                                                                 {validators, ["file-exists", "file-is-readable"]},
                                                                  hidden
                                                                 ]}. 
 {mapping, "listener.wss.crlfile", "vmq_server.listeners", [
                                                            {default, ""},
-                                                           {datatype, string},
+                                                           {datatype, file},
+                                                           {validators, ["file-exists", "file-is-readable"]},
                                                            hidden
                                                           ]}. 
 {mapping, "listener.wss.$name.crlfile", "vmq_server.listeners", [
-                                                                 {datatype, string},
+                                                                 {datatype, file},
+                                                                 {validators, ["file-exists", "file-is-readable"]},
                                                                  hidden
                                                                 ]}. 
 {mapping, "listener.vmqs.crlfile", "vmq_server.listeners", [
                                                             {default, ""},
-                                                            {datatype, string},
+                                                            {datatype, file},
+                                                            {validators, ["file-exists", "file-is-readable"]},
                                                             hidden
                                                            ]}. 
 {mapping, "listener.vmqs.$name.crlfile", "vmq_server.listeners", [
-                                                                 {datatype, string},
+                                                                 {datatype, file},
+                                                                  {validators, ["file-exists", "file-is-readable"]},
                                                                  hidden
                                                                 ]}. 
 {mapping, "listener.https.crlfile", "vmq_server.listeners", [
                                                              {default, ""},
-                                                             {datatype, string},
+                                                             {datatype, file},
+                                                             {validators, ["file-exists", "file-is-readable"]},
                                                              hidden
                                                             ]}. 
 {mapping, "listener.https.$name.crlfile", "vmq_server.listeners", [
-                                                                   {datatype, string},
+                                                                   {datatype, file},
+                                                                   {validators, ["file-exists", "file-is-readable"]},
                                                                    hidden
                                                                   ]}. 
 %% @doc Enable this option if you want to use SSL client certificates 
@@ -1649,3 +1681,18 @@
 {mapping, "metadata_plugin", "vmq_server.metadata_impl", [{default, {{ metadata_plugin }} },
                                                           {datatype, {enum, [vmq_plumtree, vmq_swc]}}
                                                          ]}.
+
+{validator, "file-exists", "file does not exist",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_exists(Name)
+ end}.
+{validator, "file-is-readable", "file is not readable, check permissions",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_is_readable(Name)
+ end}.

--- a/apps/vmq_server/test/vmq_schema_SUITE.erl
+++ b/apps/vmq_server/test/vmq_schema_SUITE.erl
@@ -51,17 +51,24 @@ global_substitutions() ->
      {["listener", "nr_of_acceptors"], "100"}].
 
 
+dummy_file(Name) ->
+    Path = filename:dirname(
+             proplists:get_value(source, ?MODULE:module_info(compile))),
+    filename:join([Path, Name]).
+
+
 ssl_certs_opts_inheritance_test(_Config) ->
+    DummyFile = dummy_file("vmq_schema_suite_dummy_file"),
     ConfFun =
         fun(LType) ->
                 [
-                 {["listener", LType, "certfile"], "certfile"},
-                 {["listener", LType, "cafile"], "cafile"},
-                 {["listener", LType, "keyfile"], "keyfile"},
+                 {["listener", LType, "certfile"], DummyFile},
+                 {["listener", LType, "cafile"], DummyFile},
+                 {["listener", LType, "keyfile"], DummyFile},
                  {["listener", LType, "depth"], 10},
 
                  {["listener", LType, "ciphers"], "ciphers"},
-                 {["listener", LType, "crlfile"], "crlfile"},
+                 {["listener", LType, "crlfile"], DummyFile},
                  {["listener", LType, "require_certificate"], "on"},
 
                  {["listener", LType, "tls_version"], "tlsv1.1"},
@@ -71,14 +78,14 @@ ssl_certs_opts_inheritance_test(_Config) ->
         end,
     TestFun =
         fun(Conf, IntName) ->
-                "certfile" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, certfile]),
-                "cafile"   = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, cafile]),
-                "keyfile"  = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, keyfile]),
-                10         = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, depth]),
-                "ciphers"  = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, ciphers]),
-                "crlfile"  = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, crlfile]),
-                true       = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, require_certificate]),
-                'tlsv1.1'  = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, tls_version])
+                DummyFile = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, certfile]),
+                DummyFile = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, cafile]),
+                DummyFile = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, keyfile]),
+                10        = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, depth]),
+                "ciphers" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, ciphers]),
+                DummyFile = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, crlfile]),
+                true      = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, require_certificate]),
+                'tlsv1.1' = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, tls_version])
         end,
 
     lists:foreach(
@@ -98,26 +105,28 @@ ssl_certs_opts_inheritance_test(_Config) ->
       ]).
 
 ssl_certs_opts_override_test(_Config) ->
+    DummyFile = dummy_file("vmq_schema_suite_dummy_file"),
+    DummyFileOverride = dummy_file("vmq_schema_suite_dummy_file_override"),
     ConfFun =
         fun(LType) ->
                 [
                  %% protocol defaults
-                 {["listener", LType, "certfile"], "certfile"},
-                 {["listener", LType, "cafile"], "cafile"},
-                 {["listener", LType, "keyfile"], "keyfile"},
+                 {["listener", LType, "certfile"], DummyFile},
+                 {["listener", LType, "cafile"], DummyFile},
+                 {["listener", LType, "keyfile"], DummyFile},
                  {["listener", LType, "depth"], 10},
                  {["listener", LType, "ciphers"], "ciphers"},
-                 {["listener", LType, "crlfile"], "crlfile"},
+                 {["listener", LType, "crlfile"], DummyFile},
                  {["listener", LType, "require_certificate"], "on"},
                  {["listener", LType, "tls_version"], "tlsv1.1"},
 
                  %% listener overrides
-                 {["listener", LType, "mylistener", "certfile"], "overridden"},
-                 {["listener", LType, "mylistener", "cafile"], "overridden"},
-                 {["listener", LType, "mylistener", "keyfile"], "overridden"},
+                 {["listener", LType, "mylistener", "certfile"], DummyFileOverride},
+                 {["listener", LType, "mylistener", "cafile"], DummyFileOverride},
+                 {["listener", LType, "mylistener", "keyfile"], DummyFileOverride},
                  {["listener", LType, "mylistener", "depth"], 20},
                  {["listener", LType, "mylistener", "ciphers"], "overridden"},
-                 {["listener", LType, "mylistener", "crlfile"], "overridden"},
+                 {["listener", LType, "mylistener", "crlfile"], DummyFileOverride},
                  {["listener", LType, "mylistener", "require_certificate"], "off"},
                  {["listener", LType, "mylistener", "tls_version"], "tlsv1.2"},
 
@@ -127,14 +136,14 @@ ssl_certs_opts_override_test(_Config) ->
         end,
     TestFun =
         fun(Conf, IntName) ->
-                "overridden" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, certfile]),
-                "overridden" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, cafile]),
-                "overridden" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, keyfile]),
-                20           = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, depth]),
-                "overridden" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, ciphers]),
-                "overridden" = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, crlfile]),
-                false        = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, require_certificate]),
-                'tlsv1.2'    = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, tls_version])
+                DummyFileOverride = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, certfile]),
+                DummyFileOverride = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, cafile]),
+                DummyFileOverride = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, keyfile]),
+                20                = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, depth]),
+                "overridden"      = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, ciphers]),
+                DummyFileOverride = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, crlfile]),
+                false             = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, require_certificate]),
+                'tlsv1.2'         = expect(Conf, [vmq_server, listeners, IntName,  {{127,0,0,1}, 1234}, tls_version])
         end,
 
     lists:foreach(

--- a/apps/vmq_server/test/vmq_schema_suite_dummy_file
+++ b/apps/vmq_server/test/vmq_schema_suite_dummy_file
@@ -1,0 +1,1 @@
+Needed to pass file validation. This file must exist and be readable.

--- a/apps/vmq_server/test/vmq_schema_suite_dummy_file_override
+++ b/apps/vmq_server/test/vmq_schema_suite_dummy_file_override
@@ -1,0 +1,1 @@
+Needed to pass file validation. This file must exist and be readable.

--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,8 @@
     `auth_on_publish_m5` hook, use the modifier map (`{ok, Modifiers}`) instead.
   - Note, MQTT 5.0 support in VerneMQ is still in Beta.
 - Fix error when tracing clients connecting with a LWT.
+- Add file validation to check if files in the `vernemq.conf` exist and are
+  readable.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
This adds validators to check if files in the ssl configuration for listeners and the bridge exist and are readable. If any of the files specified are not present or are unreadable then VerneMQ will fail to start with an error like:

```
vernemq console
14:52:13.005 [error] listener.ssl.cafile invalid, file is not readable, check permissions
14:52:13.008 [error] Error generating configuration in phase validation
14:52:13.008 [error] listener.ssl.cafile invalid, file is not readable, check permissions
Error generating config with cuttlefish
  run `vernemq config generate -l debug` for more information.
```

Note, the vmq_acl and vmq_passwd files are not checked as the defaults may or may not be present.

This partly fixes #849