### PR TITLE
Add new `no_payload` flag to the webhooks plugin

### DIFF
--- a/apps/vmq_webhooks/priv/vmq_webhooks.schema
+++ b/apps/vmq_webhooks/priv/vmq_webhooks.schema
@@ -7,53 +7,68 @@
 %% <hook> with the name <name>. Webhooks are registered in the order
 %% of the name given to it. Therefore a webhook with name 'webhook1'
 %% is regisered before a webhook with the name 'webhook2'.
-{mapping, "vmq_webhooks.$name.hook", "vmq_webhooks.user_webhooks", [
-                                                                    {datatype, {enum,
-                                                                                [auth_on_register,
-                                                                                 auth_on_publish,
-                                                                                 auth_on_subscribe,
-                                                                                 on_register,
-                                                                                 on_publish,
-                                                                                 on_subscribe,
-                                                                                 on_unsubscribe,
-                                                                                 on_deliver,
-                                                                                 on_offline_message,
-                                                                                 on_client_wakeup,
-                                                                                 on_client_offline,
-                                                                                 on_client_gone,
-                                                                                 auth_on_register_m5,
-                                                                                 auth_on_publish_m5,
-                                                                                 auth_on_subscribe_m5,
-                                                                                 on_register_m5,
-                                                                                 on_publish_m5,
-                                                                                 on_subscribe_m5,
-                                                                                 on_unsubscribe_m5,
-                                                                                 on_deliver_m5,
-                                                                                 on_auth_m5]}},
-                                                                    {commented, "auth_on_register"},
-                                                                    {include_default, "webhook1"}
-                                                                   ]}.
+{mapping, "vmq_webhooks.$name.hook", "vmq_webhooks.user_webhooks",
+ [
+  {datatype, {enum,
+              [auth_on_register,
+               auth_on_publish,
+               auth_on_subscribe,
+               on_register,
+               on_publish,
+               on_subscribe,
+               on_unsubscribe,
+               on_deliver,
+               on_offline_message,
+               on_client_wakeup,
+               on_client_offline,
+               on_client_gone,
+               auth_on_register_m5,
+               auth_on_publish_m5,
+               auth_on_subscribe_m5,
+               on_register_m5,
+               on_publish_m5,
+               on_subscribe_m5,
+               on_unsubscribe_m5,
+               on_deliver_m5,
+               on_auth_m5]}},
+  {commented, "auth_on_register"},
+  {include_default, "webhook1"}
+ ]}.
 
 %% @doc Associate an endpoint with a name.
-{mapping, "vmq_webhooks.$name.endpoint", "vmq_webhooks.user_webhooks", [
-                                                                        {datatype, string},
-                                                                        {commented, "http://localhost/myendpoints"},
-                                                                        {include_default, "webhook1"}
-                                                                       ]}.
+{mapping, "vmq_webhooks.$name.endpoint", "vmq_webhooks.user_webhooks",
+ [
+  {datatype, string},
+  {commented, "http://localhost/myendpoints"},
+  {include_default, "webhook1"}
+ ]}.
 
 %% @doc Control if the payload should be base64 encoded.
