### PR TITLE
Add `username` modifier for `auth_on_register` hooks

### DIFF
--- a/apps/vmq_commons/src/packetv5.erl
+++ b/apps/vmq_commons/src/packetv5.erl
@@ -4,7 +4,8 @@
          do_client_connect/3,
          expect_frame/2,
          receive_frame/1,
-         receive_frame/3]).
+         receive_frame/3,
+         receive_frame/4]).
 
 -export([gen_connect/2,
          gen_connack/0,
@@ -175,15 +176,15 @@ receive_frame(Socket) ->
 receive_frame(Transport, Socket) ->
     receive_frame(Transport, Socket, 5000).
 receive_frame(Transport, Socket, Timeout) ->
-    receive_frame_(Transport, Socket, Timeout, <<>>).
+    receive_frame(Transport, Socket, Timeout, <<>>).
 
-receive_frame_(Transport, Socket, Timeout, Incomplete) ->
+receive_frame(Transport, Socket, Timeout, Incomplete) ->
     case Transport:recv(Socket, 0, Timeout) of
         {ok, Data} ->
             NewData = <<Incomplete/binary, Data/binary>>,
             case vmq_parser_mqtt5:parse(NewData) of
                 more ->
-                    receive_frame_(Transport, Socket, Timeout, NewData);
+                    receive_frame(Transport, Socket, Timeout, NewData);
                 {error, R} ->
                     {error, R};
                 {Frame, Rest} ->

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -28,13 +28,17 @@ function auth_on_register(reg)
     assert(reg.username == "test-user")
     assert(reg.password == "test-password")
     assert(reg.clean_session == true)
-    if reg.client_id ~= "changed-subscriber-id" then
+    if reg.client_id == "changed-subscriber-id" then
+         -- we must change subscriber_id
+        print("auth_on_register changed subscriber_id called")
+        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
+    elseif reg.client_id == "changed-username" then
+        -- we must change username
+        print("auth_on_register changed username called")
+        return {username = "override-username"}
+    else
         print("auth_on_register called")
         return validate_client_id(reg.client_id)
-    else
-        -- we must change properties
-        print("auth_on_register changed called")
-        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
     end
 end
 
@@ -183,13 +187,17 @@ function auth_on_register_m5(reg)
     assert(reg.username == "test-user")
     assert(reg.password == "test-password")
     assert(reg.clean_start == true)
-    if reg.client_id ~= "changed-subscriber-id" then
+    if reg.client_id == "changed-subscriber-id" then
+        -- we must change subscriber_id
+        print("auth_on_register_m5 changed subscriber_id called")
+        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
+    elseif reg.client_id == "changed-username" then
+       -- we must change username
+       print("auth_on_register_m5 changed username called")
+       return {username = "override-username"} 
+    else
         print("auth_on_register_m5 called")
         return validate_client_id(reg.client_id)
-    else
-        -- we must change subscriberid
-        print("auth_on_register_m5 changed called")
-        return {subscriber_id = {mountpoint = "override-mountpoint", client_id = "override-client-id"}}
     end
     -- reg.properties are ignored for now.
 end

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -73,7 +73,9 @@ auth_on_register_test(_) ->
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register,
                       [peer(), ignored_subscriber_id(), username(), password(), true]),
     {ok, [{subscriber_id, {"override-mountpoint", <<"override-client-id">>}}]} = vmq_plugin:all_till_ok(auth_on_register,
-                      [peer(), changed_subscriber_id(), username(), password(), true]).
+                      [peer(), changed_subscriber_id(), username(), password(), true]),
+    {ok, [{username, <<"override-username">>}]} = vmq_plugin:all_till_ok(auth_on_register,
+                      [peer(), changed_username(), username(), password(), true]).
 
 props() ->
     #{p_user_property => [{<<"key1">>, <<"val1">>}]}.
