### PR TITLE
Add new `on_deliver*` hook variant and new `on_client_expired` hook

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -1376,9 +1376,8 @@ prepare_frame(#deliver{qos=QoS, msg_id=MsgId, msg=Msg}, State0) ->
              properties=Props0,
              expiry_ts=ExpiryTS} = Msg,
     NewQoS = maybe_upgrade_qos(QoS, MsgQoS, State0),
-    HookArgs = [User, SubscriberId, Topic0, Payload0, Props0],
     {Topic1, Payload1, Props2} =
-    case vmq_plugin:all_till_ok(on_deliver_m5, HookArgs) of
+    case on_deliver_hook(User, SubscriberId, QoS, Topic0, Payload0, IsRetained, Props0) of
         {error, _} ->
             %% no on_deliver hook specified... that's ok
             {Topic0, Payload0, Props0};
@@ -1414,6 +1413,15 @@ prepare_frame(#deliver{qos=QoS, msg_id=MsgId, msg=Msg}, State0) ->
              State2#state{
                waiting_acks=maps:put(OutgoingMsgId,
                                      Msg#vmq_msg{qos=NewQoS}, WAcks)}}
+    end.
+
+on_deliver_hook(User, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
+    HookArgs0 = [User, SubscriberId, Topic, Payload, Props],
+    case vmq_plugin:all_till_ok(on_deliver_m5, HookArgs0) of
+        {error, _} ->
+            HookArgs1 = [User, SubscriberId, QoS, Topic, Payload, IsRetain, Props],
+            vmq_plugin:all_till_ok(on_deliver_m5, HookArgs1);
+        Other -> Other
     end.
 
 suppress_lwt(?SESSION_TAKEN_OVER,

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@
 - Add hidden option `response_timeout` to `vmq_webhooks` endpoints. With this
   the time `vmq_webhooks` waits for a response from the remote endpoint can be
   configured. Default is 5000 milliseconds.
+- Add new `on_deliver/6` and `on_deliver_m5/7` hooks which adds QoS and retained
+  information to the parameters. The old variants are deprecated and will be
+  removed in the next major version.
 
 ## VerneMQ 1.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
 - Add new `on_deliver/6` and `on_deliver_m5/7` hooks which adds QoS and retained
   information to the parameters. The old variants are deprecated and will be
   removed in the next major version.
+- Add new `on_session_expired/1` hook which is called when an offline session
+  expires and the state is deleted.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
Old variants are deprecated and will be removed in the next major
version.

The new function signatures looks like follows:

```
on_deliver(User, SubscriberId, QoS, Topic, Payload, IsRetained)
on_deliver_m5(User, SubscriberId, QoS, Topic, Payload, IsRetain, Props)
```

Before merging this we should

- [ ] update webhooks or create issue to do so later
- [ ] update diversity or create issue to do so later
- [ ] update plugin hook docs or create issue to do so later
- [ ] update vernemq_dev or create issue to do so later

Created the issue #1346 to keep track of the above tasks