### PR TITLE
add missing case of prop_val with the binary Default

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -1144,7 +1144,9 @@ prop_val(Key, Args, Default) when is_integer(Default) ->
 prop_val(Key, Args, Default) when is_boolean(Default) ->
     prop_val(Key, Args, Default, fun erlang:is_boolean/1);
 prop_val(Key, Args, Default) when is_atom(Default) ->
-    prop_val(Key, Args, Default, fun erlang:is_atom/1).
+    prop_val(Key, Args, Default, fun erlang:is_atom/1);
+prop_val(Key, Args, Default) when is_binary(Default) ->
+    prop_val(Key, Args, Default, fun erlang:is_binary/1).
 
 prop_val(Key, Args, Default, Validator) ->
     case proplists:get_value(Key, Args) of


### PR DESCRIPTION
After the `username` modifier was added to `auth_on_register` hook, the username could not get through `prop_val` because no `prop_val` clause for binary was found.