-{mapping, "vmq_webhooks.$name.base64encode", "vmq_webhooks.user_webhooks", [
-                                                                            {datatype, flag},
-                                                                            {default, on},
-                                                                            {commented, "false"},
-                                                                            {include_default, "webhook1"},
-                                                                            hidden
-                                                                           ]}.
+{mapping, "vmq_webhooks.$name.base64encode", "vmq_webhooks.user_webhooks",
+ [
+  {datatype, flag},
+  {default, on},
+  {commented, "false"},
+  {include_default, "webhook1"},
+  hidden
+ ]}.
+
+%% @doc Applies only to the auth_on_publish and auth_on_publish_m5
+%% webhooks. If true the MQTT payload is ommitted from the JSON
+%% object. Defaults to false.
+{mapping, "vmq_webhooks.$name.no_payload", "vmq_webhooks.user_webhooks",
+ [
+  {datatype, flag},
+  {default, off},
+  {commented, "false"},
+  {include_default, "webhook1"},
+  hidden
+ ]}.
 
 {translation,
  "vmq_webhooks.user_webhooks",
  fun(Conf) ->
-         Suffixes = ["hook", "endpoint", "base64encode"],
+         Suffixes = ["hook", "endpoint", "base64encode", "no_payload"],
          UNames =
              [
               proplists:get_all_values(
@@ -68,7 +83,11 @@
                   endpoint => cuttlefish:conf_get("vmq_webhooks." ++ SortName ++ ".endpoint", Conf, undefined),
                   options => 
                       #{ base64_payload =>
-                             cuttlefish:conf_get("vmq_webhooks." ++ SortName ++ ".base64encode", Conf, true)
+                             cuttlefish:conf_get("vmq_webhooks." ++ SortName ++
+                                                     ".base64encode", Conf, true),
+                         no_payload =>
+                             cuttlefish:conf_get("vmq_webhooks." ++ SortName ++
+                                                     ".no_payload", Conf, false)
                        }
                  }}
                || SortName <- HookNames ],

--- a/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
@@ -87,7 +87,13 @@ register_cmd() ->
                                     fun("true") -> true;
                                        ("false") -> false;
                                        (Val) -> {{error, {invalid_flag_value, {base64payload, Val}}}}
-                                    end}]}],
+                                    end}]},
+                {no_payload, [{longname, "no_payload"},
+                              {typecast,
+                              fun("true") -> true;
+                                 ("false") -> false;
+                                 (Val) -> {{error, {invalid_flag_value, {no_payload, Val}}}}
+                              end}]}],
     Callback =
         fun(_, [{hook, Hook}, {endpoint, Endpoint}], Flags) ->
                 Opts = get_opts(Flags),
@@ -108,9 +114,10 @@ register_cmd() ->
 
 get_opts(Flags) ->
     Defaults = #{
-      base64_payload => true
-     },
-    Keys = [base64_payload],
+                 base64_payload => true,
+                 no_payload => false
+                },
+    Keys = [base64_payload, no_payload],
     maps:merge(Defaults, maps:with(Keys, maps:from_list(Flags))).
 
 deregister_cmd() -> 
@@ -202,7 +209,11 @@ register_usage() ->
      "  Registers a webhook endpoint with a hook.",
      "\n\n"
      "  --base64payload=<true|false>\n",
