### PR TITLE
Add client keepalive expiration metric

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -71,8 +71,6 @@
          incr_queue_in/1,
          incr_queue_out/1,
 
-         incr_client_expired/0,
-
          incr_cluster_bytes_sent/1,
          incr_cluster_bytes_received/1,
          incr_cluster_bytes_dropped/1,
@@ -237,10 +235,6 @@ incr_queue_in(N) ->
 
 incr_queue_out(N) ->
     incr_item(?METRIC_QUEUE_MESSAGE_OUT, N).
-
-incr_client_expired() ->
-    incr_item(?METRIC_CLIENT_EXPIRED, 1).
-
 
 incr_cluster_bytes_received(V) ->
     incr_item(?METRIC_CLUSTER_BYTES_RECEIVED, V).
@@ -686,6 +680,7 @@ counter_entries_def() ->
      m(counter, [{mqtt_version,"4"}], mqtt_publish_error, mqtt_publish_error, <<"The number of times a PUBLISH operation failed due to a netsplit.">>),
      m(counter, [{mqtt_version,"4"}], mqtt_subscribe_error, mqtt_subscribe_error, <<"The number of times a SUBSCRIBE operation failed due to a netsplit.">>),
      m(counter, [{mqtt_version,"4"}], mqtt_unsubscribe_error, mqtt_unsubscribe_error, <<"The number of times an UNSUBSCRIBE operation failed due to a netsplit.">>),
+     m(counter, [{mqtt_version,"4"}], ?MQTT4_CLIENT_KEEPALIVE_EXPIRED, client_keepalive_expired, <<"The number of clients which failed to communicate within the keepalive time period.">>),
 
      m(counter, [{mqtt_version,"5"}], ?MQTT5_CONNECT_RECEIVED, mqtt_connect_received, <<"The number of CONNECT packets received.">>),
      m(counter, [{mqtt_version,"5"}], ?MQTT5_INVALID_MSG_SIZE_ERROR, mqtt_invalid_msg_size_error, <<"The number of packages exceeding the maximum allowed size.">>),
@@ -704,6 +699,7 @@ counter_entries_def() ->
      m(counter, [{mqtt_version,"5"}], ?MQTT5_UNSUBACK_SENT, mqtt_unsuback_sent, <<"The number of UNSUBACK packets sent.">>),
      m(counter, [{mqtt_version,"5"}], ?MQTT5_UNSUBSCRIBE_ERROR, mqtt_unsubscribe_error, <<"The number of times an UNSUBSCRIBE operation failed due to a netsplit.">>),
      m(counter, [{mqtt_version,"5"}], ?MQTT5_UNSUBSCRIBE_RECEIVED, mqtt_unsubscribe_received, <<"The number of UNSUBSCRIBE packets received.">>),
+     m(counter, [{mqtt_version,"5"}], ?MQTT5_CLIENT_KEEPALIVE_EXPIRED, client_keepalive_expired, <<"The number of clients which failed to communicate within the keepalive time period.">>),
 
      m(counter, [], queue_setup, queue_setup, <<"The number of times a MQTT queue process has been started.">>),
      m(counter, [], queue_initialized_from_storage, queue_initialized_from_storage, <<"The number of times a MQTT queue process has been initialized from offline storage.">>),
@@ -1281,4 +1277,6 @@ met2idx(mqtt_connack_server_unavailable_sent)                     -> 190;
 met2idx(mqtt_connack_identifier_rejected_sent)                    -> 191;
 met2idx(mqtt_connack_unacceptable_protocol_sent)                  -> 192;
 met2idx(mqtt_connack_accepted_sent)                               -> 193;
-met2idx(?METRIC_SOCKET_CLOSE_TIMEOUT)                             -> 194.
+met2idx(?METRIC_SOCKET_CLOSE_TIMEOUT)                             -> 194;
+met2idx(?MQTT5_CLIENT_KEEPALIVE_EXPIRED)                          -> 195;
+met2idx(?MQTT4_CLIENT_KEEPALIVE_EXPIRED)                          -> 196.

