### PR TITLE
Add TLS support to the vmq_diversity database drivers

### DIFF
--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -208,6 +208,40 @@
   {default, safe},
   hidden]}.
 
+%% @doc Specify if the mongodb driver should use TLS or not.
+{mapping, "vmq_diversity.mongodb.ssl", "vmq_diversity.db_config.mongodb.ssl",
+ [{datatype, flag},
+  {default, off}
+ ]}.
+
+%% @doc The cafile is used to define the path to a file containing
+%% the PEM encoded CA certificates that are trusted.
+{mapping, "vmq_diversity.mongodb.cafile", "vmq_diversity.db_config.mongodb.cacertfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {commented, "{{platform_etc_dir}}/cafile.pem"},
+  {validators, ["file-exists", "file-is-readable"]}
+ ]}.
+
+%% @doc Set the path to the PEM encoded server certificate.
+{mapping, "vmq_diversity.mongodb.certfile", "vmq_diversity.db_config.mongodb.certfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/cert.pem"}
+ ]}.
+
+%% @doc Set the path to the PEM encoded key file.
+{mapping, "vmq_diversity.mongodb.keyfile", "vmq_diversity.db_config.mongodb.keyfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/keyfile.pem"}
+ ]}.
+
 
 {mapping, "vmq_diversity.auth_redis.enabled", "vmq_diversity.auth_cache.redis.enabled",
  [{datatype, flag},

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -70,6 +70,40 @@
   {default, 5},
   hidden]}.
 
+%% @doc Specify if the postgresql driver should use TLS or not.
+{mapping, "vmq_diversity.postgres.ssl", "vmq_diversity.db_config.postgres.ssl",
+ [{datatype, flag},
+  {default, off}
+ ]}.
+
+%% @doc The cafile is used to define the path to a file containing
+%% the PEM encoded CA certificates that are trusted.
+{mapping, "vmq_diversity.postgres.cafile", "vmq_diversity.db_config.postgres.cacertfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {commented, "{{platform_etc_dir}}/cafile.pem"},
+  {validators, ["file-exists", "file-is-readable"]}
+ ]}.
+
+%% @doc Set the path to the PEM encoded server certificate.
+{mapping, "vmq_diversity.postgres.certfile", "vmq_diversity.db_config.postgres.certfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/cert.pem"}
+ ]}.
+
+%% @doc Set the path to the PEM encoded key file.
+{mapping, "vmq_diversity.postgres.keyfile", "vmq_diversity.db_config.postgres.keyfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/keyfile.pem"}
+ ]}.
+
 {mapping, "vmq_diversity.auth_mysql.enabled", "vmq_diversity.auth_cache.mysql.enabled",
  [{datatype, flag},
   {default, off}]}.
@@ -256,3 +290,18 @@
  [{datatype, string},
   hidden,
   {default, "    script      Manage lua scripts\n"}]}.
+
+{validator, "file-exists", "file does not exist",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_exists(Name)
+ end}.
+{validator, "file-is-readable", "file is not readable, check permissions",
+ fun("") ->
+         %% "" is used as the default value in most places, we should
+         %% not error out because of that.
+         true;
+    (Name) -> vmq_schema_util:file_is_readable(Name)
+ end}.

--- a/apps/vmq_diversity/src/vmq_diversity_mongo.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mongo.erl
@@ -109,10 +109,33 @@ ensure_pool(As, St) ->
                               maps:get(<<"r_mode">>,
                                        Options,
                                        proplists:get_value(r_mode, DefaultConf))),
