### PR TITLE
Ensure systemd doesn't terminate VerneMQ if it is slow to start

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
   and 1.7.1 respectively. This update also means the PROXY protocol code was
   removed and the PROXY support from cowboy is used instead.
 - Handle retained flag in the bridge plugin (vmq_bridge).
+- Ensure systemd doesn't terminate VerneMQ if it is slow to start.
 
 ## VerneMQ 1.8.0
 

--- a/files/vernemq-centos.service
+++ b/files/vernemq-centos.service
@@ -11,6 +11,7 @@ User=vernemq
 Group=vernemq
 NotifyAccess=all
 LimitNOFILE=infinity
+Environment="WAIT_FOR_ERLANG=3600"
 TimeoutStartSec=3600
 RuntimeDirectory=vernemq
 WorkingDirectory=/usr/lib64/vernemq

--- a/files/vernemq.service
+++ b/files/vernemq.service
@@ -11,6 +11,7 @@ User=vernemq
 Group=vernemq
 NotifyAccess=all
 LimitNOFILE=infinity
+Environment="WAIT_FOR_ERLANG=3600"
 TimeoutStartSec=3600
 RuntimeDirectory=vernemq
 WorkingDirectory=/usr/lib/vernemq


### PR DESCRIPTION
fixes #1251