### PR TITLE
Improve diversity m5 support

### DIFF
--- a/apps/vmq_commons/src/vmq_topic.erl
+++ b/apps/vmq_commons/src/vmq_topic.erl
@@ -40,6 +40,7 @@
          validate_topic/2,
          contains_wildcard/1,
          unword/1,
+         word/1,
          triples/1]).
 
 -define(MAX_LEN, 65536).
@@ -78,6 +79,9 @@ triples([Word|Rest] = Topic, Acc) ->
 
 unword(Topic) ->
     vernemq_dev_api:unword_topic(Topic).
+
+word(Topic) ->
+    re:split(Topic, <<"/">>).
 
 validate_topic(_Type, <<>>) ->
     {error, no_empty_topic_allowed};

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -34,6 +34,7 @@
 -behaviour(auth_on_publish_m5_hook).
 -behaviour(auth_on_subscribe_m5_hook).
 -behaviour(on_publish_m5_hook).
+-behaviour(on_auth_m5_hook).
 
 -export([auth_on_register/5,
          auth_on_publish/6,

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -31,6 +31,7 @@
 -behaviour(on_client_gone_hook).
 
 -behaviour(auth_on_register_m5_hook).
+-behaviour(on_register_m5_hook).
 -behaviour(auth_on_publish_m5_hook).
 -behaviour(auth_on_subscribe_m5_hook).
 -behaviour(on_publish_m5_hook).
@@ -49,6 +50,7 @@
          on_client_offline/1,
          on_client_gone/1,
          auth_on_register_m5/6,
+         on_register_m5/4,
          auth_on_publish_m5/7,
          auth_on_subscribe_m5/4,
          on_publish_m5/7,
@@ -229,6 +231,16 @@ auth_on_register_m5(Peer, SubscriberId, UserName, Password, CleanStart, Props) -
                                             {clean_start, CleanStart},
                                             {properties, conv_args_props(Props)}]),
     conv_res(auth_on_reg, Res).
+
+on_register_m5(Peer, SubscriberId, Username, Props) ->
+    {PPeer, Port} = peer(Peer),
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    all(on_register_m5, [{addr, PPeer},
+                         {port, Port},
+                         {mountpoint, MP},
+                         {client_id, ClientId},
+                         {username, nilify(Username)},
+                         {properties, conv_args_props(Props)}]).
 
 auth_on_publish(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -393,12 +393,12 @@ on_subscribe_m5(UserName, SubscriberId, Topics, Props) ->
     Unmap = fun(SubOpts) ->
                     vmq_diversity_utils:unmap(SubOpts)
             end,
-    all(auth_on_subscribe_m5, [{username, nilify(UserName)},
-                               {mountpoint, MP},
-                               {client_id, ClientId},
-                               {topics, [[unword(T), [QoS, Unmap(SubOpts)]]
-                                         || {T, {QoS, SubOpts}} <- Topics]},
-                               {properties, conv_args_props(Props)}]).
+    all(on_subscribe_m5, [{username, nilify(UserName)},
+                          {mountpoint, MP},
+                          {client_id, ClientId},
+                          {topics, [[unword(T), [QoS, Unmap(SubOpts)]]
+                                    || {T, {QoS, SubOpts}} <- Topics]},
+                          {properties, conv_args_props(Props)}]).
 
 on_unsubscribe_m5(UserName, SubscriberId, Topics, Props) ->
     {MP, ClientId} = subscriber_id(SubscriberId),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -48,7 +48,8 @@
          on_client_gone/1,
          auth_on_register_m5/6,
          auth_on_publish_m5/7,
-         auth_on_subscribe_m5/4]).
+         auth_on_subscribe_m5/4,
+         on_auth_m5/3]).
 
 
 %% API functions
@@ -347,6 +348,14 @@ auth_on_subscribe_m5(UserName, SubscriberId, Topics, Props) ->
                                                      {properties, conv_args_props(Props)}]),
             conv_res(auth_on_sub, Res)
     end.
+
+on_auth_m5(Username, SubscriberId, Props) ->
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    all_till_ok(on_auth_m5, [{username, nilify(Username)},
+                             {mountpoint, MP},
+                             {client_id, ClientId},
+                             {properties, conv_args_props(Props)}]).
+
 
 on_register(Peer, SubscriberId, UserName) ->
     {PPeer, Port} = peer(Peer),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -543,6 +543,8 @@ conv_args_prop({?P_USER_PROPERTY, UserProps}) ->
                          {[{Ctr, [P]}|Res], Ctr+1}
                  end, {[], 1}, UserProps),
     {?P_USER_PROPERTY, lists:reverse(UPS)};
+conv_args_prop({?P_RESPONSE_TOPIC, Topic}) ->
+    {?P_RESPONSE_TOPIC, unword(Topic)};
 conv_args_prop(P) -> P.
 
 conv_res(auth_on_reg, {error, lua_script_returned_false}) ->

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -33,8 +33,9 @@
 -behaviour(auth_on_register_m5_hook).
 -behaviour(on_register_m5_hook).
 -behaviour(auth_on_publish_m5_hook).
--behaviour(auth_on_subscribe_m5_hook).
 -behaviour(on_publish_m5_hook).
+-behaviour(auth_on_subscribe_m5_hook).
+-behaviour(on_subscribe_m5_hook).
 -behaviour(on_auth_m5_hook).
 
 -export([auth_on_register/5,
@@ -52,8 +53,9 @@
          auth_on_register_m5/6,
          on_register_m5/4,
          auth_on_publish_m5/7,
-         auth_on_subscribe_m5/4,
          on_publish_m5/7,
+         auth_on_subscribe_m5/4,
+         on_subscribe_m5/4,
          on_auth_m5/3]).
 
 
@@ -374,6 +376,18 @@ auth_on_subscribe_m5(UserName, SubscriberId, Topics, Props) ->
                                                      {properties, conv_args_props(Props)}]),
             conv_res(auth_on_sub, Res)
     end.
+
+on_subscribe_m5(UserName, SubscriberId, Topics, Props) ->
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    Unmap = fun(SubOpts) ->
+                    vmq_diversity_utils:unmap(SubOpts)
+            end,
+    all(auth_on_subscribe_m5, [{username, nilify(UserName)},
+                               {mountpoint, MP},
+                               {client_id, ClientId},
+                               {topics, [[unword(T), [QoS, Unmap(SubOpts)]]
+                                         || {T, {QoS, SubOpts}} <- Topics]},
+                               {properties, conv_args_props(Props)}]).
 
 on_auth_m5(Username, SubscriberId, Props) ->
     {MP, ClientId} = subscriber_id(SubscriberId),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -33,6 +33,7 @@
 -behaviour(auth_on_register_m5_hook).
 -behaviour(auth_on_publish_m5_hook).
 -behaviour(auth_on_subscribe_m5_hook).