+                    Ssl = vmq_diversity_utils:atom(
+                            maps:get(<<"ssl">>, Options,
+                                     proplists:get_value(ssl, DefaultConf, false))),
+                    SslOpts =
+                        case Ssl of
+                            true ->
+                                CertFile = vmq_diversity_utils:str(
+                                             maps:get(<<"certfile">>, Options,
+                                                      proplists:get_value(certfile, DefaultConf))),
+                                CaCertFile = vmq_diversity_utils:str(
+                                             maps:get(<<"cacertfile">>, Options,
+                                                      proplists:get_value(cacertfile, DefaultConf))),
+                                KeyFile = vmq_diversity_utils:str(
+                                             maps:get(<<"keyfile">>, Options,
+                                                      proplists:get_value(keyfile, DefaultConf))),
+                                L = [{certfile, CertFile},
+                                     {cacertfile, CaCertFile},
+                                     {keyfile, KeyFile}],
+                                [P||{_,V}=P <- L, V /= ""];
+                           false ->
+                                []
+                        end,
                     NewOptions =
                     [{login, mbin(Login)}, {password, mbin(Password)},
                      {host, Host}, {port, Port}, {database, mbin(Database)},
-                     {w_mode, WMode}, {r_mode, RMode}],
+                     {w_mode, WMode}, {r_mode, RMode},
+                     {ssl, Ssl}, {ssl_opts, SslOpts}],
                     vmq_diversity_sup:start_pool(mongodb,
                                                  [{id, PoolId},
                                                   {size, Size},

--- a/apps/vmq_diversity/src/vmq_diversity_postgres.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_postgres.erl
@@ -128,9 +128,32 @@ ensure_pool(As, St) ->
                                  maps:get(<<"database">>,
                                           Options,
                                           proplists:get_value(database, DefaultConf))),
+                    Ssl = vmq_diversity_utils:atom(
+                            maps:get(<<"ssl">>, Options,
+                                     proplists:get_value(ssl, DefaultConf, false))),
+                    SslOpts =
+                        case Ssl of
+                            true ->
+                                CertFile = vmq_diversity_utils:str(
+                                             maps:get(<<"certfile">>, Options,
+                                                      proplists:get_value(certfile, DefaultConf))),
+                                CaCertFile = vmq_diversity_utils:str(
+                                             maps:get(<<"cacertfile">>, Options,
+                                                      proplists:get_value(cacertfile, DefaultConf))),
+                                KeyFile = vmq_diversity_utils:str(
+                                             maps:get(<<"keyfile">>, Options,
+                                                      proplists:get_value(keyfile, DefaultConf))),
+                                L = [{certfile, CertFile},
+                                     {cacertfile, CaCertFile},
+                                     {keyfile, KeyFile}],
+                                [P||{_,V}=P <- L, V /= ""];
+                           false ->
+                                []
+                        end,
                     NewOptions =
                     [{size, Size}, {user, User}, {password, Password},
-                     {host, Host}, {port, Port}, {database, Database}],
+                     {host, Host}, {port, Port}, {database, Database},
+                     {ssl, Ssl}, {ssl_opts, SslOpts}],
                     vmq_diversity_sup:start_all_pools(
                       [{pgsql, [{id, PoolId}, {opts, NewOptions}]}], []),
 

--- a/apps/vmq_diversity/src/vmq_diversity_sup.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_sup.erl
@@ -84,10 +84,13 @@ start_all_pools([{pgsql, ProviderConfig}|Rest], Acc) ->
                        Database = proplists:get_value(database, WorkerArgs),
                        Username = proplists:get_value(user, WorkerArgs),
                        Password = proplists:get_value(password, WorkerArgs),
-                       epgsql:connect(Hostname, Username, Password, [
-                           {database, Database},
-                           {port, Port}
-                       ])
+                       Ssl = proplists:get_value(ssl, WorkerArgs),
+                       SslOpts = proplists:get_value(ssl_opts, WorkerArgs),
+                       Opts = #{database => Database,
+                                port => Port,
+                                ssl => Ssl,
+                                ssl_opts => SslOpts},
+                       epgsql:connect(Hostname, Username, Password, Opts)
                end,
     TerminateFun = fun(Pid) -> ok = epgsql:close(Pid) end,
     WrapperArgs = [{reconnect_timeout, 1000},

--- a/apps/vmq_diversity/src/vmq_diversity_sup.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_sup.erl
@@ -110,7 +110,11 @@ start_all_pools([{mongodb, ProviderConfig}|Rest], Acc) ->
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = lists:keydelete(size, 1,
                                  lists:keydelete(max_overflow, 1, PoolOpts)),
-    StartFun = fun() -> mc_worker:start_link(WorkerArgs) end,
+    StartFun = fun() ->
+                       Ssl = proplists:get_value(ssl, WorkerArgs, false),
+                       SslOpts = proplists:get_value(ssl_opts, WorkerArgs),
+                       mc_worker:start_link([{ssl,Ssl}, {ssl_opts, SslOpts}|WorkerArgs])
+               end,
     TerminateFun = fun(Pid) -> mc_worker:disconnect(Pid) end,
     WrapperArgs = [{reconnect_timeout, 1000},
                    {name, mongodb},
@@ -129,6 +133,7 @@ start_all_pools([{redis, ProviderConfig}|Rest], Acc) ->
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = lists:keydelete(size, 1,
                                  lists:keydelete(max_overflow, 1, PoolOpts)),
+
     PoolArgs = [{name, {local, PoolId}},
                 {worker_module, vmq_diversity_redis},
                 {size, Size},

--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,8 @@
   Makefile as well as the upgrade of the `rebar3` build tool.
 - Improve MQTT 5.0 support in the `vmq_diversity` plugin: support all MQTT 5.0
   hooks in Lua and more properties.
+- Support TLS encrypted connections to PostgreSQL when using
+  `vmq_diversity`. Fixes #811.
 
 ## VerneMQ 1.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,7 @@
   hooks in Lua and more properties.
 - Support TLS encrypted connections to PostgreSQL when using
   `vmq_diversity`. Fixes #811.
+- Support TLS encrypted connections to MongoDB when using `vmq_diversity`.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
This adds basic TLS support for the postgresql driver. This is also
needed in order to use the posgresql driver to connect to a secure
CockroachDB installation.

- [x] postgresql
- [x] mongdb
- [ ] mysql (afaict emysql doesn't support TLS)
- [ ] redis (doesn't support TLS)

Fixes #811 
