### PR TITLE
 Fix `vmq_diversity` ACL rule hash collision issue (#1164)

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_cache.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_cache.erl
@@ -426,7 +426,7 @@ insert_cache(Key, Lts, PubAcls, SubAcls) ->
     ets:insert(table(cache), {{Key, Lts}, PubAclHashes, SubAclHashes}).
 
 insert_cache_(Table, [Rec|Rest], Acc) ->
-    AclHash = erlang:phash2(Rec),
+    AclHash = crypto:hash(sha, term_to_binary(Rec)),
     ets:update_counter(Table, AclHash,
                        {3, 1}, % Update Op
                        {AclHash, Rec, 0}),

--- a/changelog.md
+++ b/changelog.md
@@ -82,6 +82,7 @@
   by the `vmq_mqtt_pre_init`.
 - Change log level from `debug` to `warning` when VerneMQ forcefully terminates a
   MQTT session FSM because of an unexpected message.
+- Fix `vmq_diversity` ACL rule hash collision issue (#1164).
 
 ## VerneMQ 1.7.0
 


### PR DESCRIPTION
100K phash iterations: 138946 microsecs
100K t2b+md5: 234273 microsecs
100K t2b+sha1: 253248 microsec

Think SHA1 is a good tradeoff.

Fixes #1164 

