### PR TITLE
Add new `max_last_will_delay` value and change default

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -22,6 +22,7 @@ Mariano Guerra
 Szymon Kałasz
 Christoph Krey
 Michael Kuehne
+Will Lisac (@wlisac)
 Chiradip Mandal
 Chris Nesbitt-Smith
 Andrei Nesterov

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -199,23 +199,32 @@
  end}.
 
 %% @doc The maximum delay for a last will message. This setting
-%% applies only to MQTTv5 sessions and overrides the value provided by
-%% the client.
-%% The delay should be an integer followed by one of 's', 'h' 'd',
-%% 'w', 'm', 'y' for day, week, month, and year.
+%% applies only to MQTTv5 sessions and can be used to override the
+%% value provided by the client.
+
+%% The delay can be either 'client' which means the value specified by
+%% the client is used, or an integer followed by one of 's', 'h' 'd',
+%% 'w', 'm', 'y' for day, week, month, and year used to cap the value
+%% provided by the client..
 {mapping, "max_last_will_delay", "vmq_server.max_last_will_delay", [
-                                                                    {default, "0s"},
-                                                                    {commented, "0s"},
+                                                                    {default, "client"},
+                                                                    {commented, "client"},
                                                                     {datatype, string}
                                                                    ]}.
 
 {translation, "vmq_server.max_last_will_delay",
  fun(Conf) ->
          S = cuttlefish:conf_get("max_last_will_delay", Conf),
-         case vmq_schema:string_to_secs(S) of
-             error ->
-                 cuttlefish:invalid(S ++ " must be an integer followed by one of 's', 'h', 'd', 'w', 'm', 'y' for second, minute, hour, day, week, month, and year");
-             Val -> Val
+         case S of
+             "client" ->
+                 %% 2^32 max seconds in a Four Byte Integer
+                 4294967296;
+             _ ->
+                 case vmq_schema:string_to_secs(S) of
+                     error ->
+                         cuttlefish:invalid(S ++ " must be an integer followed by one of 's', 'h', 'd', 'w', 'm', 'y' for second, minute, hour, day, week, month, and year");
+                     Val -> Val
+                 end
          end
  end}.
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,9 @@
 - Fix bug in `vmq_diversity` and `vmq_webhooks` where the plugin hooks would be
   registered out of order, even though the plugins themselves would be started
   in the correct order (#1295).
+- Add new `max_last_will_delay` value `client` which means the value from the
+  client is used instead of being overriden by the broker. This `client` value
+  is now the default. This setting only applies to MQTT 5.0 clients.
 
 ## VerneMQ 1.9.1
 


### PR DESCRIPTION
The current default of `0s` was confusing to the users and as long as
it is possible from the broker side to limit this then it makes sense
for the default to be what the client provides. This can now be done
by specifying `client` instead of a time value.