### PR TITLE
Make MySQL hash_method use string instead of enum

### DIFF
--- a/apps/vmq_diversity/priv/auth/mysql.lua
+++ b/apps/vmq_diversity/priv/auth/mysql.lua
@@ -24,7 +24,8 @@ require "auth/auth_commons"
      mountpoint VARCHAR(10) NOT NULL,
      client_id VARCHAR(128) NOT NULL,
      username VARCHAR(128) NOT NULL,
-     password VARCHAR(128),
+     password CHAR(64),
+     salt CHAR(32),
      publish_acl TEXT,
      subscribe_acl TEXT,
      CONSTRAINT vmq_auth_acl_primary_key PRIMARY KEY (mountpoint, client_id, username)
@@ -39,12 +40,12 @@ require "auth/auth_commons"
 --[[
 --
    INSERT INTO vmq_auth_acl 
-   (mountpoint, client_id, username, 
-    password, publish_acl, subscribe_acl)
+   (mountpoint, client_id, username, password, salt,
+    publish_acl, subscribe_acl)
  VALUES 
-   ('', 'test-client', 'test-user', 
-    PASSWORD('123'), '[{"pattern":"a/b/c"},{"pattern":"c/b/#"}]', 
-                     '[{"pattern":"a/b/c"},{"pattern":"c/b/#"}]');
+   ('', 'test-client', 'test-user', PASSWORD('pass123'), 'salt123',
+    '[{"pattern":"a/b/c"},{"pattern":"c/b/#"}]',
+    '[{"pattern":"a/b/c"},{"pattern":"c/b/#"}]');
 
 ]]--
 -- 	The JSON array passed as publish/subscribe ACL contains the topic patterns

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -110,23 +110,26 @@
   hidden]}.
 
 %% @doc The password hashing method to use in MySQL:
-%%  PASSWORD(?): Default for compatibility, deprecated since MySQL 5.7.6 and not
-%%               usable with MySQL 8.0.11+.
-%%               Docs: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-%%       MD5(?): Calculates an MD5 128-bit checksum of the password.
-%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
-%%      SHA1(?): Calculates the SHA-1 160-bit checksum for the password.
-%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
-%% SHA2(?, 256): Calculates the SHA-2 hash of the password, using 256 bits.
-%%               Works only if MySQL has been configured with SSL support.
-%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
+%% password: Default for compatibility, deprecated since MySQL 5.7.6 and not
+%%           usable with MySQL 8.0.11+.
+%%           Alias for PASSWORD(?)
+%%           Docs: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
+%%      md5: Calculates an MD5 128-bit checksum of the password.
+%%           Alias for MD5(?)
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
+%%     sha1: Calculates the SHA-1 160-bit checksum for the password.
+%%           Alias for SHA1(?)
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
+%%   sha256: Calculates the SHA-2 hash of the password, using 256 bits.
+%%           Works only if MySQL has been configured with SSL support.
+%%           Alias for SHA2(?, 256)
+%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
 %%
 %% The password hash can also be salted for enhanced security:
-%% - SHA1(CONCAT(?, salt))
-%% - SHA2(CONCAT(?, salt), 256)
+%% - vmq_diversity.mysql.password_hash_method = SHA2(CONCAT(?, salt), 256)
 {mapping, "vmq_diversity.mysql.password_hash_method", "vmq_diversity.db_config.mysql.password_hash_method",
  [{datatype, string},
-  {default, "PASSWORD(?)"}
+  {default, "password"}
  ]}.
 
 {mapping, "vmq_diversity.auth_mongodb.enabled", "vmq_diversity.auth_cache.mongodb.enabled",

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -110,19 +110,23 @@
   hidden]}.
 
 %% @doc The password hashing method to use in MySQL:
-%% password: Default for compatibility, deprecated since MySQL 5.7.6 and not
-%%           usable with MySQL 8.0.11+.
-%%           Docs: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
-%%      md5: Calculates an MD5 128-bit checksum of the password.
-%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
-%%     sha1: Calculates the SHA-1 160-bit checksum for the password.
-%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
-%%   sha256: Calculates the SHA-2 hash of the password, using 256 bits. 
-%%           Works only if MySQL has been configured with SSL support.
-%%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
+%%  PASSWORD(?): Default for compatibility, deprecated since MySQL 5.7.6 and not
+%%               usable with MySQL 8.0.11+.
+%%               Docs: https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
+%%       MD5(?): Calculates an MD5 128-bit checksum of the password.
+%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
+%%      SHA1(?): Calculates the SHA-1 160-bit checksum for the password.
+%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
+%% SHA2(?, 256): Calculates the SHA-2 hash of the password, using 256 bits.
+%%               Works only if MySQL has been configured with SSL support.
+%%               Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
+%%
+%% The password hash can also be salted for enhanced security:
+%% - SHA1(CONCAT(?, salt))
+%% - SHA2(CONCAT(?, salt), 256)
 {mapping, "vmq_diversity.mysql.password_hash_method", "vmq_diversity.db_config.mysql.password_hash_method",
- [{datatype, {enum, [password, md5, sha1, sha256]}},
-  {default, password}
+ [{datatype, string},
+  {default, "PASSWORD(?)"}
  ]}.
 
 {mapping, "vmq_diversity.auth_mongodb.enabled", "vmq_diversity.auth_cache.mongodb.enabled",

--- a/apps/vmq_diversity/src/vmq_diversity_mysql.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mysql.erl
@@ -120,4 +120,11 @@ hash_method(_, St) ->
     {ok, DBConfigs} = application:get_env(vmq_diversity, db_config),
     DefaultConf = proplists:get_value(mysql, DBConfigs),
     HashMethod = proplists:get_value(password_hash_method, DefaultConf),
-    {[HashMethod], St}.
+    MysqlFunc = case HashMethod of
+        password -> <<"PASSWORD(?)">>;
+        md5 -> <<"MD5(?)">>;
+        sha1 -> <<"SHA1(?)">>;
+        sha256 -> <<"SHA2(?, 256)">>;
+        _ -> HashMethod
+    end,
+    {[MysqlFunc], St}.

--- a/apps/vmq_diversity/src/vmq_diversity_mysql.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mysql.erl
@@ -120,10 +120,4 @@ hash_method(_, St) ->
     {ok, DBConfigs} = application:get_env(vmq_diversity, db_config),
     DefaultConf = proplists:get_value(mysql, DBConfigs),
     HashMethod = proplists:get_value(password_hash_method, DefaultConf),
-    MysqlFunc = case HashMethod of
-        password -> <<"PASSWORD(?)">>;
-        md5 -> <<"MD5(?)">>;
-        sha1 -> <<"SHA1(?)">>;
-        sha256 -> <<"SHA2(?, 256)">>
-    end, 
-    {[MysqlFunc], St}.
+    {[HashMethod], St}.


### PR DESCRIPTION
This PR arose as a replacement for #1141.
The enum is unnecessary and uneasy to customize.
All it does is map to string anyway.

The PostgreSQL backend uses salt by default.
Using a string right away makes it trivial to do the same with MySQL.