### PR TITLE
Handle errors from the variable parser correctly in vmq_mqtt_pre_init

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -47,7 +47,7 @@
 
 -define(MAX_PACKET_SIZE, 268435455).
 
--spec parse(binary()) -> {mqtt_frame(), binary()} | {error, atom()} | more.
+-spec parse(binary()) -> {mqtt_frame(), binary()} | {error, atom()} | {{error, atom()}, any()} |more.
 parse(Data) ->
     parse(Data, ?MAX_PACKET_SIZE).
 

--- a/apps/vmq_commons/src/vmq_parser_mqtt5.erl
+++ b/apps/vmq_commons/src/vmq_parser_mqtt5.erl
@@ -40,7 +40,7 @@
 parse(Data) ->
     parse(Data, ?MAX_PACKET_SIZE).
 
--spec parse(binary(), non_neg_integer()) ->  {mqtt5_frame(), binary()} | {error, atom()} | more.
+-spec parse(binary(), non_neg_integer()) ->  {mqtt5_frame(), binary()} | {error, atom()} | {{error, atom()}, any()} | more.
 parse(<<Fixed:1/binary, 0:1, DataSize:7, Data/binary>>, MaxSize)->
     parse(DataSize, MaxSize, Fixed, Data);
 parse(<<Fixed:1/binary, 1:1, L1:7, 0:1, L2:7, Data/binary>>, MaxSize) ->

--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -68,7 +68,9 @@ data_in(Data, #state{peer = Peer,
                     {stop, Reason, Out};
                 {FsmState1, Out} ->
                     {switch_fsm, vmq_mqtt_fsm, FsmState1, Rest, Out}
-            end
+            end;
+        {{error, Reason}, _} ->
+            {error, Reason, []}
     end.
 
 parse_connect_frame(Data, MaxMessageSize) ->

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 - Ensure mountpoints specified at the protocol level are inherited on the
   specific listeners.
 - Fix missing output from `vernemq version` (#1190).
+- Ensure errors from the parser variable decode are handled correctly and logged
+  at the debug level instead of causing a crash in the socket process.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
handles crashes like the following:

```
=CRASH REPORT==== 16-May-2019::09:17:19.595858 ===
  crasher:
    initial call: vmq_ranch:init/5
    pid: <0.24700.5>
    registered_name: []
    exception error: no case clause matching {{error,cant_parse_client_id},
                                              <<>>}
      in function  vmq_mqtt_pre_init:data_in/2 (/opt/vernemq/distdir/1.7.1/_build/default/lib/vmq_server/src/vmq_mqtt_pre_init.erl, line 48)
      in call from vmq_ranch:handle_message/2 (/opt/vernemq/distdir/1.7.1/_build/default/lib/vmq_server/src/vmq_ranch.erl, line 174)
      in call from vmq_ranch:loop_/1 (/opt/vernemq/distdir/1.7.1/_build/default/lib/vmq_server/src/vmq_ranch.erl, line 117)
    ancestors: [<0.332.0>,<0.331.0>,ranch_sup,<0.125.0>]
    message_queue_len: 0
    messages: []
    links: [<0.332.0>,#Port<0.42794>]
    dictionary: [{bytes_received,#Ref<0.3465811162.2341339141.250545>},
                  {socket_open,#Ref<0.3465811162.2341339141.250548>}]
    trap_exit: true
    status: running
    heap_size: 987
    stack_size: 27
    reductions: 634
  neighbours:

```