### PR TITLE
Send LWT on Disconnect with Will Message (0x04) code

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -369,7 +369,7 @@ pre_connect_auth(#mqtt5_auth{properties = #{p_authentication_method := AuthMetho
 pre_connect_auth(#mqtt5_disconnect{properties=Properties,
                                    reason_code = RC}, State) ->
     _ = vmq_metrics:incr({?MQTT5_DISCONNECT_RECEIVED, disconnect_rc2rcn(RC)}),
-    terminate_by_client(Properties, State);
+    terminate_by_client(RC, Properties, State);
 pre_connect_auth(_, State) ->
     terminate(?PROTOCOL_ERROR, State).
 
@@ -639,7 +639,7 @@ connected(#mqtt5_pingreq{}, State) ->
     {State, [serialise_frame(Frame)]};
 connected(#mqtt5_disconnect{properties=Properties, reason_code=RC}, State) ->
     _ = vmq_metrics:incr({?MQTT5_DISCONNECT_RECEIVED, disconnect_rc2rcn(RC)}),
-    terminate_by_client(Properties, State);
+    terminate_by_client(RC, Properties, State);
 connected({disconnect, Reason}, State) ->
     lager:debug("stop due to disconnect", []),
     terminate(Reason, State);
@@ -697,38 +697,57 @@ queue_down_terminate(shutdown, State) ->
 queue_down_terminate(Reason, #state{queue_pid=QPid} = State) ->
     terminate({error, {queue_down, QPid, Reason}}, State).
 
-terminate_by_client(Props0, #state{queue_pid=QPid} = State) ->
+-spec terminate_by_client(reason_code(), properties(), state()) -> any().
+terminate_by_client(RC, Props0, #state{queue_pid=QPid} = State) ->
     OldSInt = State#state.session_expiry_interval,
     NewSInt = maps:get(p_session_expiry_interval, Props0, 0),
-    Out = case {OldSInt,NewSInt} of
-              {0,NewSInt} when NewSInt > 0 ->
-                  [gen_disconnect(?PROTOCOL_ERROR, #{})];
-              {0,0} ->
-                  [];
-              _ ->
-                  %% the session expiry is legal, use the one we just
-                  %% received or fall back to the one from the connect
-                  %% packet.
-                  SInt = maps:get(p_session_expiry_interval, Props0, OldSInt),
-                  Props1 = maps:put(p_session_expiry_interval, SInt, Props0),
-                  QueueOpts = queue_opts_from_properties(Props1),
-                  vmq_queue:set_opts(QPid, QueueOpts),
-                  handle_waiting_acks_and_msgs(State),
-                  []
+    {Out, NewState} =
+        case {OldSInt,NewSInt} of
+            {0,NewSInt} when NewSInt > 0 ->
+                {[gen_disconnect(?PROTOCOL_ERROR, #{})], State};
+            {0,0} ->
+                {[], State};
+            _ ->
+                %% the session expiry is legal, use the one we just
+                %% received or fall back to the one from the connect
+                %% packet.
+                SInt = maps:get(p_session_expiry_interval, Props0, OldSInt),
+                Props1 = maps:put(p_session_expiry_interval, SInt, Props0),
+                QueueOpts = queue_opts_from_properties(Props1),
+                vmq_queue:set_opts(QPid, QueueOpts),
+                handle_waiting_acks_and_msgs(State),
+                {[], State#state{session_expiry_interval = SInt}}
         end,
+    case RC of
+        ?M5_NORMAL_DISCONNECT ->
+            do_nothing;
+        ?M5_DISCONNECT_WITH_WILL_MSG ->
+            schedule_last_will_msg(NewState);
+        _ ->
+            %% not really clear in the spec if we should send here,
+            %% but we do for now.
+            schedule_last_will_msg(NewState)
+    end,
     {stop, normal, Out}.
 
 -spec terminate(reason_code_name() | {error, any()}, state()) -> any().
 terminate(Reason, State) ->
     terminate(Reason, #{}, State).
 
-terminate(Reason, Props, #state{session_expiry_interval=SessionExpiryInterval} = State) ->
+terminate(Reason, Props, #state{session_expiry_interval=SessionExpiryInterval,
+                                subscriber_id=SubscriberId} = State) ->
     _ = case SessionExpiryInterval of
             0 -> ok;
             _ ->
                 handle_waiting_acks_and_msgs(State)
         end,
-    maybe_publish_last_will(State, Reason),
+    case suppress_lwt(Reason, State) of
+        true ->
+            lager:debug("last will and testament suppressed on session takeover for subscriber ~p",
+                        [SubscriberId]);
+        _ ->
+            schedule_last_will_msg(State)
+    end,
     Out =
         case Reason of
             {error, _} ->
@@ -1399,19 +1418,20 @@ prepare_frame(#deliver{qos=QoS, msg_id=MsgId, msg=Msg}, State0) ->
                                      Msg#vmq_msg{qos=NewQoS}, WAcks)}}
     end.
 
--spec maybe_publish_last_will(state(), reason_code_name() | {error, any()}) -> ok.
-maybe_publish_last_will(#state{will_msg=undefined}, _Reason) -> ok;
-maybe_publish_last_will(#state{def_opts=#{suppress_lwt_on_session_takeover := true},
-                               subscriber_id=SubscriberId},
-                        ?SESSION_TAKEN_OVER) ->
-    lager:debug("last will and testament suppressed on session takeover for subscriber ~p",
-                [SubscriberId]),
-    ok;
-maybe_publish_last_will(#state{subscriber_id={_, ClientId} = SubscriberId, username=User,
+suppress_lwt(?SESSION_TAKEN_OVER,
+             #state{will_msg=WillMsg,
+                    def_opts=#{suppress_lwt_on_session_takeover := true}})
+  when WillMsg =/= undefined->
+    true;
+suppress_lwt(_,_) ->
+    false.
+
+-spec schedule_last_will_msg(state()) -> ok.
+schedule_last_will_msg(#state{will_msg=undefined}) -> ok;
+schedule_last_will_msg(#state{subscriber_id={_, ClientId} = SubscriberId, username=User,
                                will_msg=Msg, reg_view=RegView, cap_settings=CAPSettings,
                                queue_pid=QueuePid,
-                               session_expiry_interval=SessionExpiryInterval},
-                       _Reason) ->
+                               session_expiry_interval=SessionExpiryInterval}) ->
     LastWillFun =
         fun() ->
                 #vmq_msg{qos=QoS, routing_key=Topic, payload=Payload, retain=IsRetain} = Msg,
@@ -1424,8 +1444,7 @@ maybe_publish_last_will(#state{subscriber_id={_, ClientId} = SubscriberId, usern
             vmq_queue:set_delayed_will(QueuePid, LastWillFun, Delay);
         _ ->
             LastWillFun()
-    end,
-    ok.
+    end.
 
 get_last_will_delay(#vmq_msg{properties = #{p_will_delay_interval := Delay}}) ->
     MaxDuration = vmq_config:get_env(max_last_will_delay, 0),

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 - Fix bug causing idle websocket connections to be closed after 60 seconds
   (#1292).
+- Fix MQTT 5.0 bug causing LWT not being sent when client disconnected with
+  Disconnect with Will Message (0x04) (#1291).
 
 ## VerneMQ 1.9.1
 


### PR DESCRIPTION
Fixes #1291

This ensures that we do send out (or schedule) the LWT when the client disconnects with DISCONNECT with the 0x04 code (Disconnect with Will Message).

The spec isn't awfully clear on what should happen with other disconnect codes, so for now we just clear the LWT on code 0x00 as per the spec and send the LWT on all other codes.