+-behaviour(on_publish_m5_hook).
 
 -export([auth_on_register/5,
          auth_on_publish/6,
@@ -49,6 +50,7 @@
          auth_on_register_m5/6,
          auth_on_publish_m5/7,
          auth_on_subscribe_m5/4,
+         on_publish_m5/7,
          on_auth_m5/3]).
 
 
@@ -273,6 +275,17 @@ auth_on_publish_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props)
                                                    {properties, conv_args_props(Props)}]),
             conv_res(auth_on_pub, Res)
     end.
+
+on_publish_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    all(on_publish_m5, [{username, nilify(UserName)},
+                        {mountpoint, MP},
+                        {client_id, ClientId},
+                        {qos, QoS},
+                        {topic, unword(Topic)},
+                        {payload, Payload},
+                        {retain, IsRetain},
+                        {properties, conv_args_props(Props)}]).
 
 auth_on_subscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -370,7 +370,7 @@ auth_on_subscribe_m5(UserName, SubscriberId, Topics, Props) ->
             ok;
         Modifiers when is_list(Modifiers) ->
             %% Found a valid cache entry containing modifiers
-            {ok, #{topics => Modifiers}};
+            {ok, modifier_compat(auth_on_subscribe_m5, Modifiers)};
         false ->
             %% one of the provided topics doesn't match a cache entry which
             %% rejects this subscribe
@@ -656,6 +656,4 @@ conv_res(_, Other) ->
 modifier_compat(auth_on_subscribe_m5, Mods) ->
     #{topics => Mods};
 modifier_compat(auth_on_publish_m5, Mods) ->
-    maps:from_list(Mods);
-modifier_compat(_H, Mods) ->
-    Mods.
+    maps:from_list(Mods).

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -54,6 +54,7 @@
          on_register_m5/4,
          auth_on_publish_m5/7,
          on_publish_m5/7,
+         on_deliver_m5/5,
          auth_on_subscribe_m5/4,
          on_subscribe_m5/4,
          on_unsubscribe_m5/4,
@@ -302,6 +303,15 @@ on_publish_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
                         {payload, Payload},
                         {retain, IsRetain},
                         {properties, conv_args_props(Props)}]).
+
+on_deliver_m5(UserName, SubscriberId, Topic, Payload, Props) ->
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    all_till_ok(on_deliver_m5, [{username, nilify(UserName)},
+                                {mountpoint, MP},
+                                {client_id, ClientId},
+                                {topic, unword(Topic)},
+                                {payload, Payload},
+                                {properties, conv_args_props(Props)}]).
 
 auth_on_subscribe(UserName, SubscriberId, Topics) ->
     {MP, ClientId} = subscriber_id(SubscriberId),

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -277,7 +277,7 @@ auth_on_publish_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props)
             ok;
         Modifiers when is_list(Modifiers) ->
             %% Found a valid cache entry containing modifiers
-            {ok, Modifiers};
+            {ok, modifier_compat(auth_on_publish_m5, Modifiers)};
         false ->
             %% Found a valid cache entry which rejects this publish
             {error, not_authorized};
@@ -650,3 +650,12 @@ conv_res(auth_on_sub, {error, lua_script_returned_false}) ->
     {error, not_authorized};
 conv_res(_, Other) ->
     Other.
+
+%% @doc convert from the acl format to a form the MQTT 3/4/5 can
+%% understand
+modifier_compat(auth_on_subscribe_m5, Mods) ->
+    #{topics => Mods};
+modifier_compat(auth_on_publish_m5, Mods) ->
+    maps:from_list(Mods);
+modifier_compat(_H, Mods) ->
+    Mods.

--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -40,7 +40,10 @@ convert_modifiers(Hook, Mods0) ->
                   Mods1),
     case lists:member(Hook, [auth_on_register_m5,
                              auth_on_subscribe_m5,
-                             auth_on_publish_m5]) of
+                             auth_on_unsubscribe_m5,
+                             auth_on_publish_m5,
+                             on_deliver_m5,
+                             on_auth_m5]) of
         true ->
             maps:from_list(Converted);
         _ ->

--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -41,6 +41,7 @@ convert_modifiers(Hook, Mods0) ->
     case lists:member(Hook, [auth_on_register_m5,
                              auth_on_subscribe_m5,
                              auth_on_unsubscribe_m5,
+                             on_unsubscribe_m5,
                              auth_on_publish_m5,
                              on_deliver_m5,
                              on_auth_m5]) of

--- a/apps/vmq_diversity/src/vmq_diversity_utils.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_utils.erl
@@ -77,6 +77,13 @@ convert_property({?P_USER_PROPERTY, Val}) ->
      lists:map(fun({_,[T]}) -> T;
                   (V) -> V
                end, Val)};
+%% TODO: currently vmq_plugin_utils:check_modifiers splits the topic.
+%% convert_property({?P_RESPONSE_TOPIC, Topic}) ->
+%%     {?P_RESPONSE_TOPIC, vmq_topic:word(Topic)};
+convert_property({?P_PAYLOAD_FORMAT_INDICATOR, <<"undefined">>}) ->
+    {?P_PAYLOAD_FORMAT_INDICATOR, undefined};
+convert_property({?P_PAYLOAD_FORMAT_INDICATOR, <<"utf8">>}) ->
+    {?P_PAYLOAD_FORMAT_INDICATOR, utf8};
 convert_property({K, V}) ->
     {K, convert(V)}.
 

--- a/apps/vmq_diversity/test/cache_test.lua
+++ b/apps/vmq_diversity/test/cache_test.lua
@@ -74,25 +74,51 @@ assert(ret.mountpoint == "override-mountpoint2")
 
 function auth_on_register(reg)
     if reg.client_id == "allowed-subscriber-id" then
-        acls = {
-            {
-                pattern = "a/%m/%u/%c/+/#"
-            },
-            {
-                pattern = "a/b/c"
-            }
-        }
-        -- the acls above would allow to publish and subscribe to
-        -- "a//test-user/allowed-subscriber-id/+/#"
-        -- "a/b/c"
-        assert(auth_cache.insert(
-                reg.mountpoint, 
-                reg.client_id, 
-                reg.username, 
-                acls, 
-                acls) == true)
-        print("cache auth_on_register")
-        return true
+       publish_acls = {
+          {
+             pattern = "a/b/c"
+          },
+          {
+             pattern = "a/%m/%u/%c/+/#",
+          },
+          {
+             pattern = "modifiers",
+             modifiers = {
+                topic = "hello/world",
+                payload = "hello world",
+                qos = 1,
+                retain = true,
+                mountpoint = "override-mountpoint2"
+             }
+
+          }
+       }
+       subscribe_acls = {
+          {
+             pattern = "a/b/c",
+          },
+          {
+             pattern = "a/%m/%u/%c/+/#",
+          },
+          {
+             pattern = "modifiers",
+             modifiers =
+                {
+                   {"hello/world", 2}
+                },
+          }
+       }
+       -- the acls above would allow to publish and subscribe to
+       -- "a//test-user/allowed-subscriber-id/+/#"
+       -- "a/b/c"
+       assert(auth_cache.insert(
+                 reg.mountpoint,
+                 reg.client_id,
+                 reg.username,
+                 publish_acls,
+                 subscribe_acls) == true)
+       print("cache auth_on_register")
+       return true
     end
     print("uncached auth_on_register")
     return true

