### PR TITLE
Make conversion of modifiers returned from Lua context aware

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -474,7 +474,7 @@ all_till_ok([Pid|Rest], HookName, Args) ->
         true ->
             ok;
         Mods0 when is_list(Mods0) ->
-            Mods1 = normalize_modifiers(HookName, Mods0),
+            Mods1 = convert_modifiers(HookName, Mods0),
             case vmq_plugin_util:check_modifiers(HookName, Mods1) of
                 error ->
                     {error, {invalid_modifiers, Mods1}};
@@ -527,8 +527,8 @@ nilify(Val) ->
 extract_qos({QoS, _SubInfo}) -> QoS;
 extract_qos(QoS) when is_integer(QoS) -> QoS.
 
-normalize_modifiers(Hook, Mods) ->
-    vmq_diversity_utils:normalize_modifiers(Hook, Mods).
+convert_modifiers(Hook, Mods0) ->
+    vmq_diversity_utils:convert_modifiers(Hook, Mods0).
 
 conv_res(auth_on_reg, {error, lua_script_returned_false}) ->
     {error, invalid_credentials};

--- a/apps/vmq_diversity/src/vmq_diversity_script_state.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script_state.erl
@@ -165,7 +165,7 @@ handle_info({call_function, Ref, CallerPid, Function, Args}, State) ->
         {[], NewLuaState} ->
             {undefined, ch_state(NewLuaState, State)};
         {[Val], NewLuaState} ->
-            {vmq_diversity_utils:convert(Val), ch_state(NewLuaState, State)}
+            {Val, ch_state(NewLuaState, State)}
     catch
         error:{lua_error, Reason, _} ->
             lager:error("can't call function ~p with args ~p in ~p due to ~p",

--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -13,7 +13,7 @@
 %% limitations under the License.
 
 -module(vmq_diversity_utils).
--export([normalize_modifiers/2,
+-export([convert_modifiers/2,
          normalize_subscribe_topics/1,
          convert/1,
          map/1,
@@ -23,23 +23,46 @@
          ustr/1,
          atom/1]).
 
-%% @doc change modifiers into a canonical form so it can be run
-%% through the modifier checker.
-normalize_modifiers(auth_on_subscribe_m5, Mods) ->
-    Mods1 =
+%% @doc convert modifiers returned from lua to the canonical form so
+%% it can be run throught the modifier checker and returned to the
+%% mqtt fsms.
+convert_modifiers(auth_on_subscribe, Mods0) ->
+    normalize_subscribe_topics(convert(Mods0));
+convert_modifiers(on_unsubscribe, Mods0) ->
+    convert(Mods0);
+convert_modifiers(Hook, Mods0) ->
+    Mods1 = atomize_keys(Mods0),
+    Converted = lists:map(
+                  fun(Mod) ->
+                          convert_modifier(Hook, Mod)
+                  end,
+                  Mods1),
+    case lists:member(Hook, [auth_on_register_m5,
+                             auth_on_subscribe_m5,
+                             auth_on_publish_m5]) of
+        true ->
+            maps:from_list(Converted);
+        _ ->
+            Converted
+    end.
+
+atomize_keys(Mods) ->
     lists:map(
-      fun({topics, Topics}) ->
-              {topics, normalize_subscribe_topics(Topics)}
-      end, Mods),
-    maps:from_list(Mods1);
-normalize_modifiers(auth_on_register_m5, Mods) ->
-    maps:from_list(Mods);
-normalize_modifiers(auth_on_publish_m5, Mods) ->
-    maps:from_list(Mods);
-normalize_modifiers(auth_on_subscribe, Mods) ->
-    normalize_subscribe_topics(Mods);
-normalize_modifiers(_Hook, Mods) ->
-    Mods.
+      fun({K,V}) when is_binary(K) ->
+              {binary_to_existing_atom(K,utf8), V};
+         ({K,V}) when is_atom(K) ->
+              {K,V}
+      end, Mods).
+
+convert_modifier(Hook, {subscriber_id, SID})
+  when Hook =:= auth_on_register_m5;
+       Hook =:= auth_on_register ->
+    {subscriber_id, atomize_keys(SID)};
+convert_modifier(auth_on_subscribe_m5, {topics, Topics}) ->
+    {topics, normalize_subscribe_topics(convert(Topics))};
+convert_modifier(_, {Key, Val}) ->
+    %% fall back to automatic conversion,
+    {Key, convert(Val)}.
 
 normalize_subscribe_topics(Topics0) ->
     lists:map(


### PR DESCRIPTION
We need to have a context when converting modifiers returned from Lua
in order to handle MQTT 5.0 properties correctly. In particular the
`vmq_diversity_utils:convert/1` function cannot be used to convert the
user properties as it would convert the user property keys to atoms.

So now all conversion has been moved into the `vmq_diversity_plugin`
where we can hint the conversion which hook is being invoked and
handle the special cases directly.