### PR TITLE
Optimize retain lookup when subscribing with wildcards

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,8 @@
 - Handle CRL PEM entries with certificates containing empty revocation lists
   (#1337).
 - Fix typo in `vmq-admin listener start` command (#1348).
+- Optimize subscription performance when many retained messages are stored on
+  the broker and the subscription contains wildcards.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
Using the test suite provided by @mholc: https://github.com/mholc/mqtt-tests

measurements before:

``` shell

$ python3 test.py
on_connect 0
on_subscribe 0.002396011957898736

$ python3 dump.py < testtopics

$ python3 test.py
on_connect 0
on_subscribe 1.808376237982884
```

measurements after:

``` shell

$ python3 test.py
on_connect 0
on_subscribe 0.0016006500227376819

$ python3 dump.py < testtopics

$ python3 test.py
on_connect 0
on_subscribe 0.0021167430095374584
```


That the first run of `test.py` is faster after the change is likely just a fluke. The insert should actually be slightly slower (as the table items are now ordered).

@dergraf, note that we still do a fold over the result set. This could
potentially be inefficient if we return many results (for example if the user subscribes to `#`). But it's still likely (much) better than the old code with the full table scan.