--- a/apps/vmq_diversity/test/cache_test.lua
+++ b/apps/vmq_diversity/test/cache_test.lua
@@ -138,10 +138,27 @@ function on_offline(c)
     print("clear cache, client is offline")
 end
 
+function auth_on_register_m5(reg)
+   return auth_on_register(reg)
+end
+
+function auth_on_publish_m5(pub)
+   return false
+end
+
+function auth_on_subscribe_m5(sub)
+   return false
+end
+
 hooks = {
     auth_on_register = auth_on_register,
     auth_on_publish = auth_on_publish,
     auth_on_subscribe = auth_on_subscribe,
     on_client_gone = on_offline,
-    on_client_offline = on_offline
+    on_client_offline = on_offline,
+
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_publish_m5 = auth_on_publish_m5,
+    auth_on_subscribe_m5 = auth_on_subscribe_m5,
+
 }

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -271,6 +271,31 @@ function on_publish_m5(pub)
    print("on_publish_m5 called")
 end
 
+function on_deliver_m5(pub)
+   assert(pub.username == "test-user")
+   assert(pub.client_id == "allowed-subscriber-id")
+   assert(pub.mountpoint == "")
+   assert(pub.topic == "test/topic")
+   assert(pub.payload == "hello world")
+   assert(pub.properties)
+   properties = pub.properties
+   assert(properties.p_correlation_data == "correlation_data")
+   assert(properties.p_response_topic == "response/topic")
+   assert(properties.p_payload_format_indicator == "utf8")
+   assert(properties.p_content_type == "content_type")
+   assert(properties.p_user_property[1].k1 == "v1")
+   assert(properties.p_user_property[2].k2 == "v2")
+
+   print("on_deliver_m5 called")
+   return {properties =
+              {p_correlation_data = "modified_correlation_data",
+               p_response_topic = "modified/response/topic",
+               p_payload_format_indicator = "undefined",
+               p_content_type = "modified_content_type",
+               p_user_property =
+                  {{k1 = "v1"}, {k2 = "v2"}, {k3 = "v3"}}}}
+end
+
 function auth_on_subscribe_m5(sub)
    assert(sub.username == "test-user")
    assert(sub.mountpoint == "")
@@ -353,5 +378,6 @@ hooks = {
     on_unsubscribe_m5 = on_unsubscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
     on_publish_m5 = on_publish_m5,
+    on_deliver_m5 = on_deliver_m5,
     on_auth_m5 = on_auth_m5,
 }

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -330,7 +330,6 @@ function on_subscribe_m5(sub)
    assert(properties.p_user_property[1].k1 == "v1")
    assert(comparetables(properties.p_subscription_id,{1, 2, 3}))
    print("on_subscribe_m5 called")
-   return validate_client_id(sub.client_id)
 end
 
 function on_unsubscribe_m5(usub)
