### PR TITLE
Fix issue where errors would be logged when the /health endpoint was called (#1281).

### DIFF
--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -17,26 +17,12 @@
 -behaviour(vmq_http_config).
 
 -export([routes/0]).
--export([init/2,
-         allowed_methods/2,
-         content_types_provided/2,
-         reply/2]).
+-export([init/2]).
 
 routes() ->
   [{"/health", ?MODULE, []}].
 
 init(Req, Opts) ->
-    {cowboy_rest, Req, Opts}.
-
-allowed_methods(Req, State) ->
-    {[<<"GET">>], Req, State}.
-
-content_types_provided(Req, State) ->
-	{[
-		{<<"application/json">>, reply}
-    ], Req, State}.
-
-reply(Req, _State) ->
     {Code, Payload} = case check_health_concerns() of
       [] ->
         {200, [{<<"status">>, <<"OK">>}]};
@@ -45,8 +31,8 @@ reply(Req, _State) ->
                {<<"reasons">>, Concerns}]}
     end,
     Headers = #{<<"content-type">> => <<"application/json">>},
-    cowboy_req:reply(Code, Headers, jsx:encode(Payload), Req).
-
+    cowboy_req:reply(Code, Headers, jsx:encode(Payload), Req),
+    {ok, Req, Opts}.
 
 -spec check_health_concerns() -> [] | [Concern :: string()].
 check_health_concerns() ->

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
   consisting solely of white-space (#1208).
 - Fix bug in the `vmq_webhooks` `auth_on_subscribe_m5` and `on_subscribe_m5`
   hooks (#1280).
+- Fix issue where errors would be logged when the /health endpoint was called
+  (#1281).
 
 ## VerneMQ 1.9.0
 


### PR DESCRIPTION
Fixes #1281 

Perhaps we have this issue in other `cowboy_rest` endpoints as well - I'll investigate.