### PR TITLE
Separate command-line args from `su` options in `check_user`.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -8,6 +8,7 @@ Johanna Appel
 Dairon Medina Caro (@codeadict)
 craftup (baranga)
 Riccardo Binetti (@rbino)
+Jordan Carlson (@jwgcarlson)
 Justin Crown
 Lars Hesel Christensen
 Mihail Davydenkov

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 - Fix prefix handling in the bridge plugin (vmq_bridge).
 - Strengthen parameter validation in the `bcrypt.hashpw/2` LUA function in
   `vmq_diversity`.
+- Pass arguments correctly to `vmq-admin` when called via `sudo`.
 
 ## VerneMQ 1.8.0
 

--- a/files/env.sh
+++ b/files/env.sh
@@ -244,7 +244,7 @@ check_user() {
 
         # This will drop priviledges into the runner user
         # It exec's in a new shell and the current shell will exit
-        exec su - $RUNNER_USER -s $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT "$ESCAPED_ARGS"
+        exec su - $RUNNER_USER -s $RUNNER_SCRIPT_DIR/$RUNNER_SCRIPT -- "$ESCAPED_ARGS"
     fi
 }
 


### PR DESCRIPTION
This makes `sudo vmq-admin --help` do something sensible, rather than just exec'ing `su --help`.

Fixes #1239. (Only tested on Linux though.)
