### PR TITLE
Fix missing output from `vernemq version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,13 @@ rpi32: rel
 ## Release targets
 ##
 rel:
+	cat vars.config > vars.generated
+	echo "{app_version, \"${GIT_VERSION}\"}." >> vars.generated
 ifeq ($(OVERLAY_VARS),)
-	cat vars.config > vars.generated
-	$(REBAR) $(PROFILE) release
 else
-	cat vars.config > vars.generated
 	cat $(OVERLAY_VARS) >> vars.generated
-	$(REBAR) $(PROFILE) release
 endif
+	$(REBAR) $(PROFILE) release
 
 ##
 ## Support RPM and Debian based linux systems

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 - Ensure mountpoints specified at the protocol level are inherited on the
   specific listeners.
+- Fix missing output from `vernemq version` (#1190).
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
Fixes #1190 and #1119 