### PR TITLE
Treat migration disconnects as normal termination reason

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -736,13 +736,8 @@ terminate(Reason, Props, #state{session_expiry_interval=SessionExpiryInterval} =
         end,
     {stop, terminate_reason(Reason), Out}.
 
-%% TODO Unify with terminate_reason in `vmq_mqtt_fsm`?
-terminate_reason(?NORMAL_DISCONNECT) -> normal;
-terminate_reason(?SESSION_TAKEN_OVER) -> normal;
-terminate_reason(?ADMINISTRATIVE_ACTION) -> normal;
-terminate_reason(?CLIENT_DISCONNECT) -> normal;
-terminate_reason(Reason) ->  Reason.
-
+terminate_reason(Reason) ->
+    vmq_mqtt_fsm_util:terminate_reason(Reason).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% internal

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -477,12 +477,7 @@ terminate(Reason, #state{clean_session=CleanSession} = State) ->
     {stop, terminate_reason(Reason), []}.
 
 terminate_reason(publish_not_authorized_3_1_1) -> normal;
-terminate_reason(?NORMAL_DISCONNECT) -> normal;
-terminate_reason(?SESSION_TAKEN_OVER) -> normal;
-terminate_reason(?ADMINISTRATIVE_ACTION) -> normal;
-terminate_reason(?DISCONNECT_KEEP_ALIVE) -> normal;
-terminate_reason(?CLIENT_DISCONNECT) -> normal;
-terminate_reason(Reason) ->  Reason.
+terminate_reason(Reason) ->  vmq_mqtt_fsm_util:terminate_reason(Reason).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% internal

--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -21,7 +21,8 @@
          msg_ref/0,
          plugin_receive_loop/2,
          to_vmq_subtopics/2,
-         peertoa/1]).
+         peertoa/1,
+         terminate_reason/1]).
 
 -define(TO_SESSION, to_session_fsm).
 
@@ -111,3 +112,12 @@ peertoa({IP,Port}) ->
         {_,_,_,_,_,_,_,_} ->
             io_lib:format("[~s]:~p", [inet:ntoa(IP),Port])
     end.
+
+-spec terminate_reason(any()) -> any().
+terminate_reason(?ADMINISTRATIVE_ACTION) -> normal;
+terminate_reason(?CLIENT_DISCONNECT) -> normal;
+terminate_reason(?DISCONNECT_KEEP_ALIVE) -> normal;
+terminate_reason(?DISCONNECT_MIGRATION) -> normal;
+terminate_reason(?NORMAL_DISCONNECT) -> normal;
+terminate_reason(?SESSION_TAKEN_OVER) -> normal;
+terminate_reason(Reason) ->  Reason.

--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,8 @@
 - Fix error when tracing clients connecting with a LWT.
 - Add file validation to check if files in the `vernemq.conf` exist and are
   readable.
+- Fix that disconnects due to client migrations were logged as warnings. They
+  are now treated as the normal termination case.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
Fixes logs like the following:

```
10:49:33.791 [warning] session stopped abnormally due to 'disconnect_migration'
```

Also moved the termination reason list from the fsms into the util module.