### PR TITLE
Make it possible to reload `vmq_webhooks` config from schema format

### DIFF
--- a/apps/vmq_webhooks/src/vmq_webhooks_sup.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_sup.erl
@@ -24,7 +24,7 @@ start_link() ->
         {ok, _} = Ret ->
             spawn(fun() ->
                           Webhooks = application:get_env(vmq_webhooks, user_webhooks, []),
-                          register_webhooks(Webhooks)
+                          ok = vmq_webhooks_app:register_webhooks(Webhooks)
                   end),
             Ret;
         E -> E
@@ -49,14 +49,3 @@ init([]) ->
 %% Internal functions
 %%====================================================================
 
-register_webhooks(Webhooks) ->
-    [ register_webhook(Webhook) || Webhook <- Webhooks ].
-
-register_webhook({Name, #{hook := HookName, endpoint := Endpoint, options := Opts}}) ->
-    case vmq_webhooks_plugin:register_endpoint(Endpoint, HookName, Opts) of
-        ok ->
-            ok;
-        {error, Reason} ->
-            lager:error("failed to register the ~p webhook ~p ~p ~p due to ~p",
-                        [Name, Endpoint, HookName, Opts, Reason])
-    end.

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 - Fix warnings due to deprecated lager configuration (#1209).
 - Upgrade `lager` to version *3.7.0* (In preparation for OTP 22 support).
 - Make VerneMQ run on Erlang/OTP 22.
+- Make it possible to reconfigure the `vmq_webhooks` plugin using the schema
+  format. This makes it possible to dynamically change the configuration from
+  the VerneMQ Kubernetes operator.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
This PR makes it possible to reload the webhooks config using the config format defined by the schema file. This is required for the current approach taken in the vernemq operator for dynamically reloading plugin configurations.