@@ -375,6 +374,7 @@ hooks = {
     auth_on_register_m5 = auth_on_register_m5,
     on_register_m5 = on_register_m5,
     auth_on_subscribe_m5 = auth_on_subscribe_m5,
+    on_subscribe_m5 = on_subscribe_m5,
     on_unsubscribe_m5 = on_unsubscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
     on_publish_m5 = on_publish_m5,

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -308,6 +308,19 @@ function on_subscribe_m5(sub)
    return validate_client_id(sub.client_id)
 end
 
+function on_unsubscribe_m5(usub)
+   assert(usub.username == "test-user")
+   assert(usub.mountpoint == "")
+   assert(#usub.topics == 1)
+   assert(usub.topics[1] == "test/topic")
+   assert(usub.properties)
+   properties = usub.properties
+   assert(properties.p_user_property[1].k1 == "v1")
+   -- we must change properties
+   print("on_unsubscribe_m5 changed called")
+   return {topics = {"hello/world"}}
+end
+
 function on_auth_m5(auth)
    assert(auth.client_id == "allowed-subscriber-id")
    assert(auth.mountpoint == "")
@@ -337,6 +350,7 @@ hooks = {
     auth_on_register_m5 = auth_on_register_m5,
     on_register_m5 = on_register_m5,
     auth_on_subscribe_m5 = auth_on_subscribe_m5,
+    on_unsubscribe_m5 = on_unsubscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
     on_publish_m5 = on_publish_m5,
     on_auth_m5 = on_auth_m5,

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -233,6 +233,24 @@ function auth_on_publish_m5(pub)
     end
 end
 
+function on_publish_m5(pub)
+   assert(pub.username == "test-user")
+   assert(pub.mountpoint == "")
+   assert(pub.topic == "test/topic")
+   assert(pub.qos == 1)
+   assert(pub.payload == "hello world")
+   assert(pub.retain == false)
+   properties = pub.properties
+   assert(properties)
+   assert(properties.p_correlation_data == "correlation_data")
+   assert(properties.p_response_topic == "response/topic")
+   assert(properties.p_payload_format_indicator == "utf8")
+   assert(properties.p_content_type == "content_type")
+   assert(properties.p_user_property[1].k1 == "v1")
+   assert(properties.p_user_property[2].k2 == "v2")
+   print("on_publish_m5 called")
+end
+
 function auth_on_subscribe_m5(sub)
    assert(sub.username == "test-user")
    assert(sub.mountpoint == "")
@@ -284,5 +302,6 @@ hooks = {
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_subscribe_m5 = auth_on_subscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
+    on_publish_m5 = on_publish_m5,
     on_auth_m5 = on_auth_m5,
 }

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -98,13 +98,31 @@ function auth_on_publish_m5(pub)
        return {topic = 5}
     elseif pub.client_id == "unknown_mod" then
        return {unknown = 5}
+    elseif pub.client_id == "modify_props" then
+       properties = pub.properties
+       assert(properties)
+       assert(properties.p_correlation_data == "correlation_data")
+       assert(properties.p_response_topic == "response/topic")
+       assert(properties.p_payload_format_indicator == "utf8")
+       assert(properties.p_content_type == "content_type")
+       assert(properties.p_user_property[1].k1 == "v1")
+       assert(properties.p_user_property[2].k2 == "v2")
+
+       print("auth_on_publish_m5 changed called")
+       return {properties =
+                  {p_correlation_data = "modified_correlation_data",
+                   p_response_topic = "modified/response/topic",
+                   p_payload_format_indicator = "undefined",
+                   p_content_type = "modified_content_type",
+                   p_user_property =
+                      {{k1 = "v1"}, {k2 = "v2"}, {k3 = "v3"}}}}
     elseif pub.client_id ~= "changed-subscriber-id" then
-        print("auth_on_publish_m5 called")
-        return validate_client_id(pub.client_id)
+       print("auth_on_publish_m5 called")
+       return validate_client_id(pub.client_id)
     else
-        -- change the publish topic
-        print("auth_on_publish_m5 changed called")
-        return {topic = "hello/world"}
+       -- change the publish topic
+       print("auth_on_publish_m5 changed called")
+       return {topic = "hello/world"}
     end
 end
 

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -293,6 +293,21 @@ function auth_on_subscribe_m5(sub)
    end
 end
 
+function on_subscribe_m5(sub)
+   assert(sub.username == "test-user")
+   assert(sub.mountpoint == "")
+   assert(#sub.topics == 1)
+   assert(sub.topics[1][1] == "test/topic")
+   assert(sub.topics[1][2][1] == 1)
+   assert(sub.client_id, "allowed-subscriber-id")
+   assert(sub.properties)
+   properties = sub.properties
+   assert(properties.p_user_property[1].k1 == "v1")
+   assert(comparetables(properties.p_subscription_id,{1, 2, 3}))
+   print("on_subscribe_m5 called")
+   return validate_client_id(sub.client_id)
+end
+
 function on_auth_m5(auth)
    assert(auth.client_id == "allowed-subscriber-id")
    assert(auth.mountpoint == "")

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -38,6 +38,22 @@ function auth_on_register_m5(reg)
        assert(reg.username == nil)
        assert(reg.password == nil)
        return true
+    elseif reg.client_id == "modify_props" then
+       assert(reg.properties)
+       properties = reg.properties
+       assert(properties.p_session_expiry_interval == 5)
+       assert(properties.p_receive_max == 10)
+       assert(properties.p_topic_alias_max == 15)
+       assert(properties.p_request_response_info == true)
+       assert(properties.p_request_problem_info == true)
+
+       assert(properties.p_user_property[1].k1 == "v1")
+       assert(properties.p_user_property[2].k1 == "v2")
+       assert(properties.p_user_property[3].k2 == "v2")
+       print("auth_on_register_m5 modify props called")
+       return {properties =
+                  {p_user_property = {{k3 = "v3"}},
+                   p_session_expiry_interval = 10}}
     end
     assert(reg.username == "test-user")
     assert(reg.password == "test-password")

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -194,6 +194,26 @@ function auth_on_register_m5(reg)
     -- reg.properties are ignored for now.
 end
 
+function on_register_m5(reg)
+   assert(reg.addr == "192.168.123.123")
+   assert(reg.port == 12345)
+   assert(reg.mountpoint == "")
+   assert(reg.username == "test-user")
+   assert(reg.client_id == "allowed-subscriber-id")
+   assert(reg.properties)
+   properties = reg.properties
+   assert(properties.p_session_expiry_interval == 5)
+   assert(properties.p_receive_max == 10)
+   assert(properties.p_topic_alias_max == 15)
+   assert(properties.p_request_response_info == true)
+   assert(properties.p_request_problem_info == true)
+
+   assert(properties.p_user_property[1].k1 == "v1")
+   assert(properties.p_user_property[2].k1 == "v2")
+   assert(properties.p_user_property[3].k2 == "v2")
+   print("on_register_m5 props called")
+end
+
 function auth_on_publish_m5(pub)
     assert(pub.username == "test-user")
     assert(pub.mountpoint == "")
@@ -300,6 +320,7 @@ hooks = {
     on_client_gone = on_client_gone,
 
     auth_on_register_m5 = auth_on_register_m5,
+    on_register_m5 = on_register_m5,
     auth_on_subscribe_m5 = auth_on_subscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
     on_publish_m5 = on_publish_m5,

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -38,45 +38,6 @@ function auth_on_register(reg)
     end
 end
 
-function auth_on_register_m5(reg)
-    assert(reg.addr == "192.168.123.123")
-    assert(reg.port == 12345)
-    assert(reg.mountpoint == "")
-    if reg.client_id == "undefined_creds" then
-       assert(reg.username == nil)
-       assert(reg.password == nil)
-       return true
-    elseif reg.client_id == "modify_props" then
-       assert(reg.properties)
-       properties = reg.properties
-       assert(properties.p_session_expiry_interval == 5)
-       assert(properties.p_receive_max == 10)
-       assert(properties.p_topic_alias_max == 15)
-       assert(properties.p_request_response_info == true)
-       assert(properties.p_request_problem_info == true)
-
-       assert(properties.p_user_property[1].k1 == "v1")
-       assert(properties.p_user_property[2].k1 == "v2")
-       assert(properties.p_user_property[3].k2 == "v2")
-       print("auth_on_register_m5 modify props called")
-       return {properties =
-                  {p_user_property = {{k3 = "v3"}},
-                   p_session_expiry_interval = 10}}
-    end
-    assert(reg.username == "test-user")
-    assert(reg.password == "test-password")
-    assert(reg.clean_start == true)
-    if reg.client_id ~= "changed-subscriber-id" then
-        print("auth_on_register_m5 called")
-        return validate_client_id(reg.client_id)
-    else
-        -- we must change subscriberid
-        print("auth_on_register_m5 changed called")
-        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
-    end
-    -- reg.properties are ignored for now.
-end
-
 
 function auth_on_publish(pub)
     assert(pub.username == "test-user")
@@ -95,45 +56,6 @@ function auth_on_publish(pub)
     end
 end
 
-function auth_on_publish_m5(pub)
-    assert(pub.username == "test-user")
-    assert(pub.mountpoint == "")
-    assert(pub.topic == "test/topic")
-    assert(pub.qos == 1)
-    assert(pub.payload == "hello world")
-    assert(pub.retain == false)
-    if pub.client_id == "invalid_topic_mod" then
-       return {topic = 5}
-    elseif pub.client_id == "unknown_mod" then
-       return {unknown = 5}
-    elseif pub.client_id == "modify_props" then
-       properties = pub.properties
-       assert(properties)
-       assert(properties.p_correlation_data == "correlation_data")
-       assert(properties.p_response_topic == "response/topic")
-       assert(properties.p_payload_format_indicator == "utf8")
-       assert(properties.p_content_type == "content_type")
-       assert(properties.p_user_property[1].k1 == "v1")
-       assert(properties.p_user_property[2].k2 == "v2")
-
-       print("auth_on_publish_m5 changed called")
-       return {properties =
-                  {p_correlation_data = "modified_correlation_data",
-                   p_response_topic = "modified/response/topic",
-                   p_payload_format_indicator = "undefined",
-                   p_content_type = "modified_content_type",
-                   p_user_property =
-                      {{k1 = "v1"}, {k2 = "v2"}, {k3 = "v3"}}}}
-    elseif pub.client_id ~= "changed-subscriber-id" then
-       print("auth_on_publish_m5 called")
-       return validate_client_id(pub.client_id)
-    else
-       -- change the publish topic
-       print("auth_on_publish_m5 changed called")
-       return {topic = "hello/world"}
-    end
-end
-
 function auth_on_subscribe(sub)
     assert(sub.username == "test-user")
     assert(sub.mountpoint == "")
@@ -148,28 +70,6 @@ function auth_on_subscribe(sub)
         print("auth_on_subscribe changed called")
         return {{"hello/world", 2}}
     end
-end
-
-function auth_on_subscribe_m5(sub)
-   assert(sub.username == "test-user")
-   assert(sub.mountpoint == "")
-   assert(#sub.topics == 1)
-   assert(sub.topics[1][1] == "test/topic")
-   assert(sub.topics[1][2][1] == 1)
-   if sub.client_id ~= "changed-subscriber-id" then
-      if sub.client_id == "allowed-subscriber-id" then
-         assert(sub.properties)
-         properties = sub.properties
-         assert(properties.p_user_property[1].k1 == "v1")
-         assert(comparetables(properties.p_subscription_id,{1, 2, 3}))
-      end
-      print("auth_on_subscribe_m5 called")
-      return validate_client_id(sub.client_id)
-   else
-      -- change the subscription
-      print("auth_on_subscribe changed_m5 called")
-      return {topics = {{"hello/world", {2, {rap = true}}}}}
-   end
 end
 
 function on_register(reg)
@@ -253,6 +153,106 @@ function on_client_gone(ev)
     assert(ev.client_id == "allowed-subscriber-id")
     assert(ev.mountpoint == "")
     print("on_client_gone called")
+end
+
+function auth_on_register_m5(reg)
+    assert(reg.addr == "192.168.123.123")
+    assert(reg.port == 12345)
+    assert(reg.mountpoint == "")
+    if reg.client_id == "undefined_creds" then
+       assert(reg.username == nil)
+       assert(reg.password == nil)
+       return true
+    elseif reg.client_id == "modify_props" then
+       assert(reg.properties)
+       properties = reg.properties
+       assert(properties.p_session_expiry_interval == 5)
+       assert(properties.p_receive_max == 10)
+       assert(properties.p_topic_alias_max == 15)
+       assert(properties.p_request_response_info == true)
+       assert(properties.p_request_problem_info == true)
+
+       assert(properties.p_user_property[1].k1 == "v1")
+       assert(properties.p_user_property[2].k1 == "v2")
+       assert(properties.p_user_property[3].k2 == "v2")
+       print("auth_on_register_m5 modify props called")
+       return {properties =
+                  {p_user_property = {{k3 = "v3"}},
+                   p_session_expiry_interval = 10}}
+    end
+    assert(reg.username == "test-user")
+    assert(reg.password == "test-password")
+    assert(reg.clean_start == true)
+    if reg.client_id ~= "changed-subscriber-id" then
+        print("auth_on_register_m5 called")
+        return validate_client_id(reg.client_id)
+    else
+        -- we must change subscriberid
+        print("auth_on_register_m5 changed called")
+        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
+    end
+    -- reg.properties are ignored for now.
+end
+
+function auth_on_publish_m5(pub)
+    assert(pub.username == "test-user")
+    assert(pub.mountpoint == "")
+    assert(pub.topic == "test/topic")
+    assert(pub.qos == 1)
+    assert(pub.payload == "hello world")
+    assert(pub.retain == false)
+    if pub.client_id == "invalid_topic_mod" then
+       return {topic = 5}
+    elseif pub.client_id == "unknown_mod" then
+       return {unknown = 5}
+    elseif pub.client_id == "modify_props" then
+       properties = pub.properties
+       assert(properties)
+       assert(properties.p_correlation_data == "correlation_data")
+       assert(properties.p_response_topic == "response/topic")
+       assert(properties.p_payload_format_indicator == "utf8")
+       assert(properties.p_content_type == "content_type")
+       assert(properties.p_user_property[1].k1 == "v1")
+       assert(properties.p_user_property[2].k2 == "v2")
+
+       print("auth_on_publish_m5 changed called")
+       return {properties =
+                  {p_correlation_data = "modified_correlation_data",
+                   p_response_topic = "modified/response/topic",
+                   p_payload_format_indicator = "undefined",
+                   p_content_type = "modified_content_type",
+                   p_user_property =
+                      {{k1 = "v1"}, {k2 = "v2"}, {k3 = "v3"}}}}
+    elseif pub.client_id ~= "changed-subscriber-id" then
+       print("auth_on_publish_m5 called")
+       return validate_client_id(pub.client_id)
+    else
+       -- change the publish topic
+       print("auth_on_publish_m5 changed called")
+       return {topic = "hello/world"}
+    end
+end
+
+function auth_on_subscribe_m5(sub)
+   assert(sub.username == "test-user")
+   assert(sub.mountpoint == "")
+   assert(#sub.topics == 1)
+   assert(sub.topics[1][1] == "test/topic")
+   assert(sub.topics[1][2][1] == 1)
+   if sub.client_id ~= "changed-subscriber-id" then
+      if sub.client_id == "allowed-subscriber-id" then
+         assert(sub.properties)
+         properties = sub.properties
+         assert(properties.p_user_property[1].k1 == "v1")
+         assert(comparetables(properties.p_subscription_id,{1, 2, 3}))
+      end
+      print("auth_on_subscribe_m5 called")
+      return validate_client_id(sub.client_id)
+   else
+      -- change the subscription
+      print("auth_on_subscribe changed_m5 called")
+      return {topics = {{"hello/world", {2, {rap = true}}}}}
+   end
 end
 
 function on_auth_m5(auth)

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -8,6 +8,14 @@ local function validate_client_id(client_id)
     end
 end
 
+function comparetables(t1, t2)
+  if #t1 ~= #t2 then return false end
+  for i=1,#t1 do
+    if t1[i] ~= t2[i] then return false end
+  end
+  return true
+end
+
 function auth_on_register(reg)
     assert(reg.addr == "192.168.123.123")
     assert(reg.port == 12345)
@@ -143,19 +151,25 @@ function auth_on_subscribe(sub)
 end
 
 function auth_on_subscribe_m5(sub)
-    assert(sub.username == "test-user")
-    assert(sub.mountpoint == "")
-    assert(#sub.topics == 1)
-    assert(sub.topics[1][1] == "test/topic")
-    assert(sub.topics[1][2][1] == 1)
-    if sub.client_id ~= "changed-subscriber-id" then
-        print("auth_on_subscribe_m5 called")
-        return validate_client_id(sub.client_id)
-    else
-        -- change the subscription
-        print("auth_on_subscribe changed_m5 called")
-        return {topics = {{"hello/world", {2, {rap = true}}}}}
-    end
+   assert(sub.username == "test-user")
+   assert(sub.mountpoint == "")
+   assert(#sub.topics == 1)
+   assert(sub.topics[1][1] == "test/topic")
+   assert(sub.topics[1][2][1] == 1)
+   if sub.client_id ~= "changed-subscriber-id" then
+      if sub.client_id == "allowed-subscriber-id" then
+         assert(sub.properties)
+         properties = sub.properties
+         assert(properties.p_user_property[1].k1 == "v1")
+         assert(comparetables(properties.p_subscription_id,{1, 2, 3}))
+      end
+      print("auth_on_subscribe_m5 called")
+      return validate_client_id(sub.client_id)
+   else
+      -- change the subscription
+      print("auth_on_subscribe changed_m5 called")
+      return {topics = {{"hello/world", {2, {rap = true}}}}}
+   end
 end
 
 function on_register(reg)

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -255,6 +255,18 @@ function on_client_gone(ev)
     print("on_client_gone called")
 end
 
+function on_auth_m5(auth)
+   assert(auth.client_id == "allowed-subscriber-id")
+   assert(auth.mountpoint == "")
+   assert(auth.properties)
+   properties = auth.properties
+   assert(properties.p_authentication_method == "AUTH_METHOD")
+   assert(properties.p_authentication_data == "AUTH_DATA0")
+   return {properties =
+              {p_authentication_method = "AUTH_METHOD",
+               p_authentication_data = "AUTH_DATA1"}}
+end
+
 hooks = {
     auth_on_register = auth_on_register,
     auth_on_publish = auth_on_publish,
@@ -272,4 +284,5 @@ hooks = {
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_subscribe_m5 = auth_on_subscribe_m5,
     auth_on_publish_m5 = auth_on_publish_m5,
+    on_auth_m5 = on_auth_m5,
 }

--- a/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
@@ -78,6 +78,14 @@ auth_cache_test(_) ->
                                [username(), allowed_subscriber_id(),
                                 [{[<<"modifiers">>], 0}]]),
 
+    {ok, #{topic := [<<"hello">>,<<"world">>],
+           retain := true,
+           qos := 1,
+           payload := <<"hello world">>,
+           mountpoint := "override-mountpoint2"}} =
+        vmq_plugin:all_till_ok(auth_on_publish_m5,
+                               [username(), allowed_subscriber_id(), 0,
+                                [<<"modifiers">>], payload(), false, #{}]),
     ok.
 
 auth_cache_reject_test(_) ->

--- a/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
@@ -49,20 +49,36 @@ auth_cache_test(_) ->
     %% This test verifies that an action is granted if a cached ACL is found
     %% for this MP/ClientId
     ok = vmq_plugin:all_till_ok(auth_on_register,
-                      [peer(), allowed_subscriber_id(), username(), password(), true]),
+                                [peer(), allowed_subscriber_id(), username(), password(), true]),
     ok = vmq_plugin:all_till_ok(auth_on_publish,
-                      [username(), allowed_subscriber_id(), 0,
-                       [<<"a">>, <<"b">>, <<"c">>], payload(), false]),
+                                [username(), allowed_subscriber_id(), 0,
+                                 [<<"a">>,<<"b">>, <<"c">>], payload(), false]),
     ok = vmq_plugin:all_till_ok(auth_on_publish,
                       [username(), allowed_subscriber_id(), 0,
                        [<<"a">>, <<>>, <<"test-user">>,
                         <<"allowed-subscriber-id">>, <<"hello">>, <<"world">>],
                        payload(), false]),
     ok = vmq_plugin:all_till_ok(auth_on_subscribe,
-                      [username(), allowed_subscriber_id(),
-                       [{[<<"a">>, <<"b">>, <<"c">>], 0},
-                        {[<<"a">>, <<>>, <<"test-user">>,
-                          <<"allowed-subscriber-id">>, <<"+">>, <<"world">>], 0}]]).
+                                [username(), allowed_subscriber_id(),
+                                 [{[<<"a">>, <<"b">>, <<"c">>], 0},
+                                  {[<<"a">>, <<>>, <<"test-user">>,
+                                    <<"allowed-subscriber-id">>, <<"+">>, <<"world">>], 0}]]),
+    {ok, PubMods1} =
+        vmq_plugin:all_till_ok(auth_on_publish,
+                               [username(), allowed_subscriber_id(), 0,
+                                [<<"modifiers">>], payload(), false]),
+    [] = PubMods1 -- [{topic,[<<"hello">>,<<"world">>]},
+                      {retain,true},
+                      {qos,1},
+                      {payload,<<"hello world">>},
+                      {mountpoint,"override-mountpoint2"}],
+
+    {ok, [{[<<"hello">>,<<"world">>],2}]} =
+        vmq_plugin:all_till_ok(auth_on_subscribe,
+                               [username(), allowed_subscriber_id(),
+                                [{[<<"modifiers">>], 0}]]),
+
+    ok.
 
 auth_cache_reject_test(_) ->
     %% This test verifies that an action is rejected if a cached ACL is found
@@ -110,8 +126,8 @@ auth_cache_cleanup_test(_) ->
                       [peer(), allowed_subscriber_id(), username(), password(), true]),
     [{publish, PublishAcls},
      {subscribe, SubscribeAcls}] = vmq_diversity_cache:entries(<<"">>, <<"allowed-subscriber-id">>),
-    2 = length(PublishAcls),
-    2 = length(SubscribeAcls),
+    3 = length(PublishAcls),
+    3 = length(SubscribeAcls),
     vmq_plugin:all(on_client_offline, [allowed_subscriber_id()]),
     [] = vmq_diversity_cache:entries(<<"">>, <<"allowed-subscriber-id">>).
 

--- a/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_auth_cache_SUITE.erl
@@ -86,6 +86,11 @@ auth_cache_test(_) ->
         vmq_plugin:all_till_ok(auth_on_publish_m5,
                                [username(), allowed_subscriber_id(), 0,
                                 [<<"modifiers">>], payload(), false, #{}]),
+
+    {ok, #{topics := [{[<<"hello">>,<<"world">>],2}]}} =
+        vmq_plugin:all_till_ok(auth_on_subscribe_m5,
+                               [username(), allowed_subscriber_id(),
+                                [{[<<"modifiers">>], 0}], #{}]),
     ok.
 
 auth_cache_reject_test(_) ->

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -52,6 +52,7 @@ all() ->
 
      auth_on_register_m5_test,
      auth_on_register_m5_modify_props_test,
+     on_publish_m5_test,
      auth_on_subscribe_m5_test,
      auth_on_publish_m5_test,
      auth_on_publish_m5_modify_props_test,
@@ -175,6 +176,17 @@ auth_on_register_m5_modify_props_test(_) ->
                  ?P_SESSION_EXPIRY_INTERVAL := 10}}}
         = vmq_plugin:all_till_ok(auth_on_register_m5, Args).
 
+on_publish_m5_test(_) ->
+    Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
+            #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>},
+                   {<<"k2">>, <<"v2">>}],
+              ?P_CORRELATION_DATA => <<"correlation_data">>,
+              ?P_RESPONSE_TOPIC => [<<"response">>,<<"topic">>],
+              ?P_PAYLOAD_FORMAT_INDICATOR => utf8,
+              ?P_CONTENT_TYPE => <<"content_type">>}],
+    [next] = vmq_plugin:all(on_publish_m5, Args).
+
 auth_on_publish_m5_modify_props_test(_) ->
     Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
             #{?P_USER_PROPERTY =>
@@ -194,6 +206,17 @@ auth_on_publish_m5_modify_props_test(_) ->
           ?P_PAYLOAD_FORMAT_INDICATOR => undefined,
           ?P_CONTENT_TYPE => <<"modified_content_type">>},
     {ok, #{properties := ExpProps}} = vmq_plugin:all_till_ok(auth_on_publish_m5, Args).
+
+on_publish_m5_test(_) ->
+    Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
+            #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>},
+                   {<<"k2">>, <<"v2">>}],
+              ?P_CORRELATION_DATA => <<"correlation_data">>,
+              ?P_RESPONSE_TOPIC => [<<"response">>,<<"topic">>],
+              ?P_PAYLOAD_FORMAT_INDICATOR => utf8,
+              ?P_CONTENT_TYPE => <<"content_type">>}],
+    [next] = vmq_plugin:all(on_publish_m5, Args).
 
 auth_on_subscribe_m5_test(_) ->
     Props = #{?P_USER_PROPERTY =>

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -160,8 +160,11 @@ auth_on_subscribe_test(_) ->
                       [username(), changed_subscriber_id(), [{topic(), 1}]]).
 
 auth_on_subscribe_m5_test(_) ->
+    Props = #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>}],
+              ?P_SUBSCRIPTION_ID => [1,2,3]},
     ok = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