@@ -160,7 +162,9 @@ auth_on_register_m5_test(_) ->
     {error, chain_exhausted} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [peer(), ignored_subscriber_id(), username(), password(), true, #{}]),
     {ok, #{subscriber_id := {"override-mountpoint", <<"override-client-id">>}}} = vmq_plugin:all_till_ok(auth_on_register_m5,
-                      [peer(), changed_subscriber_id(), username(), password(), true, #{}]).
+                      [peer(), changed_subscriber_id(), username(), password(), true, #{}]),
+    {ok, [{username, <<"override-username">>}]} = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [peer(), changed_username(), username(), password(), true, #{}]).
 
 auth_on_register_m5_modify_props_test(_) ->
     WantUserProps = [{<<"k1">>, <<"v1">>},
@@ -294,6 +298,8 @@ not_allowed_subscriber_id() ->
 changed_subscriber_id() ->
     {"", <<"changed-subscriber-id">>}.
 
+changed_username() ->
+    {"", <<"changed-username">>}.
 
 username() -> <<"test-user">>.
 password() -> <<"test-password">>.

--- a/apps/vmq_plugin/src/vmq_plugin_util.erl
+++ b/apps/vmq_plugin/src/vmq_plugin_util.erl
@@ -103,6 +103,7 @@ modifiers(auth_on_register) ->
      {allow_unsubscribe, fun val_bool/1},
      {max_message_size, fun val_int/1},
      {subscriber_id, fun val_subscriber_id/1},
+     {username, fun val_binary/1},
      {clean_session, fun val_bool/1},
      {max_message_rate, fun val_int/1},
      {max_inflight_messages, fun val_int/1},

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1024,6 +1024,7 @@ auth_on_register(User, Password, Props, State) ->
 
             ChangedState = State#state{
                              subscriber_id=?state_val(subscriber_id, Args, State),
+                             username=?state_val(username, Args, State),
                              clean_start=?state_val(clean_start, Args, State),
                              session_expiry_interval=?state_val(session_expiry_interval, Args, State),
                              reg_view=?state_val(reg_view, Args, State),

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -640,6 +640,7 @@ auth_on_register(User, Password, State) ->
 
             ChangedState = State#state{
                              subscriber_id=?state_val(subscriber_id, Args, State),
+                             username=?state_val(username, Args, State),
                              clean_session=?state_val(clean_session, Args, State),
                              reg_view=?state_val(reg_view, Args, State),
                              max_message_rate=?state_val(max_message_rate, Args, State),

--- a/apps/vmq_server/test/vmq_retain_SUITE.erl
+++ b/apps/vmq_server/test/vmq_retain_SUITE.erl
@@ -359,11 +359,11 @@ subscribe_retain_as_published_test(Cfg) ->
     {ok, #mqtt5_publish{
             retain = 1,
             payload = <<"msg1">>
-           }, <<>>} = packetv5:receive_frame(Socket),
+           }, Rest0} = packetv5:receive_frame(Socket),
     {ok, #mqtt5_publish{
             retain = 0,
             payload = <<"msg2">>
-           }, <<>>} = packetv5:receive_frame(Socket),
+           }, <<>>} = packetv5:receive_frame(gen_tcp, Socket, 5000, Rest0),
 
     %% Test subscription with RAP false
     PublishRetainedRapFalse = packetv5:gen_publish(TopicRapFalse, 0, <<"msg3">>, [{retain, true}]),
@@ -375,11 +375,11 @@ subscribe_retain_as_published_test(Cfg) ->
     {ok, #mqtt5_publish{
             retain = 0,
             payload = <<"msg3">>
-           }, <<>>} = packetv5:receive_frame(Socket),
+           }, Rest1} = packetv5:receive_frame(Socket),
     {ok, #mqtt5_publish{
             retain = 0,
             payload = <<"msg4">>
-           }, <<>>} = packetv5:receive_frame(Socket),
+           }, <<>>} = packetv5:receive_frame(gen_tcp, Socket, 5000, Rest1),
 
     Disconnect = packetv5:gen_disconnect(),
     ok = gen_tcp:send(Socket, Disconnect),

--- a/apps/vmq_server/test/vmq_subscribe_SUITE.erl
+++ b/apps/vmq_server/test/vmq_subscribe_SUITE.erl
@@ -34,8 +34,7 @@ end_per_testcase(_, Config) ->
 all() ->
     [
      {group, mqttv4},
-     {group, mqttv5},
-     {group, try_private}
+     {group, mqttv5}
     ].
 
 groups() ->

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -169,6 +169,8 @@ auth_on_register_test(_) ->
     {ok, [{subscriber_id,
            {"mynewmount", <<"changed_client_id">>}}]} = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
+    {ok, [{username, <<"changed_username">>}]} = vmq_plugin:all_till_ok(auth_on_register,
+                      [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?CHANGED_USERNAME, ?PASSWORD, true]),
     deregister_hook(auth_on_register, ?ENDPOINT).
 
 auth_on_publish_test(_) ->
