### PR TITLE
Fix inflight offline message ordering

### DIFF
--- a/apps/vmq_server/src/vmq_queue.erl
+++ b/apps/vmq_server/src/vmq_queue.erl
@@ -1025,33 +1025,44 @@ publish_last_will(#state{delayed_will = {_, Fun}} = State) ->
     Fun(),
     unset_will_timer(State#state{delayed_will = undefined}).
 
-maybe_offline_store(Offline, SubscriberId, #deliver{qos=QoS, msg=#vmq_msg{persisted=false, dup=IsDup} = Msg}=D) when QoS > 0 ->
+maybe_offline_store(Offline, SubscriberId, #deliver{qos=QoS, msg=#vmq_msg{persisted=false, dup=IsDup, expiry_ts=ExpiryTs} = Msg}=D) when QoS > 0 ->
+    %% this function writes the message to the message store, in case the queue
+    %% has no online session attached anymore (Offline = true) the queue can
+    %% 'compress' the messages. Compressing is done by only keeping the message
+    %% reference in the queue (the rest of the message is fetched from the
+    %% message store during 'decompress'). However, the message store doesn't
+    %% store all message properties, therefore the queue can't just 'compress'
+    %% every message. The following properties aren't stored by the currently
+    %% provided message store:
+    %% - Message ID (required when storing a message with the DUP flag)
+    %% - Expiry Timestamp (required when storing a message that should expire)
     PMsg = Msg#vmq_msg{persisted=true, qos=QoS},
     case vmq_plugin:only(msg_store_write, [SubscriberId, PMsg]) of
-        %% Although we have no online/serving session attached
-        %% to this queue we can't compress this message, as it is
-        %% a publish with the DUP flag set, and we must keep the
-        %% message id around (which isn't stored in the message store yet)
         ok when Offline and IsDup ->
+            % No compress
             D#deliver{msg=PMsg};
-        %% in case we have no online/serving session attached
-        %% to this queue anymore we can save memory by only
-        %% keeping the message ref in the queue
+        ok when Offline and (ExpiryTs =/= undefined) ->
+            % No compress
+            D#deliver{msg=PMsg};
         ok when Offline ->
+            % Compress
             PMsg#vmq_msg.msg_ref;
-        %% in case we still have online sessions attached
-        %% to this queue, we keep the full message structure around
         ok ->
+            % No compress, we're still online
             D#deliver{msg=PMsg};
-        %% in case we cannot store the message we keep the
-        %% full message structure around
         {error, _} ->
+            %% in case we cannot store the message we keep the
+            %% full message structure around
             D
     end;
 maybe_offline_store(true, _, #deliver{msg=#vmq_msg{persisted=true, dup=true}} = D) ->
     % we can't compress a DUP message as we'd lose the message id when compressing
     D;
+maybe_offline_store(true, _, #deliver{msg=#vmq_msg{persisted=true, expiry_ts=ExpiryTs}} = D) when ExpiryTs =/= undefined ->
+    % we can't compress a message that has the expiry_ts set as we'd lose the expiry ts when compressing
+    D;
 maybe_offline_store(true, _, #deliver{msg=#vmq_msg{persisted=true} = Msg}) ->
+    % Compress
     Msg#vmq_msg.msg_ref;
 maybe_offline_store(_, _, MsgOrRef) -> MsgOrRef.
 

--- a/apps/vmq_server/test/vmq_test_utils.erl
+++ b/apps/vmq_server/test/vmq_test_utils.erl
@@ -72,8 +72,11 @@ disable_all_plugins() ->
                           ignore
                   end, Plugins),
     %% Disable Mod Plugins
-    _ = [vmq_plugin_mgr:disable_plugin(P) || P <- vmq_plugin:info(all)],
-    ok.
+    lists:foreach(fun ({_, vmq_lvldb_store, _, _}) ->
+                          ignore;
+                      (P) ->
+                          vmq_plugin_mgr:disable_plugin(P)
+                  end, vmq_plugin:info(all)).
 
 maybe_start_distribution(Name) ->
     case ets:info(sys_dist) of

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,12 @@
 - Fix typo in `vmq-admin listener start` command (#1348).
 - Optimize subscription performance when many retained messages are stored on
   the broker and the subscription contains wildcards.
+- Fix bug where MQTT 5 publish expiry interval was lost when writing the message
+  to the message store.
+- Fix bug where a retried MQTT publish after resuming an offline session used
+  the wrong message id.
+- Fix MQTT 5 shared subscription bug where writing the message to the message
+  store resulted in a corrupt message record once a offline session was resumed.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
This PR addresses multiple issues, all discovered by fixing that the common tests use a 'real' message store. We haven't discovered this bug so far because our test suite disabled the message storage plugin by default (not sure why, performance?). Because of this queue compression never happened when running the vmq_server test suites.

The root cause of this issue is that the queue compresses queued messages when transitioning to offline state. During compression it loses information about message ids. This is an issue for messages with the DUP flag set, as we'd have to keep the message id to recover a qos1/qos2 flow.