-                      [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
+                      [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], Props]),
     {error, not_authorized} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), not_allowed_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -1,4 +1,5 @@
 -module(vmq_diversity_plugin_SUITE).
+-include_lib("vernemq_dev/include/vernemq_dev.hrl").
 -export([
          %% suite/0,
          init_per_suite/1,
@@ -49,6 +50,7 @@ all() ->
      auth_on_register_undefined_creds_test,
 
      auth_on_register_m5_test,
+     auth_on_register_m5_modify_props_test,
      auth_on_subscribe_m5_test,
      auth_on_publish_m5_test,
 
@@ -80,6 +82,23 @@ auth_on_register_m5_test(_) ->
                       [peer(), ignored_subscriber_id(), username(), password(), true, #{}]),
     {ok, #{subscriber_id := {"override-mountpoint", <<"override-client-id">>}}} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [peer(), changed_subscriber_id(), username(), password(), true, #{}]).
+
+auth_on_register_m5_modify_props_test(_) ->
+    WantUserProps = [{<<"k1">>, <<"v1">>},
+                     {<<"k1">>, <<"v2">>},
+                     {<<"k2">>, <<"v2">>}],
+    Args = [peer(), {"", <<"modify_props">>}, username(), password(), true,
+            #{?P_SESSION_EXPIRY_INTERVAL => 5,
+              ?P_RECEIVE_MAX => 10,
+              ?P_TOPIC_ALIAS_MAX => 15,
+              ?P_REQUEST_RESPONSE_INFO => true,
+              ?P_REQUEST_PROBLEM_INFO => true,
+              ?P_USER_PROPERTY => WantUserProps}],
+    {ok, #{properties :=
+               #{?P_USER_PROPERTY :=
+                     [{<<"k3">>, <<"v3">>}],
+                 ?P_SESSION_EXPIRY_INTERVAL := 10}}}
+        = vmq_plugin:all_till_ok(auth_on_register_m5, Args).
 
 auth_on_publish_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_publish,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -54,7 +54,8 @@ all() ->
      auth_on_register_m5_modify_props_test,
      auth_on_subscribe_m5_test,
      auth_on_publish_m5_test,
-     auth_on_publish_m5_modify_props_test
+     auth_on_publish_m5_modify_props_test,
+     on_auth_m5_test
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -207,6 +208,15 @@ auth_on_subscribe_m5_test(_) ->
     {ok, #{topics := [{[<<"hello">>, <<"world">>], {2, #{rap := true}}}]}} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), changed_subscriber_id(), [{topic(), {1, subopts()}}], props()]).
 
+on_auth_m5_test(_) ->
+    {ok, #{properties := #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,
+                           ?P_AUTHENTICATION_DATA := <<"AUTH_DATA1">>}}}
+        = vmq_plugin:all_till_ok(on_auth_m5,
+                                 [username(), allowed_subscriber_id(),
+                                  #{?P_AUTHENTICATION_METHOD => <<"AUTH_METHOD">>,
+                                    ?P_AUTHENTICATION_DATA => <<"AUTH_DATA0">>}]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%% helpers %%%%%%%%%%%%%%%%%%%%%%%%%
 peer() -> {{192, 168, 123, 123}, 12345}.
 
 ignored_subscriber_id() ->

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -223,6 +223,26 @@ on_publish_m5_test(_) ->
               ?P_CONTENT_TYPE => <<"content_type">>}],
     [next] = vmq_plugin:all(on_publish_m5, Args).
 
