### PR TITLE
Fix bug in protocol version check for MQTT 5.0 clients

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
   Disconnect with Will Message (0x04) (#1291).
 - Ensure MQTT 5.0 subscription identifers are added to messages delivered via
   shared subscriptions (#1294).
+- Fix protocol version check bug which would allow MQTT 5.0 clients to connect
+  even if the MTT 5.0 protocol was not specified for the listener. This happened
+  for clients which connected with an empty client-id.
 
 ## VerneMQ 1.9.1
 


### PR DESCRIPTION
MQTT 5.0 clients without a client id would be allowed to connect even
if the listener was not alloweing the MQTT 5.0 protocol.

This change moves the protocol version up into the init function of
the two mqtt fsms so we don't do any other work if the protocol isn't
allowed.

Another approach would be to check this in the `vmq_mqtt_pre_init` module,
before calling init in the fsms.

Note this also means we no longer store the `allowed_protocol_versions` in the fsm states.