### PR TITLE
Handle retained bit in the bridge (vmq_bridge)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 - Upgrade cowboy to version 2.6.3 as well as cowlib and ranch to versions 2.7.3
   and 1.7.1 respectively. This update also means the PROXY protocol code was
   removed and the PROXY support from cowboy is used instead.
+- Handle retained flag in the bridge plugin (vmq_bridge).
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
This should fix #1223 

I'm not sure why we didn't forward the retain bits before - to me it looks like an oversight. Note that this PR changes the `gen_mqtt_client` behaviour callback definition for the `publish` function.

I think this is a bug, I've therefore included it into the 1.8.1 milestone.