### PR TITLE
Support cockroachdb

### DIFF
--- a/apps/vmq_diversity/priv/auth/cockroachdb.lua
+++ b/apps/vmq_diversity/priv/auth/cockroachdb.lua
@@ -1,4 +1,4 @@
--- Copyright 2018 Erlio GmbH Basel Switzerland (http://erl.io)
+-- Copyright 2019 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -21,15 +21,15 @@ require "auth/auth_commons"
 require "auth/postgres_cockroach_commons"
 
 function auth_on_register(reg)
-   return auth_on_register_common(postgres, reg)
+   return auth_on_register_common(cockroachdb, reg)
 end
 
-pool = "auth_postgres"
+pool = "auth_cockroachdb"
 config = {
     pool_id = pool,
 }
 
-postgres.ensure_pool(config)
+cockroachdb.ensure_pool(config)
 hooks = {
     auth_on_register = auth_on_register,
     auth_on_publish = auth_on_publish,

--- a/apps/vmq_diversity/priv/auth/postgres_cockroach_commons.lua
+++ b/apps/vmq_diversity/priv/auth/postgres_cockroach_commons.lua
@@ -1,0 +1,177 @@
+-- Copyright 2019 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- PostgreSQL Configuration, read the documentation below to properly
+-- provision your database.
+
+-- In order to use this Lua plugin you must deploy the following database
+-- schema and grant the user configured above with the required privileges:
+--[[
+  CREATE EXTENSION pgcrypto;
+  CREATE TABLE vmq_auth_acl
+  (
+    mountpoint character varying(10) NOT NULL,
+    client_id character varying(128) NOT NULL,
+    username character varying(128) NOT NULL,
+    password character varying(128),
+    publish_acl json,
+    subscribe_acl json,
+    CONSTRAINT vmq_auth_acl_primary_key PRIMARY KEY (mountpoint, client_id, username)
+  );
+]]--
+-- This plugin relies on a PostgreSQL version that supports the `gen_salt('bf')
+-- built-in function, as the passwords are stored as blowfish hashes.
+-- Moreover the json datatype is used for storing the publish/subscribe ACLs.
+--
+-- To insert a client ACL use a similar SQL statement:
+--[[
+  WITH x AS (
+      SELECT
+          ''::text AS mountpoint,
+  	       'test-client'::text AS client_id,
+  	       'test-user'::text AS username,
+  	       '123'::text AS password,
+  	       gen_salt('bf')::text AS salt,
+  	       '[{"pattern": "a/b/c"}, {"pattern": "c/b/#"}]'::json AS publish_acl,
+  	       '[{"pattern": "a/b/c"}, {"pattern": "c/b/#"}]'::json AS subscribe_acl
+  	)
+  INSERT INTO vmq_auth_acl (mountpoint, client_id, username, password, publish_acl, subscribe_acl)
+  	SELECT
+  		x.mountpoint,
+  		x.client_id,
+  		x.username,
+  		crypt(x.password, x.salt),
+  		publish_acl,
+  		subscribe_acl
+  	FROM x;
+]]--
+--
+-- 	The JSON array passed as publish/subscribe ACL contains the ACL objects
+-- 	this particular user. MQTT wildcards as well as the variable
+-- 	substitution for %m (mountpoint), %c (client_id), %u (username) are allowed
+-- 	inside a pattern.
+--
+-- Note, it is also possible to use client-side password validation
+-- using for example `bcrypt` as the hash method. Then an example
+-- client ACL would look like the following:
+--
+--[[
+  WITH x AS (
+      SELECT
+          ''::text AS mountpoint,
+             'test-client'::text AS client_id,
+             'test-user'::text AS username,
+             '$2a$12$97PlnSsouvCV7HaxDPV80.EXfsKM4Fg7DAwWhSbGJ6O5CpNep20n2'::text AS hash,
+             '[{"pattern": "a/b/c"}, {"pattern": "c/b/#"}]'::json AS publish_acl,
+             '[{"pattern": "a/b/c"}, {"pattern": "c/b/#"}]'::json AS subscribe_acl
+      )
+  INSERT INTO vmq_auth_acl (mountpoint, client_id, username, password, publish_acl, subscribe_acl)
+      SELECT
+          x.mountpoint,
+          x.client_id,
+          x.username,
+          x.hash,
+          publish_acl,
+          subscribe_acl
+      FROM x;
+]]--
+--
+-- IF YOU USE THE SCHEMA PROVIDED ABOVE NOTHING HAS TO BE CHANGED IN THE
+-- FOLLOWING SCRIPT.
+function auth_on_register_common(db_library, reg)
+   method = db_library.hash_method()
+   if reg.username ~= nil and reg.password ~= nil then
+      if client_side_hashing(method) then
+         -- use client side hash functions
+         results = db_library.execute(
+            pool,
+            [[SELECT publish_acl::TEXT, subscribe_acl::TEXT, password AS passhash
+              FROM vmq_auth_acl
+              WHERE
+                mountpoint=$1 AND
+                client_id=$2 AND
+                username=$3]],
+            reg.mountpoint,
+            reg.client_id,
+            reg.username)
+         if #results == 1 then
+            row = results[1]
+            if row.passhash == do_hash(method, reg.password, row.passhash) then
+               cache_result(reg, row)
+               return true
+            else
+              return false
+           end
+        else
+            return false
+         end
+      else
+         -- use server side hash functions
+         if method == "crypt" then
+            -- only supported in postgresql
+            server_hash = "crypt($4, password)"
+         elseif method == "sha256" then
+            -- only supported in cockroachdb
+            server_hash = "sha256($4:::TEXT)"
+         else
+            return false
+         end
+         results = db_library.execute(
+            pool,
+            [[SELECT publish_acl::TEXT, subscribe_acl::TEXT
+              FROM vmq_auth_acl
+              WHERE
+                mountpoint=$1 AND
+                client_id=$2 AND
+                username=$3 AND
+                password=]]..server_hash,
+            reg.mountpoint,
+            reg.client_id,
+            reg.username,
+            reg.password)
+         if #results == 1 then
+            row = results[1]
+            cache_result(reg, row)
+            return true
+         else
+            return false
+         end
+      end
+   else
+      return false
+   end
+end
+
+function client_side_hashing(method)
+   return method == "bcrypt"
+end
+
+function do_hash(method, password, passhash)
+   if method == "bcrypt" then
+      return bcrypt.hashpw(password, passhash)
+   else
+      return false
+   end
+end
+
+function cache_result(reg, row)
+   publish_acl = json.decode(row.publish_acl)
+   subscribe_acl = json.decode(row.subscribe_acl)
+   cache_insert(
+      reg.mountpoint,
+      reg.client_id,
+      reg.username,
+      publish_acl,
+      subscribe_acl)
+end

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -104,6 +104,92 @@
   {commented, "{{platform_etc_dir}}/keyfile.pem"}
  ]}.
 
+%% @doc The password hashing method to use in PostgreSQL:
+{mapping, "vmq_diversity.postgres.password_hash_method", "vmq_diversity.db_config.postgres.password_hash_method",
+ [{datatype, {enum, [crypt, bcrypt]}},
+  {default, crypt}
+ ]}.
+
+{mapping, "vmq_diversity.auth_cockroachdb.enabled", "vmq_diversity.auth_cache.cockroachdb.enabled",
+ [{datatype, flag},
+  {default, off}]}.
+
+{mapping, "vmq_diversity.auth_cockroachdb.script", "vmq_diversity.auth_cache.cockroachdb.file",
+ [{datatype, file},
+  {default, "{{platform_share_dir}}/lua/auth/cockroachdb.lua"},
+  hidden
+ ]}.
+
+{mapping, "vmq_diversity.cockroachdb.host", "vmq_diversity.db_config.cockroachdb.host",
+ [{datatype, string},
+  {default, "localhost"},
+  {commented, "localhost"}]}.
+
+{mapping, "vmq_diversity.cockroachdb.port", "vmq_diversity.db_config.cockroachdb.port",
+ [{datatype, integer},
+  {default, 5432},
+  {commented, 5432}]}.
+
+{mapping, "vmq_diversity.cockroachdb.user", "vmq_diversity.db_config.cockroachdb.user",
+ [{datatype, string},
+  {default, "root"},
+  {commented, "root"}]}.
+
+{mapping, "vmq_diversity.cockroachdb.password", "vmq_diversity.db_config.cockroachdb.password",
+ [{datatype, string},
+  {default, "password"},
+  {commented, "password"}]}.
+
+{mapping, "vmq_diversity.cockroachdb.database", "vmq_diversity.db_config.cockroachdb.database",
+ [{datatype, string},
+  {default, "vernemq_db"},
+  {commented, "vernemq_db"}]}.
+
+{mapping, "vmq_diversity.cockroachdb.pool_size", "vmq_diversity.db_config.cockroachdb.pool_size",
+ [{datatype, integer},
+  {default, 5},
+  hidden]}.
+
+%% @doc Specify if the cockroachdb driver should use TLS or not.
+{mapping, "vmq_diversity.cockroachdb.ssl", "vmq_diversity.db_config.cockroachdb.ssl",
+ [{datatype, flag},
+  {default, on}
+ ]}.
+
+%% @doc The cafile is used to define the path to a file containing
+%% the PEM encoded CA certificates that are trusted.
+{mapping, "vmq_diversity.cockroachdb.cafile", "vmq_diversity.db_config.cockroachdb.cacertfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {commented, "{{platform_etc_dir}}/cafile.pem"},
+  {validators, ["file-exists", "file-is-readable"]}
+ ]}.
+
+%% @doc Set the path to the PEM encoded server certificate.
+{mapping, "vmq_diversity.cockroachdb.certfile", "vmq_diversity.db_config.cockroachdb.certfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/cert.pem"}
+ ]}.
+
+%% @doc Set the path to the PEM encoded key file.
+{mapping, "vmq_diversity.cockroachdb.keyfile", "vmq_diversity.db_config.cockroachdb.keyfile",
+ [
+  {default, ""},
+  {datatype, file},
+  {validators, ["file-exists", "file-is-readable"]},
+  {commented, "{{platform_etc_dir}}/keyfile.pem"}
+ ]}.
+
+%% @doc The password hashing method to use in CockroachDB:
+{mapping, "vmq_diversity.cockroachdb.password_hash_method", "vmq_diversity.db_config.cockroachdb.password_hash_method",
+ [{datatype, {enum, [sha256, bcrypt]}},
+  {default, bcrypt}
+ ]}.
+
 {mapping, "vmq_diversity.auth_mysql.enabled", "vmq_diversity.auth_cache.mysql.enabled",
  [{datatype, flag},
   {default, off}]}.

--- a/apps/vmq_diversity/src/vmq_diversity_cockroachdb.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_cockroachdb.erl
@@ -1,0 +1,57 @@
+%% Copyright 2019 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_diversity_cockroachdb).
+
+%% API functions
+-export([install/1,
+         squery/2,
+         equery/3]).
+
+-import(luerl_lib, [badarg_error/3]).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+install(St) ->
+    luerl_emul:alloc_table(table(), St).
+
+squery(PoolName, Sql) ->
+    vmq_diversity_postgres:squery(PoolName, Sql).
+
+equery(PoolName, Stmt, Params) ->
+    vmq_diversity_postgres:equery(PoolName, Stmt, Params).
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+table() ->
+    [
+     {<<"execute">>, {function, fun execute/2}},
+     {<<"ensure_pool">>, {function, fun ensure_pool/2}},
+     {<<"hash_method">>, {function, fun hash_method/2}}
+    ].
+
+execute(As, St) ->
+    vmq_diversity_postgres:execute(As, St).
+
+ensure_pool(As, St) ->
+    vmq_diversity_postgres:ensure_pool(As, St, cockroachdb, pool_cockroachdb).
+
+hash_method(_, St) ->
+    {ok, DBConfigs} = application:get_env(vmq_diversity, db_config),
+    DefaultConf = proplists:get_value(cockroachdb, DBConfigs),
+    HashMethod = proplists:get_value(password_hash_method, DefaultConf),
+    {[atom_to_binary(HashMethod,utf8)], St}.

--- a/apps/vmq_diversity/src/vmq_diversity_script_state.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script_state.erl
@@ -218,6 +218,7 @@ load_script(Id, Script) ->
     Libs = [
             {vmq_diversity_mysql,       <<"mysql">>},
             {vmq_diversity_postgres,    <<"postgres">>},
+            {vmq_diversity_cockroachdb, <<"cockroachdb">>},
             {vmq_diversity_mongo,       <<"mongodb">>},
             {vmq_diversity_redis,       <<"redis">>},
             {vmq_diversity_http,        <<"http">>},

--- a/changelog.md
+++ b/changelog.md
@@ -64,6 +64,7 @@
 - Support TLS encrypted connections to PostgreSQL when using
   `vmq_diversity`. Fixes #811.
 - Support TLS encrypted connections to MongoDB when using `vmq_diversity`.
+- Add CockroachDB support to the `vmq_diversity` plugin.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
[x] Depends on #1155 

Next steps for diversity would probably be to add salts to mysql passwords (#1141) and let it support bcrypt. Also we should fix #579 