### PR TITLE
Handle `vmq_reg:sync/3` error cases while fixing dead queues

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -606,7 +606,12 @@ fix_dead_queue(SubscriberId, Subs, {DeadNodes, [Target|Targets], N}) ->
                                 {DeadNodes, Targets ++ [Target], N}
                         end
                 end,
-            vmq_reg_sync:sync(SubscriberId, RepairQueueFun, 60000)
+            case vmq_reg_sync:sync(SubscriberId, RepairQueueFun, 60000) of
+                {error, Error} ->
+                    lager:info("repairing dead queue for ~p on ~p failed due to ~p~n", [SubscriberId, Target, Error]),
+                    {DeadNodes, Targets ++ [Target], N};
+                {_,_,_} = Acc -> Acc
+            end
     end.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,8 @@
 - Fix incorrect format string in shared subscription debug log.
 - Upgrade `hackney` to version 1.15.1 (dependencies of `hackney` were updated as
   well).
+- Fix bug which could happen while repairing dead queues in case the sync
+  request fails.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
I think this should handle the `{error, not_ready}` accumulator issue during dead queue fixing.