### PR TITLE
Fix regression in vmq_bridge where the retain bit wasn't handled properly

### DIFF
--- a/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
@@ -203,7 +203,7 @@ bridge_reg(ReportProc) ->
     RegisterFun = fun() ->
                           ok
                   end,
-    PublishFun = fun(Topic, Payload, _Opts) ->
+    PublishFun = fun(Topic, Payload, _Opts = #{retain=IsRetain}) when is_boolean(IsRetain) ->
                          ReportProc ! {publish, Topic, Payload},
                          ok
                  end,

--- a/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
@@ -203,7 +203,7 @@ bridge_reg(ReportProc) ->
     RegisterFun = fun() ->
                           ok
                   end,
-    PublishFun = fun(Topic, Payload, _Opts = #{retain=IsRetain}) when is_boolean(IsRetain) ->
+    PublishFun = fun(Topic, Payload, _Opts = #{retain := IsRetain}) when is_boolean(IsRetain) ->
                          ReportProc ! {publish, Topic, Payload},
                          ok
                  end,

--- a/apps/vmq_bridge/test/vmq_bridge_tests.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_tests.erl
@@ -228,7 +228,7 @@ bridge_plugin(ReportProc) ->
     RegisterFun = fun() ->
                         ok
                   end,
-    PublishFun = fun(Topic, Payload, _Opts = #{retain=IsRetain, dup=IsDup}) when is_boolean(IsRetain) ->
+    PublishFun = fun(Topic, Payload, _Opts = #{retain := IsRetain}) when is_boolean(IsRetain) ->
                          ReportProc ! {publish, Topic, Payload},
                          ok
                  end,

--- a/apps/vmq_bridge/test/vmq_bridge_tests.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_tests.erl
@@ -228,7 +228,7 @@ bridge_plugin(ReportProc) ->
     RegisterFun = fun() ->
                         ok
                   end,
-    PublishFun = fun(Topic, Payload, _Opts) ->
+    PublishFun = fun(Topic, Payload, _Opts = #{retain=IsRetain, dup=IsDup}) when is_boolean(IsRetain) ->
                          ReportProc ! {publish, Topic, Payload},
                          ok
                  end,

--- a/apps/vmq_commons/src/gen_mqtt_client.erl
+++ b/apps/vmq_commons/src/gen_mqtt_client.erl
@@ -507,8 +507,8 @@ handle_frame(connected, #mqtt_publish{message_id=MessageId, topic=Topic,
     #state{transport={Transport, _}, sock=Socket, info_fun=InfoFun} = State,
     NewInfoFun = call_info_fun({publish_in, MessageId, Payload, QoS}, InfoFun),
     Opts = #{qos => QoS,
-             retain => Retain,
-             dup => Dup},
+             retain => unflag(Retain),
+             dup => unflag(Dup)},
     case QoS of
         0 ->
             wrap_res(connected, on_publish, [Topic, Payload, Opts], State#state{info_fun=NewInfoFun});
@@ -746,3 +746,6 @@ active_once(ssl, Sock) ->
 
 call_info_fun(Info, {Fun, FunState}) ->
     {Fun, Fun(Info, FunState)}.
+
+unflag(0) -> false;
+unflag(1) -> true.

--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,8 @@
 - Refactor built-in message storage to enable multiple storage engines as well as
   to streamline the implementation of alternative message storage plugins. 
 - Fix metric description string in vmq_bridge.
+- Fix regression in vmq_bridge where the retain bit wasn't handled properly for
+  incoming publishes.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
Should fix #1362 

Instead of fixing the regression I'd prefer to fix the root cause which is that the gen_mqtt_client didn't 'unflag' the retain bit properly.