### PR TITLE
Debug readable ct output crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
   include:
     - stage: Test
       before_script: "epmd -daemon"
-      script: "./rebar3 as all_tests do dialyzer, eunit, ct --readable=false"
+      script: "./rebar3 as all_tests do dialyzer, eunit && ./rebar3 ct"
     - stage: GitHub Release
       script: echo "Nothing to test here"
       before_deploy:


### PR DESCRIPTION
since a while using `rebar3 ct` is broken and we have to pass `--readable=false` to run the tests. This is super annoying as the output is ... unreadable.

Was finally able to reproduce locally and opened an issue on the rebar3 repo: https://github.com/erlang/rebar3/issues/2063