### PR TITLE
Replace duplicate is_binary(Pass) check

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -3,6 +3,7 @@ The following people have contributed to VerneMQ, or one of its plugins or libra
 THANKS A LOT
 ------------
 
+Dan Ambrisco (@dambrisco)
 Johanna Appel
 Dairon Medina Caro (@codeadict)
 craftup (baranga)

--- a/apps/vmq_diversity/src/vmq_diversity_bcrypt.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_bcrypt.erl
@@ -30,6 +30,6 @@ gen_salt(_, St) ->
     {ok, Salt} = bcrypt:gen_salt(),
     {[list_to_binary(Salt)], St}.
 
-hashpw([Pass, Salt], St) when is_binary(Pass) and is_binary(Pass) ->
+hashpw([Pass, Salt], St) when is_binary(Pass) and is_binary(Salt) ->
     {ok, Hash} = bcrypt:hashpw(Pass, Salt),
     {[list_to_binary(Hash)], St}.

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,8 @@
   http://erlang.org/doc/man/crypto.html#Digests%20and%20hash. If passed an
   unknown hashing algorithm an error is raised.
 - Fix prefix handling in the bridge plugin (vmq_bridge).
+- Strengthen parameter validation in the `bcrypt.hashpw/2` LUA function in
+  `vmq_diversity`.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
The code seems to imply the second check should be `is_binary(Salt)`. I have not tested this change, this PR is intended merely as a convenience if, in fact, this was a simple duplication error.