### PR TITLE
Use bcrypt on multiple cores

### DIFF
--- a/apps/vmq_diversity/priv/vmq_bcrypt.schema
+++ b/apps/vmq_diversity/priv/vmq_bcrypt.schema
@@ -1,0 +1,14 @@
+%% @doc The pool_size specifies how many bcrypt operations that are
+%% allowed concurrently.
+{mapping, "vmq_bcrypt.pool_size", "bcrypt.pool_size", [
+                                                       {datatype, integer},
+                                                       {default, 1},
+                                                       {include_default, 1}
+                                                      ]}.
+
+{mapping, "vmq_bcrypt.mechanism", "bcrypt.mechanism", [
+                                                       {datatype, {enum, [nif, port]}},
+                                                       {default, port},
+                                                       hidden,
+                                                       {include_default, port}
+                                                      ]}.

--- a/apps/vmq_diversity/priv/vmq_bcrypt.schema
+++ b/apps/vmq_diversity/priv/vmq_bcrypt.schema
@@ -1,16 +1,19 @@
 %% @doc The pool_size specifies how many bcrypt operations that are
-%% allowed concurrently.
+%% allowed concurrently. The value `auto` will try to detect all
+%% logical cpus and set the pool size to that number. If the number of
+%% logical cpus cannot be detected, a value of 1 is used.
 {mapping, "vmq_bcrypt.pool_size", "bcrypt.pool_size", [
-                                                       {datatype, [integer, {enum, [logical_processors_online]}]},
+                                                       {datatype, [integer, {enum, [auto]}]},
                                                        {default, 1},
-                                                       {include_default, 1}
+                                                       {include_default, 1},
+                                                       {validators, ["non-zero-positive-int"]}
                                                       ]}.
 
 {translation,
  "bcrypt.pool_size",
  fun(Conf) ->
          case cuttlefish:conf_get("vmq_bcrypt.pool_size", Conf) of
-             logical_processors_online ->
+             auto ->
                  case erlang:system_info(logical_processors_online) of
                      unknown ->
                          1;
@@ -28,3 +31,9 @@
                                                        hidden,
                                                        {include_default, port}
                                                       ]}.
+
+{validator, "non-zero-positive-int", "0 or negative values not allowed",
+ fun(Int) when is_integer(Int), Int < 1 ->
+         false;
+    (_) -> true
+ end}.

--- a/apps/vmq_diversity/priv/vmq_bcrypt.schema
+++ b/apps/vmq_diversity/priv/vmq_bcrypt.schema
@@ -1,10 +1,26 @@
 %% @doc The pool_size specifies how many bcrypt operations that are
 %% allowed concurrently.
 {mapping, "vmq_bcrypt.pool_size", "bcrypt.pool_size", [
-                                                       {datatype, integer},
+                                                       {datatype, [integer, {enum, [logical_processors_online]}]},
                                                        {default, 1},
                                                        {include_default, 1}
                                                       ]}.
+
+{translation,
+ "bcrypt.pool_size",
+ fun(Conf) ->
+         case cuttlefish:conf_get("vmq_bcrypt.pool_size", Conf) of
+             logical_processors_online ->
+                 case erlang:system_info(logical_processors_online) of
+                     unknown ->
+                         1;
+                     N when is_integer(N) ->
+                         N
+                 end;
+             Size when is_integer(Size) ->
+                 Size
+         end
+ end}.
 
 {mapping, "vmq_bcrypt.mechanism", "bcrypt.mechanism", [
                                                        {datatype, {enum, [nif, port]}},

--- a/apps/vmq_diversity/rebar.config
+++ b/apps/vmq_diversity/rebar.config
@@ -9,7 +9,7 @@
         {eredis, "1.0.8"},
         hackney,
         {jsx, "2.8.0"},
-        {bcrypt, "1.0.0"},
+        {bcrypt, "1.0.2"},
         {gen_server2, {git, "git://github.com/erlio/gen_server2.git", {branch, "master"}}},
         {luerl, {git, "git://github.com/rvirding/luerl.git", {branch, "develop"}}},
         {emysql, {git, "git://github.com/djustinek/Emysql.git", "fa7c94b5237a56cec6d75c3d3b1e51060426e099"}},

--- a/changelog.md
+++ b/changelog.md
@@ -65,6 +65,8 @@
   `vmq_diversity`. Fixes #811.
 - Support TLS encrypted connections to MongoDB when using `vmq_diversity`.
 - Add CockroachDB support to the `vmq_diversity` plugin.
+- Make it possible to configure how many concurrent bcrypt operations are
+  possible via the `vmq_bcrypt.pool_size` config.
 
 ## VerneMQ 1.7.0
 

--- a/rebar.config
+++ b/rebar.config
@@ -124,11 +124,12 @@
              {template, "apps/vmq_acl/priv/vmq_acl.schema", "share/schema/13-vmq_acl.schema"},
              {template, "apps/vmq_passwd/priv/vmq_passwd.schema", "share/schema/14-vmq_passwd.schema"},
              {template, "apps/vmq_diversity/priv/vmq_diversity.schema", "share/schema/15-vmq_diversity.schema"},
+             {template, "apps/vmq_diversity/priv/vmq_bcrypt.schema", "share/schema/16-vmq_bcrypt.schema"},
              {copy, "apps/vmq_diversity/priv/init.lua", "share/lua/init.lua"},
              {copy, "apps/vmq_diversity/priv/auth", "share/lua/"},
-             {template, "apps/vmq_webhooks/priv/vmq_webhooks.schema", "share/schema/16-vmq_webhooks.schema"},
-             {template, "apps/vmq_bridge/priv/vmq_bridge.schema", "share/schema/17-vmq_bridge.schema"},
-             {template, "apps/vmq_swc/priv/vmq_swc.schema", "share/schema/18-vmq_swc.schema"},
+             {template, "apps/vmq_webhooks/priv/vmq_webhooks.schema", "share/schema/17-vmq_webhooks.schema"},
+             {template, "apps/vmq_bridge/priv/vmq_bridge.schema", "share/schema/18-vmq_bridge.schema"},
+             {template, "apps/vmq_swc/priv/vmq_swc.schema", "share/schema/19-vmq_swc.schema"},
 
              {template, "files/vmq.schema", "share/schema/30-vmq.schema"},
 


### PR DESCRIPTION
- [x] add a vmq_bcrypt.pool_size schema setting
- [x] allow automatic detection of all cores as the pool size.

Note, if this gets merged we should add a note about the setting in the `vmq_diversity` docs vernemq/vmq-docs#18

Fixes #579 