### PR TITLE
Fix Grafana metrics

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -33,6 +33,7 @@ Torsten Rehn
 Tristan Sloughter
 Artur Sobierak
 Ivan Subotic
+Anton Troyanov (@troyanov)
 SoftAtHome (https://softathome.com/)
 testark
 urjitbhatia

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 - Strengthen parameter validation in the `bcrypt.hashpw/2` LUA function in
   `vmq_diversity`.
 - Pass arguments correctly to `vmq-admin` when called via `sudo`.
+- Handle rate metric labels correctly in the example grafana dashboard.
 
 ## VerneMQ 1.8.0
 

--- a/metrics_scripts/grafana/VerneMQ Node Metrics.json
+++ b/metrics_scripts/grafana/VerneMQ Node Metrics.json
@@ -259,7 +259,7 @@
           },
           "targets": [
             {
-              "expr": "rate(mqtt_publish_received[30s])",
+              "expr": "sum(rate(mqtt_publish_received[30s]))",
               "hide": false,
               "intervalFactor": 2,
               "metric": "mqtt_publish_sent",
@@ -336,7 +336,7 @@
           },
           "targets": [
             {
-              "expr": "rate(mqtt_publish_sent[30s])",
+              "expr": "sum(rate(mqtt_publish_sent[30s]))",
               "intervalFactor": 2,
               "metric": "mqtt_publish_sent",
               "refId": "A",


### PR DESCRIPTION
Metrics 'Current MQTT send rate' and 'Current MQTT Receive rate' might not work because of 'Multiple Series Error'.
This happens when you have both mqtt_version="4" and mqtt_version="5".

To fix this error we can simply apply sum() to get a summary rate on all versions.