+on_deliver_m5_test(_) ->
+    Args = [username(), allowed_subscriber_id(), topic(), payload(),
+            #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>},
+                   {<<"k2">>, <<"v2">>}],
+              ?P_CORRELATION_DATA => <<"correlation_data">>,
+              ?P_RESPONSE_TOPIC => [<<"response">>,<<"topic">>],
+              ?P_PAYLOAD_FORMAT_INDICATOR => utf8,
+              ?P_CONTENT_TYPE => <<"content_type">>}],
+    {ok, #{properties :=
+          #{?P_USER_PROPERTY :=
+                [{<<"k1">>, <<"v1">>},
+                 {<<"k2">>, <<"v2">>},
+                 {<<"k3">>, <<"v3">>}],
+            ?P_CORRELATION_DATA := <<"modified_correlation_data">>,
+            ?P_RESPONSE_TOPIC := [<<"modified">>, <<"response">>,<<"topic">>],
+            ?P_PAYLOAD_FORMAT_INDICATOR := undefined,
+            ?P_CONTENT_TYPE := <<"modified_content_type">>}}}
+        = vmq_plugin:all_till_ok(on_deliver_m5, Args).
+
 auth_on_subscribe_m5_test(_) ->
     Props = #{?P_USER_PROPERTY =>
                   [{<<"k1">>, <<"v1">>}],

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -176,17 +176,6 @@ auth_on_register_m5_modify_props_test(_) ->
                  ?P_SESSION_EXPIRY_INTERVAL := 10}}}
         = vmq_plugin:all_till_ok(auth_on_register_m5, Args).
 