-     "     base64 encode the MQTT payload. Defaults to true.",
+     "     base64 encode the MQTT payload. Defaults to true.\n",
+     "  --no_payload=<true|false>\n",
+     "     Applies only to the auth_on_publish and auth_on_publish_m5\n",
+     "     webhooks. If true the MQTT payload is ommitted from the JSON"
+     "     object. Defaults to false.",
      "\n\n"
     ].
 

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -40,6 +40,7 @@ all() ->
     [
      auth_on_register_m5_test,
      auth_on_publish_m5_test,
+     auth_on_publish_m5_no_payload_test,
      auth_on_publish_m5_modify_props_test,
      auth_on_subscribe_m5_test,
      on_register_m5_test,
@@ -52,6 +53,7 @@ all() ->
 
      auth_on_register_test,
      auth_on_publish_test,
+     auth_on_publish_no_payload_test,
      auth_on_subscribe_test,
      on_register_test,
      on_publish_test,
@@ -447,6 +449,23 @@ base64payload_test(_) ->
           auth_on_publish,
           [?USERNAME, {?MOUNTPOINT, ?BASE64_PAYLOAD_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     deregister_hook(auth_on_publish, ?ENDPOINT).
+
+
+auth_on_publish_no_payload_test(_) ->
+    ok = clique:run(["vmq-admin", "webhooks", "register",
+                     "hook=auth_on_publish", "endpoint=" ++ ?ENDPOINT, "--no_payload=true", "--base64payload=true"]),
+    ok = vmq_plugin:all_till_ok(
+          auth_on_publish,
+          [?USERNAME, {?MOUNTPOINT, ?NO_PAYLOAD_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
+    deregister_hook(auth_on_publish, ?ENDPOINT).
+
+auth_on_publish_m5_no_payload_test(_) ->
+    ok = clique:run(["vmq-admin", "webhooks", "register",
+                     "hook=auth_on_publish_m5", "endpoint=" ++ ?ENDPOINT, "--no_payload=true"]),
+    ok = vmq_plugin:all_till_ok(
+          auth_on_publish_m5,
+          [?USERNAME, {?MOUNTPOINT, ?NO_PAYLOAD_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #{}]),
+    deregister_hook(auth_on_publish_m5, ?ENDPOINT).
 
 auth_on_register_undefined_creds_test(_) ->
     register_hook(auth_on_register, ?ENDPOINT),

--- a/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
@@ -6,6 +6,7 @@
 -define(IGNORED_CLIENT_ID, <<"ignored-subscriber-id">>).
 -define(ALLOWED_CLIENT_ID, <<"allowed-subscriber-id">>).
 -define(BASE64_PAYLOAD_CLIENT_ID, <<"payload-is-base64-encoded">>).
+-define(NO_PAYLOAD_CLIENT_ID, <<"no-payload">>).
 -define(WITH_PROPERTIES, <<"with_properties">>).
 -define(NOT_ALLOWED_CLIENT_ID, <<"not-allowed-subscriber-id">>).
 -define(SERVER_ERR_SUBSCIBER_ID, <<"internal-server-error">>).

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -161,6 +161,15 @@ auth_on_publish(#{username := ?USERNAME,
     ?PAYLOAD = base64:decode(Base64Payload),
     {200, #{result => <<"ok">>,
             modifiers => #{payload => base64:encode(?PAYLOAD)}}};
+auth_on_publish(#{username := ?USERNAME,
+                  client_id := ?NO_PAYLOAD_CLIENT_ID,
+                  mountpoint := ?MOUNTPOINT_BIN,
+                  qos := 1,
+                  topic := ?TOPIC,
+                  retain := false
+                 }=Args) ->
+    false = maps:is_key(payload, Args),
+    {200, #{result => <<"ok">>}};
 auth_on_publish(#{client_id := ?NOT_ALLOWED_CLIENT_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
 auth_on_publish(#{client_id := ?IGNORED_CLIENT_ID}) ->
@@ -191,6 +200,15 @@ auth_on_publish_m5(#{username := ?USERNAME,
     ?PAYLOAD = base64:decode(Base64Payload),
     {200, #{result => <<"ok">>,
             modifiers => #{payload => base64:encode(?PAYLOAD)}}};
+auth_on_publish_m5(#{username := ?USERNAME,
+                     client_id := ?NO_PAYLOAD_CLIENT_ID,
+                     mountpoint := ?MOUNTPOINT_BIN,
+                     qos := 1,
+                     topic := ?TOPIC,
+                     retain := false
+                    }=Args) ->
+    false = maps:is_key(payload, Args),
+    {200, #{result => <<"ok">>}};
 auth_on_publish_m5(#{client_id := ?NOT_ALLOWED_CLIENT_ID}) ->
     {200, #{result => #{error => <<"not_allowed">>}}};
 auth_on_publish_m5(#{client_id := ?IGNORED_CLIENT_ID}) ->

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@
 - Fix warnings due to deprecated lager configuration (#1209).
 - Upgrade `lager` to version *3.7.0* (In preparation for OTP 22 support).
 - Make VerneMQ run on Erlang/OTP 22.
+- Add new webhooks CLI register flag `--no_payload=true` which, if enabled, will
+  remove the MQTT payload from the JSON object send via the `auth_on_publish`
+  and `auth_on_publish_m5` payloads. The flag can also be set in the config file
+  using `vmq_webhooks.hookname.no_payload=on`.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
The flag prevents the payload to be sent in the JSON object for the
`auth_on_publish` and `auth_on_publish_m5` webhooks.

This adds a new `no_payload` flag on the webhooks CLI and in the webhooks schema file. The flag in the schema file is hidden.

Note - the docs would need to be updated with this.