### PR TITLE
Better handling of the `close_timeout`

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -24,6 +24,7 @@
 
          incr_socket_open/0,
          incr_socket_close/0,
+         incr_socket_close_timeout/0,
          incr_socket_error/0,
          incr_bytes_received/1,
          incr_bytes_sent/1,
@@ -115,6 +116,9 @@ incr_socket_open() ->
 
 incr_socket_close() ->
     incr_item(?METRIC_SOCKET_CLOSE, 1).
+
+incr_socket_close_timeout() ->
+    incr_item(?METRIC_SOCKET_CLOSE_TIMEOUT, 1).
 
 incr_socket_error() ->
     incr_item(?METRIC_SOCKET_ERROR, 1).
@@ -644,6 +648,7 @@ counter_entries_def() ->
     [
      m(counter, [], socket_open, socket_open, <<"The number of times an MQTT socket has been opened.">>),
      m(counter, [], socket_close, socket_close, <<"The number of times an MQTT socket has been closed.">>),
+     m(counter, [], socket_close_timeout, socket_close_timeout, <<"The number of times VerneMQ closed an MQTT socket due to no CONNECT frame has been received on time.">>),
      m(counter, [], socket_error, socket_error, <<"The total number of socket errors that have occurred.">>),
      m(counter, [], bytes_received, bytes_received, <<"The total number of bytes received.">>),
      m(counter, [], bytes_sent, bytes_sent, <<"The total number of bytes sent.">>),
@@ -1275,4 +1280,5 @@ met2idx(mqtt_connack_bad_credentials_sent)                        -> 189;
 met2idx(mqtt_connack_server_unavailable_sent)                     -> 190;
 met2idx(mqtt_connack_identifier_rejected_sent)                    -> 191;
 met2idx(mqtt_connack_unacceptable_protocol_sent)                  -> 192;
-met2idx(mqtt_connack_accepted_sent)                               -> 193.
+met2idx(mqtt_connack_accepted_sent)                               -> 193;
+met2idx(?METRIC_SOCKET_CLOSE_TIMEOUT)                             -> 194.

--- a/apps/vmq_server/src/vmq_metrics.hrl
+++ b/apps/vmq_server/src/vmq_metrics.hrl
@@ -88,6 +88,7 @@
 -define(METRIC_CLUSTER_BYTES_DROPPED, cluster_bytes_dropped).
 -define(METRIC_SOCKET_OPEN, socket_open).
 -define(METRIC_SOCKET_CLOSE, socket_close).
+-define(METRIC_SOCKET_CLOSE_TIMEOUT, socket_close_timeout).
 -define(METRIC_SOCKET_ERROR, socket_error).
 -define(METRIC_BYTES_RECEIVED, bytes_received).
 -define(METRIC_BYTES_SENT, bytes_sent).

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -673,6 +673,10 @@ connected({Ref, {error, cant_remote_enqueue}}, State) when is_reference(Ref) ->
     %% TODO: this should be cleaned up for 2.0 as changing this is
     %% likely backwards incompatible.
     {State, []};
+connected(close_timeout, State) ->
+    %% Late arrival of the close_timeout that has been fired by vmq_mqtt_pre_init
+    %% As we're in the connected state, it's ok to ignore this timeout
+    {State, []};
 connected(Unexpected, State) ->
     lager:debug("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
     terminate({error, {unexpected_message, Unexpected}}, State).

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -678,7 +678,7 @@ connected(close_timeout, State) ->
     %% As we're in the connected state, it's ok to ignore this timeout
     {State, []};
 connected(Unexpected, State) ->
-    lager:debug("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
+    lager:warning("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
     terminate({error, {unexpected_message, Unexpected}}, State).
 
 -spec connack_terminate(reason_code_name(), state()) -> any().

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -453,6 +453,10 @@ connected({Ref, {error, cant_remote_enqueue}}, State) when is_reference(Ref) ->
     %% TODO: this should be cleaned up for 2.0 as changing this is
     %% likely backwards incompatible.
     {State, []};
+connected(close_timeout, State) ->
+    %% Late arrival of the close_timeout that has been fired by vmq_mqtt_pre_init
+    %% As we're in the connected state, it's ok to ignore this timeout
+    {State, []};
 connected(Unexpected, State) ->
     lager:debug("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
     terminate({error, unexpected_message, Unexpected}, State).

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -458,7 +458,7 @@ connected(close_timeout, State) ->
     %% As we're in the connected state, it's ok to ignore this timeout
     {State, []};
 connected(Unexpected, State) ->
-    lager:debug("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
+    lager:warning("stopped connected session, due to unexpected frame type ~p", [Unexpected]),
     terminate({error, unexpected_message, Unexpected}, State).
 
 connack_terminate(RC, _State) ->

--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -123,7 +123,7 @@ msg_in({disconnect, ?NORMAL_DISCONNECT}, _FsmState0) ->
 msg_in(disconnect, _FsmState0) ->
     ignore;
 msg_in(close_timeout, _FsmState0) ->
-    vmq_metrics:incr_mqtt_connect_timeout(),
+    vmq_metrics:incr_socket_close_timeout(),
     lager:debug("stop due to timeout", []),
     {stop, normal, []}.
 

--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -123,6 +123,7 @@ msg_in({disconnect, ?NORMAL_DISCONNECT}, _FsmState0) ->
 msg_in(disconnect, _FsmState0) ->
     ignore;
 msg_in(close_timeout, _FsmState0) ->
+    vmq_metrics:incr_mqtt_connect_timeout(),
     lager:debug("stop due to timeout", []),
     {stop, normal, []}.
 

--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,9 @@
 - It is now possible to configure TCP send and receive buffer and user-level
   buffer sizes directly on the MQTT listeners or protocol levels (currently only
   TCP and TLS listeners).
+- Add the `socket_close_timeout` metric. The metric counts the number of times
+  VerneMQ hasn't received the MQTT CONNECT frame on time and therefore forcefully
+  closed the socket.
 
 ## VerneMQ 1.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -80,6 +80,8 @@
   closed the socket.
 - Fix the potential case of late arriving `close_timeout` messages triggered
   by the `vmq_mqtt_pre_init`.
+- Change log level from `debug` to `warning` when VerneMQ forcefully terminates a
+  MQTT session FSM because of an unexpected message.
 
 ## VerneMQ 1.7.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -78,6 +78,8 @@
 - Add the `socket_close_timeout` metric. The metric counts the number of times
   VerneMQ hasn't received the MQTT CONNECT frame on time and therefore forcefully
   closed the socket.
+- Fix the potential case of late arriving `close_timeout` messages triggered
+  by the `vmq_mqtt_pre_init`.
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
The `close_timeout` is a message that gets triggered by the `vmq_mqtt_pre_init` if VerneMQ doesn't receive the MQTT CONNECT within 5 seconds after opening the connection. If the `close_timeout` is triggered VerneMQ forcefully closes the connection.

This PR adds a new metric `socket_close_timeout` which increases a counter whenever VerneMQ closes a connection due to such a timeout.

Additionally it fixes a potential race condition, where VerneMQ receives and handles the MQTT CONNECT, but the `close_timeout` has already been triggered (e.g. this could happen in overload situations). In such a case the `close_timout` message gets now properly handled by the `vmq_mqtt_fsm`/`vmq_mqtt5_fsm`. Previously this would have been handled as unexpected message, resulting in a teardown of the MQTT session.