--- a/apps/vmq_server/src/vmq_metrics.hrl
+++ b/apps/vmq_server/src/vmq_metrics.hrl
@@ -44,6 +44,7 @@
 -define(MQTT5_UNSUBSCRIBE_RECEIVED, mqtt5_unsubscribe_received).
 -define(MQTT5_AUTH_SENT, mqtt5_auth_sent).
 -define(MQTT5_AUTH_RECEIVED, mqtt5_auth_received).
+-define(MQTT5_CLIENT_KEEPALIVE_EXPIRED, mqtt5_client_keepalive_expired).
 
 
 -define(MQTT4_CONNACK_SENT, mqtt_connack_sent).
@@ -74,6 +75,7 @@
 -define(MQTT4_PUBLISH_ERROR, mqtt_publish_error).
 -define(MQTT4_SUBSCRIBE_ERROR, mqtt_subscribe_error).
 -define(MQTT4_UNSUBSCRIBE_ERROR, mqtt_unsubscribe_error).
+-define(MQTT4_CLIENT_KEEPALIVE_EXPIRED, mqtt4_client_keepalive_expired).
 -define(METRIC_QUEUE_SETUP, queue_setup).
 -define(METRIC_QUEUE_INITIALIZED_FROM_STORAGE, queue_initialized_from_storage).
 -define(METRIC_QUEUE_TEARDOWN, queue_teardown).
@@ -82,7 +84,7 @@
 -define(METRIC_QUEUE_MESSAGE_UNHANDLED, queue_message_unhandled).
 -define(METRIC_QUEUE_MESSAGE_IN, queue_message_in).
 -define(METRIC_QUEUE_MESSAGE_OUT, queue_message_out).
--define(METRIC_CLIENT_EXPIRED, client_expired).
+-define(METRIC_CLIENT_EXPIRED, client_expired). %% unused/deprecated
 -define(METRIC_CLUSTER_BYTES_RECEIVED, cluster_bytes_received).
 -define(METRIC_CLUSTER_BYTES_SENT, cluster_bytes_sent).
 -define(METRIC_CLUSTER_BYTES_DROPPED, cluster_bytes_dropped).

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -649,6 +649,7 @@ connected(check_keepalive, #state{last_time_active=Last, keep_alive=KeepAlive,
     case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
         true ->
             lager:warning("client ~p with username ~p stopped due to keepalive expired", [SubscriberId, UserName]),
+            _ = vmq_metrics:incr(?MQTT5_CLIENT_KEEPALIVE_EXPIRED),
             terminate(?KEEP_ALIVE_TIMEOUT, State);
         false ->
             set_keepalive_check_timer(KeepAlive),

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -429,6 +429,7 @@ connected(check_keepalive, #state{last_time_active=Last, keep_alive=KeepAlive,
     case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
         true ->
             lager:warning("client ~p with username ~p stopped due to keepalive expired", [SubscriberId, UserName]),
+            _ = vmq_metrics:incr(?MQTT4_CLIENT_KEEPALIVE_EXPIRED),
             terminate(normal, State);
         false ->
             set_keepalive_check_timer(KeepAlive),

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
   remove the MQTT payload from the JSON object send via the `auth_on_publish`
   and `auth_on_publish_m5` payloads. The flag can also be set in the config file
   using `vmq_webhooks.hookname.no_payload=on`.
+- Add metric `client_keepalive_expired` which tracks clients that failed to
+  communicate within the keepalive time.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
This adds a new metric `client_keepalive_expired` tracking MQTT keepalive violations.

The initial idea was to use the `client_expiry` metrics was is marked as unused and deprecated. It's not clear to me what the original idea behind `client_expiry` was but perhaps it was thought as to track `persistent_client_expiration`? In any case I thought the name  `client_expiry` was too vague so I didn't re-enable this one, but rather added a new one. If we want to add a metric tracking `persistent_client_expiration` events we could call it `persistent_client_expired` or `offline_client_expired`.