### PR TITLE
Make buffer sizes configurable

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -337,6 +337,63 @@
          Term
  end}.
 
+%% @doc listener.tcp.buffer_sizes is an list of three integers
+%% (sndbuf,recbuf,buffer) specifying respectively the kernel TCP send
+%% buffer, the kernel TCP receive buffer and the user-level buffer
+%% size in the erlang driver.
+%%
+%% It is recommended to have val(user-level buffer) >= val(receive
+%% buffer) to avoid performance issues because of unnecessary copying.
+%%
+%% If not set, the operating system defaults are used.
+%%
+%% This option can be set on the protocol level by:
+%%
+%%     - listener.tcp.buffer_sizes
+%%     - listener.ssl.buffer_sizes
+%%
+%% or on the listener level by:
+%%
+%%     - listener.tcp.my_tcp_listener.buffer_sizes
+%%     - listener.ssl.my_ssl_listener.buffer_sizes
+{mapping, "listener.tcp.buffer_sizes", "vmq_server.listeners",
+ [{commented, "4096,16384,32768"},
+  {datatype, string},
+  {validators, ["buffer_size_validator"]}
+ ]}.
+
+{mapping, "listener.tcp.$name.buffer_sizes", "vmq_server.listeners",
+ [{datatype, string},
+  hidden,
+  {validators, ["buffer_size_validator"]}
+ ]}.
+
+{mapping, "listener.ssl.buffer_sizes", "vmq_server.listeners",
+ [{datatype, string},
+  hidden,
+  {validators, ["buffer_size_validator"]}
+ ]}.
+
+{mapping, "listener.ssl.$name.buffer_sizes", "vmq_server.listeners",
+ [{datatype, string},
+  hidden,
+  {validators, ["buffer_size_validator"]}
+ ]}.
+
+
+{validator, "buffer_size_validator", "value must be three comma-separated, positive integers",
+ fun(Val) when is_list(Val) ->
+         case vmq_schema:parse_list_to_term(Val) of
+             {ok, [A,B,C]} when is_integer(A), is_integer(B), is_integer(C),
+                                A >= 0, B >= 0, C >= 0 ->
+                 true;
+             _ ->
+                 false
+         end;
+    (Val) ->
+         false
+ end}.
+
 %% @doc listener.max_connections is an integer or 'infinity' defining 
 %% the maximum number of concurrent connections. This option can be overridden
 %% on the protocol level by:

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -285,9 +285,11 @@ default_session_opts(Opts) ->
             {_, V1} -> [{proxy_protocol_use_cn_as_username, V1}|MaybeSSLDefaults]
         end,
     AllowedProtocolVersions = proplists:get_value(allowed_protocol_versions, Opts, [3,4]),
+    BufferSizes = proplists:get_value(buffer_sizes, Opts, undefined),
     %% currently only the mountpoint option is supported
     [{mountpoint, proplists:get_value(mountpoint, Opts, "")},
-     {allowed_protocol_versions, AllowedProtocolVersions}|MaybeProxyDefaults].
+     {allowed_protocol_versions, AllowedProtocolVersions},
+     {buffer_sizes, BufferSizes}|MaybeProxyDefaults].
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/changelog.md
+++ b/changelog.md
@@ -72,6 +72,9 @@
   well).
 - Fix bug which could happen while repairing dead queues in case the sync
   request fails.
+- It is now possible to configure TCP send and receive buffer and user-level
+  buffer sizes directly on the MQTT listeners or protocol levels (currently only
+  TCP and TLS listeners).
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
This makes it possible to configure the buffer sizes on the MQTT TCP and TLS listeners. For now ws/wss, http/https and vmq/vmqs are not supported. 

I'll have to look into how to do this for ws/wss and vmq/vmqs as well.