### PR TITLE
Fix message store startup consistency checking routine

### DIFF
--- a/apps/vmq_server/src/vmq_lvldb_store.erl
+++ b/apps/vmq_server/src/vmq_lvldb_store.erl
@@ -350,7 +350,7 @@ handle_req({write, {MP, _} = SubscriberId,
             eleveldb:write(Bucket, [{put, MsgKey, Val},
                                     {put, IdxKey, IdxVal}], WriteOpts);
         _ ->
-            %% only write ref
+            %% only write the idx
             eleveldb:write(Bucket, [{put, IdxKey, IdxVal}], WriteOpts)
     end;
 handle_req({read, {MP, _} = SubscriberId, MsgRef},
@@ -384,7 +384,7 @@ handle_req({delete, {MP, _} = SubscriberId, MsgRef},
             eleveldb:write(Bucket, [{delete, IdxKey},
                                     {delete, MsgKey}], WriteOpts);
         _ ->
-            %% we have to keep the message, but can delete the ref and idx
+            %% we have to keep the message, but can delete the idx
             eleveldb:write(Bucket, [{delete, IdxKey}], WriteOpts)
     end;
 handle_req({find_for_subscriber_id, SubscriberId},

--- a/apps/vmq_server/src/vmq_lvldb_store.erl
+++ b/apps/vmq_server/src/vmq_lvldb_store.erl
@@ -150,7 +150,7 @@ init([InstanceId]) ->
             case setup_index(State) of
                 0 -> ok;
                 N ->
-                    lager:info("indexed ~n offline messages in msg store instance ~p",
+                    lager:info("indexed ~p offline messages in msg store instance ~p",
                                [N, InstanceId])
             end,
             %% Register Bucket Instance with the Bucket Registry

--- a/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
+++ b/apps/vmq_server/test/vmq_lvldb_store_SUITE.erl
@@ -60,12 +60,12 @@ all() ->
 %%% Actual Tests
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 insert_delete_test(Config) ->
-    {0,0,0} = store_summary(),
+    {0,0} = store_summary(),
     Msgs = generate_msgs(1000, []),
     Refs = [Ref || #vmq_msg{msg_ref=Ref} <- Msgs],
     ok = store_msgs({"", "foo"}, Msgs),
 
-    {1000,1000,1000} = store_summary(),
+    {1000,1000} = store_summary(),
 
     1000 = refcount(Refs, 0),
     %% we should get back the exact same list
@@ -75,11 +75,11 @@ insert_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo"}),
 
     0 = refcount(Refs, 0),
-    {0,0,0} = store_summary(),
+    {0,0} = store_summary(),
     Config.
 
 ref_delete_test(Config) ->
-    {0,0,0} = store_summary(),
+    {0,0} = store_summary(),
     Msgs = generate_msgs(1000, []),
     Refs = [Ref || #vmq_msg{msg_ref=Ref} <- Msgs],
     ok = store_msgs({"", "foo0"}, Msgs),
@@ -94,7 +94,7 @@ ref_delete_test(Config) ->
     ok = store_msgs({"", "foo9"}, Msgs),
 
     10000 = refcount(Refs, 0),
-    {1000,10000,10000} = store_summary(),
+    {1000,10000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo0"}),
     {ok, Msgs} = read_msgs({"", "foo0"}, Refs),
@@ -102,7 +102,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo0"}),
 
     9000 = refcount(Refs, 0),
-    {1000,9000,9000} = store_summary(),
+    {1000,9000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo1"}),
     {ok, Msgs} = read_msgs({"", "foo1"}, Refs),
@@ -110,7 +110,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo1"}),
 
     8000 = refcount(Refs, 0),
-    {1000,8000,8000} = store_summary(),
+    {1000,8000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo2"}),
     {ok, Msgs} = read_msgs({"", "foo2"}, Refs),
@@ -118,7 +118,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo2"}),
 
     7000 = refcount(Refs, 0),
-    {1000,7000,7000} = store_summary(),
+    {1000,7000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo3"}),
     {ok, Msgs} = read_msgs({"", "foo3"}, Refs),
@@ -126,7 +126,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo3"}),
 
     6000 = refcount(Refs, 0),
-    {1000,6000,6000} = store_summary(),
+    {1000,6000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo4"}),
     {ok, Msgs} = read_msgs({"", "foo4"}, Refs),
@@ -134,7 +134,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo4"}),
 
     5000 = refcount(Refs, 0),
-    {1000,5000,5000} = store_summary(),
+    {1000,5000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo5"}),
     {ok, Msgs} = read_msgs({"", "foo5"}, Refs),
@@ -142,7 +142,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo5"}),
 
     4000 = refcount(Refs, 0),
-    {1000,4000,4000} = store_summary(),
+    {1000,4000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo6"}),
     {ok, Msgs} = read_msgs({"", "foo6"}, Refs),
@@ -150,7 +150,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo6"}),
 
     3000 = refcount(Refs, 0),
-    {1000,3000,3000} = store_summary(),
+    {1000,3000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo7"}),
     {ok, Msgs} = read_msgs({"", "foo7"}, Refs),
@@ -158,7 +158,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo7"}),
 
     2000 = refcount(Refs, 0),
-    {1000,2000,2000} = store_summary(),
+    {1000,2000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo8"}),
     {ok, Msgs} = read_msgs({"", "foo8"}, Refs),
@@ -166,7 +166,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo8"}),
 
     1000 = refcount(Refs, 0),
-    {1000,1000,1000} = store_summary(),
+    {1000,1000} = store_summary(),
 
     {ok, Refs} = vmq_lvldb_store:msg_store_find({"", "foo9"}),
     {ok, Msgs} = read_msgs({"", "foo9"}, Refs),
@@ -174,7 +174,7 @@ ref_delete_test(Config) ->
     {ok, []} = vmq_lvldb_store:msg_store_find({"", "foo9"}),
 
     0 = refcount(Refs, 0),
-    {0,0,0} = store_summary(),
+    {0,0} = store_summary(),
 
     Config.
 
@@ -262,11 +262,9 @@ random_qos() ->
 store_summary() ->
     vmq_lvldb_store_utils:full_table_scan(
       fun
-          ({msg, _, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
-              {NumMsgs + 1, NumRefs, NumIdxs};
-          ({ref, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
-              {NumMsgs, NumRefs + 1, NumIdxs};
-          ({idx, _, _, _, _}, {NumMsgs, NumRefs, NumIdxs}) ->
-              {NumMsgs, NumRefs, NumIdxs + 1}
-      end, {0,0,0}).
+          ({msg, _, _, _, _}, {NumMsgs, NumIdxs}) ->
+              {NumMsgs + 1, NumIdxs};
+          ({idx, _, _, _, _}, {NumMsgs, NumIdxs}) ->
+              {NumMsgs, NumIdxs + 1}
+      end, {0,0}).
 

--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,12 @@
   connecting to VerneMQ such that the retained bit is kept on messages routed to
   the bridge (Retained as Publish) and messages coming from the bridge are not
   forwarded to the bridge if it has a matching description (No Local).
+- Fix message store startup consistency checking routine which resulted in
+  potentially deleting wrong messages in cases where an inconsistency was detected.
+  This fix also increases message storage performance during startup as well as
+  during normal operation. However, the nature of the bug and the provided solution
+  don't enable a simple downgrade path and introduces a backward incompatibility if
+  a VerneMQ message store containing offline messages has to be downgraded to 1.8.0.
 
 ## VerneMQ 1.8.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -44,7 +44,8 @@
   This fix also increases message storage performance during startup as well as
   during normal operation. However, the nature of the bug and the provided solution
   don't enable a simple downgrade path and introduces a backward incompatibility if
-  a VerneMQ message store containing offline messages has to be downgraded to 1.8.0.
+  a VerneMQ message store containing offline messages has to be downgraded to 1.8.0
+  or earlier versions.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
Fix message store startup consistency checking routine which resulted in
  potentially deleting wrong messages in cases where an inconsistency was detected.
  This fix also increases message storage performance during startup as well as
  during normal operation. However, the nature of the bug and the provided solution
  don't enable a simple downgrade path and introduces a backward incompatibility if
  a VerneMQ message store containing offline messages has to be downgraded to 1.8.0.