### PR TITLE
Add `response_timeout` to `vmq_webhook` HTTP requests

### DIFF
--- a/apps/vmq_webhooks/priv/vmq_webhooks.schema
+++ b/apps/vmq_webhooks/priv/vmq_webhooks.schema
@@ -65,10 +65,17 @@
   hidden
  ]}.
 
+%% @doc Configure the timeout the HTTP client will wait for a response
+%% from the remote endpoint. Default to 5000 milliseconds.
+{mapping, "vmq_webhooks.$name.response_timeout", "vmq_webhooks.user_webhooks",
+ [{datatype, integer},
+  hidden,
+  {default, 5000}]}.
+
 {translation,
  "vmq_webhooks.user_webhooks",
  fun(Conf) ->
-         Suffixes = ["hook", "endpoint", "base64encode", "no_payload"],
+         Suffixes = ["hook", "endpoint", "base64encode", "no_payload", "response_timeout"],
          UNames =
              [
               proplists:get_all_values(
@@ -87,14 +94,12 @@
                                                      ".base64encode", Conf, true),
                          no_payload =>
                              cuttlefish:conf_get("vmq_webhooks." ++ SortName ++
-                                                     ".no_payload", Conf, false)
+                                                     ".no_payload", Conf, false),
+                         response_timeout => cuttlefish:conf_get("vmq_webhooks." ++ SortName ++
+                                                                     ".response_timeout", Conf, 8000)
                        }
                  }}
                || SortName <- HookNames ],
-         %% I know of no other way to abort the translation phase and
-         %% report an error back to the user than using throw. Though
-         %% it's not too pretty I think it's nicer than just warning
-         %% that something is configured incorrectly.
          lists:map(
            fun({SortName, #{endpoint := undefined}}) ->
                    cuttlefish:invalid("vmq_webhooks."

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -573,7 +573,8 @@ call_endpoint(Endpoint, EOpts, Hook, Args0) ->
     Method = post,
     Headers = [{<<"Content-Type">>, <<"application/json">>},
                {<<"vernemq-hook">>, atom_to_binary(Hook, utf8)}],
-    Opts = [{pool, Endpoint}],
+    Opts = [{pool, Endpoint},
+            {recv_timeout, maps:get(response_timeout, EOpts)}],
     Args1 = filter_args(Args0, Hook, EOpts),
     Payload = encode_payload(Hook, Args1, EOpts),
     Res =

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 - Fix lager issue on Raspberry Pi preventing VerneMQ from starting (#1305).
 - Upgrade `epgsql` dependency to version 4.3.0 to get better error messages
   (#1336).
+- Add hidden option `response_timeout` to `vmq_webhooks` endpoints. With this
+  the time `vmq_webhooks` waits for a response from the remote endpoint can be
+  configured. Default is 5000 milliseconds.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
Adds a new hidden config option so the response timeout can be configured on a per endpoint basis. For example setting a 100s  timeout:

```
vmq_webhooks.webhook1.hook = auth_on_register
vmq_webhooks.webhook1.endpoint = http://localhost:8080
vmq_webhooks.webhook1.response_timeout = 100000
```

resolves #1321