-on_publish_m5_test(_) ->
-    Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
-            #{?P_USER_PROPERTY =>
-                  [{<<"k1">>, <<"v1">>},
-                   {<<"k2">>, <<"v2">>}],
-              ?P_CORRELATION_DATA => <<"correlation_data">>,
-              ?P_RESPONSE_TOPIC => [<<"response">>,<<"topic">>],
-              ?P_PAYLOAD_FORMAT_INDICATOR => utf8,
-              ?P_CONTENT_TYPE => <<"content_type">>}],
-    [next] = vmq_plugin:all(on_publish_m5, Args).
-
 auth_on_publish_m5_modify_props_test(_) ->
     Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
             #{?P_USER_PROPERTY =>

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -56,6 +56,7 @@ all() ->
      on_publish_m5_test,
      auth_on_subscribe_m5_test,
      on_subscribe_m5_test,
+     on_unsubscribe_m5_test,
      auth_on_publish_m5_test,
      auth_on_publish_m5_modify_props_test,
      on_auth_m5_test
@@ -241,6 +242,14 @@ on_subscribe_m5_test(_) ->
               ?P_SUBSCRIPTION_ID => [1,2,3]},
     [ok] = vmq_plugin:all(auth_on_subscribe_m5,
                           [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], Props]).
+
+
+on_unsubscribe_m5_test(_) ->
+    Args = [username(), changed_subscriber_id(), [topic()],
+            #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>}]}],
+    {ok, #{topics := [[<<"hello">>, <<"world">>]]}}
+        = vmq_plugin:all_till_ok(on_unsubscribe_m5, Args).
 
 on_auth_m5_test(_) ->
     {ok, #{properties := #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -55,6 +55,7 @@ all() ->
      on_register_m5_test,
      on_publish_m5_test,
      auth_on_subscribe_m5_test,
+     on_subscribe_m5_test,
      auth_on_publish_m5_test,
      auth_on_publish_m5_modify_props_test,
      on_auth_m5_test
@@ -233,6 +234,13 @@ auth_on_subscribe_m5_test(_) ->
                       [username(), ignored_subscriber_id(), [{topic(), {1, subopts()}}], props()]),
     {ok, #{topics := [{[<<"hello">>, <<"world">>], {2, #{rap := true}}}]}} = vmq_plugin:all_till_ok(auth_on_subscribe_m5,
                       [username(), changed_subscriber_id(), [{topic(), {1, subopts()}}], props()]).
+
+on_subscribe_m5_test(_) ->
+    Props = #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>}],
+              ?P_SUBSCRIPTION_ID => [1,2,3]},
+    [ok] = vmq_plugin:all(auth_on_subscribe_m5,
+                          [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], Props]).
 
 on_auth_m5_test(_) ->
     {ok, #{properties := #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -53,6 +53,7 @@ all() ->
      auth_on_register_m5_modify_props_test,
      auth_on_subscribe_m5_test,
      auth_on_publish_m5_test,
+     auth_on_publish_m5_modify_props_test,
 
      invalid_modifiers_test
     ].
