### PR TITLE
Gracefully handle ws clients without `sec-websocket-protocol` header

### DIFF
--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -167,7 +167,7 @@ maybe_reply(Out, State) ->
 
 add_websocket_sec_header(Req) ->
     case cowboy_req:header(<<"sec-websocket-protocol">>, Req) of
-        undefined -> Req;
+        undefined -> {error, unsupported_protocol};
         SubProtocols when is_list(SubProtocols);
                           is_binary(SubProtocols) ->
             case select_protocol(SubProtocols, ?SUPPORTED_PROTOCOLS) of

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Fix bug where websocket MQTT clients that didn't provide a
+  `sec-websocket-protocol` header to cause a crash to be logged. This case is
+  now handled and the connection is terminated gracefully (#1317).
+
 ## VerneMQ 1.9.2
 
 - Fix bug causing idle websocket connections to be closed after 60 seconds


### PR DESCRIPTION
Fixes #1317