### PR TITLE
Ensure the RPI build uses the correct version of lager

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
   22.1.
 - Fix bug preventing MQTT 5 publish in/out counts from being shown on the HTTP
   status page.
+- Fix lager issue on Raspberry Pi preventing VerneMQ from starting (#1305).
 
 ## VerneMQ 1.9.2
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
             {platform_define, "^(R|1|20)", fun_stacktrace}]}.
 {project_plugins, [
                    {rebar3_cuttlefish, {git, "git://github.com/vernemq/rebar3_cuttlefish",
-                                        {ref, "417560a"}}}]}.
+                                        {branch, "master"}}}]}.
 {dialyzer, [{exclude_mods, [vmq_plugin]},
             {plt_location, "plts"},
             {base_plt_location, "plts_base"}]}.
@@ -14,7 +14,7 @@
         {recon, "2.3.2"},
         {lager, "3.7.0"},
         %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
-        {cuttlefish, {git, "git://github.com/Kyorai/cuttlefish.git", {branch, "develop"}}},
+        {cuttlefish, {git, "git://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
         {vernemq_dev, {git, "git://github.com/vernemq/vernemq_dev.git", {branch, "master"}}},
 
         {lager_syslog, {git, "git://github.com/basho/lager_syslog.git", {tag, "3.0.1"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -17,7 +17,7 @@
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
  {<<"cuttlefish">>,
   {git,"git://github.com/Kyorai/cuttlefish.git",
-       {ref,"fff866a3a22dc2a8f3d23aa13933b90542485728"}},
+       {ref,"27fc2d2f525e8e27dbe34b257ce3eb8beaff86c6"}},
   0},
  {<<"dht_ring">>,
   {git,"git://github.com/EchoTeam/dht_ring.git",


### PR DESCRIPTION
Why exactly `rebar3` uses the lager version pulled in by
`rebar3_cuttlefish` when the a profile (`rpi32`) is used is a
mystery. However, ensuring that the `lager` version from
`rebar3_cuttlefish` is usable makes things work.

Fixes #1305