@@ -119,6 +120,26 @@ auth_on_publish_m5_test(_) ->
                       [username(), ignored_subscriber_id(), 1, topic(), payload(), false, props()]),
     {ok, #{topic := [<<"hello">>, <<"world">>]}} = vmq_plugin:all_till_ok(auth_on_publish_m5,
                       [username(), changed_subscriber_id(), 1, topic(), payload(), false, props()]).
+
+auth_on_publish_m5_modify_props_test(_) ->
+    Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,
+            #{?P_USER_PROPERTY =>
+                  [{<<"k1">>, <<"v1">>},
+                   {<<"k2">>, <<"v2">>}],
+              ?P_CORRELATION_DATA => <<"correlation_data">>,
+              ?P_RESPONSE_TOPIC => [<<"response">>,<<"topic">>],
+              ?P_PAYLOAD_FORMAT_INDICATOR => utf8,
+              ?P_CONTENT_TYPE => <<"content_type">>}],
+    ExpProps =
+        #{?P_USER_PROPERTY =>
+              [{<<"k1">>, <<"v1">>},
+               {<<"k2">>, <<"v2">>},
+               {<<"k3">>, <<"v3">>}],
+          ?P_CORRELATION_DATA => <<"modified_correlation_data">>,
+          ?P_RESPONSE_TOPIC => [<<"modified">>, <<"response">>, <<"topic">>],
+          ?P_PAYLOAD_FORMAT_INDICATOR => undefined,
+          ?P_CONTENT_TYPE => <<"modified_content_type">>},
+    {ok, #{properties := ExpProps}} = vmq_plugin:all_till_ok(auth_on_publish_m5, Args).
 
 invalid_modifiers_test(_) ->
     {error,{invalid_modifiers,#{topic := 5}}} =

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -52,6 +52,7 @@ all() ->
 
      auth_on_register_m5_test,
      auth_on_register_m5_modify_props_test,
+     on_register_m5_test,
      on_publish_m5_test,
      auth_on_subscribe_m5_test,
      auth_on_publish_m5_test,
@@ -175,6 +176,19 @@ auth_on_register_m5_modify_props_test(_) ->
                      [{<<"k3">>, <<"v3">>}],
                  ?P_SESSION_EXPIRY_INTERVAL := 10}}}
         = vmq_plugin:all_till_ok(auth_on_register_m5, Args).
+
+on_register_m5_test(_) ->
+    UserProps = [{<<"k1">>, <<"v1">>},
+                 {<<"k1">>, <<"v2">>},
+                 {<<"k2">>, <<"v2">>}],
+    Args = [peer(), allowed_subscriber_id(), username(),
+            #{?P_SESSION_EXPIRY_INTERVAL => 5,
+              ?P_RECEIVE_MAX => 10,
+              ?P_TOPIC_ALIAS_MAX => 15,
+              ?P_REQUEST_RESPONSE_INFO => true,
+              ?P_REQUEST_PROBLEM_INFO => true,
+              ?P_USER_PROPERTY => UserProps}],
+    [next] = vmq_plugin:all(on_register_m5, Args).
 
 auth_on_publish_m5_modify_props_test(_) ->
     Args = [username(), {"", <<"modify_props">>}, 1, topic(), payload(), false,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -260,7 +260,7 @@ on_subscribe_m5_test(_) ->
     Props = #{?P_USER_PROPERTY =>
                   [{<<"k1">>, <<"v1">>}],
               ?P_SUBSCRIPTION_ID => [1,2,3]},
-    [ok] = vmq_plugin:all(auth_on_subscribe_m5,
+    [next] = vmq_plugin:all(on_subscribe_m5,
                           [username(), allowed_subscriber_id(), [{topic(), {1, subopts()}}], Props]).
 
 


### PR DESCRIPTION
This PR adds 

- [x] missing mqtt 5 hooks
- [x] support passing and modifying properties in lua
- [x] ensure cached modifiers can be used in an MQTT 5 context as well (fixes #1123)
 
depends on #1121 