@@ -250,6 +252,8 @@ auth_on_register_m5_test(_) ->
     {ok, #{subscriber_id :=
            {"mynewmount", <<"changed_client_id">>}}} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true, #{}]),
+    {ok, [{username, <<"changed_username">>}]} = vmq_plugin:all_till_ok(auth_on_register_m5,
+                      [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?CHANGED_USERNAME, ?PASSWORD, true, #{}]),
     WantUserProps = [{<<"k1">>, <<"v1">>},
                      {<<"k1">>, <<"v2">>},
                      {<<"k2">>, <<"v2">>}],

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -252,7 +252,7 @@ auth_on_register_m5_test(_) ->
     {ok, #{subscriber_id :=
            {"mynewmount", <<"changed_client_id">>}}} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true, #{}]),
-    {ok, [{username, <<"changed_username">>}]} = vmq_plugin:all_till_ok(auth_on_register_m5,
+    {ok, #{username := <<"changed_username">>}} = vmq_plugin:all_till_ok(auth_on_register_m5,
                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?CHANGED_USERNAME, ?PASSWORD, true, #{}]),
     WantUserProps = [{<<"k1">>, <<"v1">>},
                      {<<"k1">>, <<"v2">>},

--- a/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
@@ -14,6 +14,7 @@
 -define(MOUNTPOINT_BIN, <<"mountpoint">>).
 -define(CHANGED_CLIENT_ID, <<"changed-subscriber-id">>).
 -define(USERNAME, <<"test-user">>).
+-define(CHANGED_USERNAME, <<"changed-user">>).
 -define(PASSWORD, <<"test-password">>).
 -define(TOPIC, <<"test/topic">>).
 -define(PAYLOAD, <<"hello world">>).

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -98,6 +98,9 @@ auth_on_register(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             modifiers => #{mountpoint => <<"mynewmount">>,
                            client_id => <<"changed_client_id">>}}};
+auth_on_register(#{username := ?CHANGED_USERNAME}) ->
+    {200, #{result => <<"ok">>,
+            modifiers => #{username => <<"changed_username">>}}};
 auth_on_register(#{subscriberid := <<"internal_server_error">>}) ->
     throw(internal_server_error).
 
@@ -118,6 +121,9 @@ auth_on_register_m5(#{client_id := ?CHANGED_CLIENT_ID}) ->
     {200, #{result => <<"ok">>,
             modifiers => #{mountpoint => <<"mynewmount">>,
                            client_id => <<"changed_client_id">>}}};
+auth_on_register_m5(#{username := ?CHANGED_USERNAME}) ->
+    {200, #{result => <<"ok">>,
+            modifiers => #{username => <<"changed_username">>}}};
 auth_on_register_m5(#{client_id := ?WITH_PROPERTIES,
                       properties :=
                           #{?P_SESSION_EXPIRY_INTERVAL := 5,

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,8 @@
 - Upgrade dependency `cuttlefish` to version *2.2.0*.
 - Improve large queue initialization performance by reducing algorithmic
   complexity from O(n^2) to O(nlogn) where n is the number of offline messages.
+- Add the ability to modify the `username` on `auth_on_register` hooks. Supports both
+  `vmq_diversity` and `vmq_webhooks`.
 
 ## VerneMQ 1.8.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -49,8 +49,8 @@
 - Upgrade dependency `cuttlefish` to version *2.2.0*.
 - Improve large queue initialization performance by reducing algorithmic
   complexity from O(n^2) to O(nlogn) where n is the number of offline messages.
-- Add the ability to modify the `username` on `auth_on_register` hooks. Supports both
-  `vmq_diversity` and `vmq_webhooks`.
+- Add the ability to modify the `username` on `auth_on_register` and `auth_on_register_m5`
+  hooks. Supports both `vmq_diversity` and `vmq_webhooks`.
 
 ## VerneMQ 1.8.0
 


### PR DESCRIPTION
Closes #1246 

- Added the ability to modify the username from the `auth_on_register`
hook.
- Changed the `vmq_diversity` plugin to support this new modifier.
- Changed the `vmq_webhooks` plugin to support this new modifier.

**Question:** Should `username` be added to the `reg_modifiers` type on https://github.com/vernemq/vernemq_dev/blob/master/src/auth_on_register_hook.erl and https://github.com/vernemq/vernemq_dev/blob/master/src/auth_on_register_m5_hook.erl?

Skål!