### PR TITLE
Minor vmq_swc fixes and improvements

### DIFF
--- a/apps/vmq_swc/rebar.config
+++ b/apps/vmq_swc/rebar.config
@@ -4,8 +4,6 @@
         {sext, "1.5.0"},
         {swc, {git, "git://github.com/vernemq/ServerWideClocks.git", "master"}},
         {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
-
-        %% plumtree related
         riak_dt
        ]}.
 

--- a/apps/vmq_swc/src/vmq_swc_edist_srv.erl
+++ b/apps/vmq_swc/src/vmq_swc_edist_srv.erl
@@ -60,10 +60,10 @@ start_connection(_Config, _Member) ->
 stop_connection(_Config, _Member) ->
     ok.
 
-rpc(#swc_config{group=SwcGroup} = _Config, RemotePeer, Module, Function, Args) ->
+rpc(SwcGroup, RemotePeer, Module, Function, Args) ->
     gen_server:call({name(SwcGroup), RemotePeer}, {apply, Module, Function, Args}, infinity).
 
-rpc_cast(#swc_config{group=SwcGroup} = _Config, RemotePeer, Module, Function, Args) ->
+rpc_cast(SwcGroup, RemotePeer, Module, Function, Args) ->
     gen_server:cast({name(SwcGroup), RemotePeer}, {apply, Module, Function, Args}).
 
 name(SwcGroup) ->

--- a/apps/vmq_swc/src/vmq_swc_metrics.erl
+++ b/apps/vmq_swc/src/vmq_swc_metrics.erl
@@ -154,7 +154,7 @@ handle_cast(_Msg, State) ->
 
 handle_info({'DOWN', MRef, process, OwnerPid, _Info}, #state{gauges=Gauges0} = State) ->
     Gauges1 =
-    maps:filter(fun(_MetricName, {_, {OwnerPid, MRef}}) -> false;
+    maps:filter(fun(_MetricName, {_, MetricRef}) when MetricRef == {OwnerPid, MRef} -> false;
                    (_, _) -> true
                 end, Gauges0),
     {noreply, State#state{gauges=Gauges1}}.

--- a/apps/vmq_swc/src/vmq_swc_metrics.erl
+++ b/apps/vmq_swc/src/vmq_swc_metrics.erl
@@ -1,11 +1,17 @@
-%%%-------------------------------------------------------------------
-%%% @author graf
-%%% @copyright (C) 2018, graf
-%%% @doc
-%%%
-%%% @end
-%%% Created : 2018-12-05 13:53:59.754915
-%%%-------------------------------------------------------------------
+%% Copyright 2018 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(vmq_swc_metrics).
 
 -behaviour(gen_server).

--- a/apps/vmq_swc/src/vmq_swc_metrics.erl
+++ b/apps/vmq_swc/src/vmq_swc_metrics.erl
@@ -42,7 +42,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_gauge(MetricName, Fun) ->
-    gen_server:call(?SERVER, {register_gauge, MetricName, Fun}, infinity).
+    gen_server:call(?SERVER, {register_gauge, self(), MetricName, Fun}, infinity).
 
 metric_name({Metric, SubMetric}) ->
     LMetric = atom_to_list(Metric),
@@ -69,7 +69,7 @@ metrics() ->
       end, [], ?TIMER_TABLE),
 
     Gauges = gen_server:call(?SERVER, get_gauges, infinity),
-    maps:fold(fun({MetricName, Group}, GaugeFun, Acc) ->
+    maps:fold(fun({MetricName, Group}, {GaugeFun, _OwnerRef}, Acc) ->
                       try
                           UniqueId = list_to_atom(atom_to_list(MetricName) ++ "_" ++ atom_to_list(Group)),
                           {Labels, Description, Value} = GaugeFun(),
@@ -136,17 +136,22 @@ init([]) ->
     ets:new(?TIMER_TABLE, [named_table, public, {write_concurrency, true}]),
     {ok, #state{}}.
 
-handle_call({register_gauge, MetricName, Fun}, _From, #state{gauges=Gauges} = State) ->
+handle_call({register_gauge, OwnerPid, MetricName, Fun}, _From, #state{gauges=Gauges} = State) ->
+    MRef = monitor(process, OwnerPid),
     Reply = ok,
-    {reply, Reply, State#state{gauges=maps:put(MetricName, Fun, Gauges)}};
+    {reply, Reply, State#state{gauges=maps:put(MetricName, {Fun, {OwnerPid, MRef}}, Gauges)}};
 handle_call(get_gauges, _From, #state{gauges=Gauges} = State) ->
     {reply, Gauges, State}.
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info(_Info, State) ->
-    {noreply, State}.
+handle_info({'DOWN', MRef, process, OwnerPid, _Info}, #state{gauges=Gauges0} = State) ->
+    Gauges1 =
+    maps:filter(fun(_MetricName, {_, {OwnerPid, MRef}}) -> false;
+                   (_, _) -> true
+                end, Gauges0),
+    {noreply, State#state{gauges=Gauges1}}.
 
 terminate(_Reason, _State) ->
     ok.

--- a/apps/vmq_swc/src/vmq_swc_peer_service_events.erl
+++ b/apps/vmq_swc/src/vmq_swc_peer_service_events.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(vmq_swc_plumtree_peer_service_events).
+-module(vmq_swc_peer_service_events).
 
 -behaviour(gen_event).
 
@@ -64,7 +64,7 @@ update(LocalState) ->
 %% ===================================================================
 
 init([Fn]) ->
-    {ok, LocalState} = vmq_swc_plumtree_peer_service_manager:get_local_state(),
+    {ok, LocalState} = vmq_swc_peer_service_manager:get_local_state(),
     Fn(LocalState),
     {ok, #state { callback = Fn }}.
 

--- a/apps/vmq_swc/src/vmq_swc_peer_service_gossip.erl
+++ b/apps/vmq_swc/src/vmq_swc_peer_service_gossip.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(vmq_swc_plumtree_peer_service_gossip).
+-module(vmq_swc_peer_service_gossip).
 
 -behavior(gen_server).
 
@@ -54,19 +54,19 @@ init([]) ->
 handle_call(stop, _From, State) ->
     {stop, normal, State};
 handle_call(send_state, _From, State) ->
-    {ok, LocalState} = vmq_swc_plumtree_peer_service_manager:get_local_state(),
+    {ok, LocalState} = vmq_swc_peer_service_manager:get_local_state(),
     {reply, {ok, LocalState}, State}.
 
 handle_cast({receive_state, PeerState}, State) ->
-    {ok, LocalState} = vmq_swc_plumtree_peer_service_manager:get_local_state(),
+    {ok, LocalState} = vmq_swc_peer_service_manager:get_local_state(),
     case riak_dt_orswot:equal(PeerState, LocalState) of
         true ->
             %% do nothing
             {noreply, State};
         false ->
             Merged = riak_dt_orswot:merge(PeerState, LocalState),
-            vmq_swc_plumtree_peer_service_manager:update_state(Merged),
-            vmq_swc_plumtree_peer_service_events:update(Merged),
+            vmq_swc_peer_service_manager:update_state(Merged),
+            vmq_swc_peer_service_events:update(Merged),
             {noreply, State}
     end.
 
@@ -92,7 +92,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc initiate gossip on local node
 do_gossip() ->
-    {ok, Local} = vmq_swc_plumtree_peer_service_manager:get_local_state(),
+    {ok, Local} = vmq_swc_peer_service_manager:get_local_state(),
     case get_peers(Local) of
         [] ->
             {error, singleton};

--- a/apps/vmq_swc/src/vmq_swc_peer_service_manager.erl
+++ b/apps/vmq_swc/src/vmq_swc_peer_service_manager.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(vmq_swc_plumtree_peer_service_manager).
+-module(vmq_swc_peer_service_manager).
 
 -define(TBL, swc_cluster_state).
 

--- a/apps/vmq_swc/src/vmq_swc_store.erl
+++ b/apps/vmq_swc/src/vmq_swc_store.erl
@@ -140,7 +140,7 @@ lock(#swc_config{store=StoreName}) ->
     gen_server:call(StoreName, {lock, self()}, infinity).
 
 -spec remote_sync_missing(config(), peer(), [dot()]) -> [{db_key(), object()}].
-remote_sync_missing(#swc_config{group=SwcGroup, transport=TMod, peer=OriginPeer} = Config, RemotePeer, Dots) ->
+remote_sync_missing(#swc_config{group=SwcGroup, transport=TMod, peer=OriginPeer}, RemotePeer, Dots) ->
     TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_sync_missing, [OriginPeer, Dots]).
 
 -spec rpc_sync_missing(peer(), [dot()], config()) -> [{db_key(), object()}].
@@ -156,7 +156,7 @@ node_clock(#swc_config{store=StoreName}) ->
     gen_server:call(StoreName, get_node_clock, infinity).
 
 -spec remote_node_clock(config(), peer()) -> nodeclock().
-remote_node_clock(#swc_config{group=SwcGroup, transport=TMod} = Config, RemotePeer) ->
+remote_node_clock(#swc_config{group=SwcGroup, transport=TMod}, RemotePeer) ->
     TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_node_clock, []).
 
 -spec rpc_node_clock(config()) -> nodeclock().
@@ -168,7 +168,7 @@ watermark(Config) ->
     get_watermark(Config).
 
 -spec remote_watermark(config(), peer()) -> watermark().
-remote_watermark(#swc_config{group=SwcGroup, transport=TMod} = Config, RemotePeer) ->
+remote_watermark(#swc_config{group=SwcGroup, transport=TMod}, RemotePeer) ->
     TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_watermark, []).
 
 -spec rpc_watermark(config()) -> watermark().

--- a/apps/vmq_swc/src/vmq_swc_store.erl
+++ b/apps/vmq_swc/src/vmq_swc_store.erl
@@ -140,8 +140,8 @@ lock(#swc_config{store=StoreName}) ->
     gen_server:call(StoreName, {lock, self()}, infinity).
 
 -spec remote_sync_missing(config(), peer(), [dot()]) -> [{db_key(), object()}].
-remote_sync_missing(#swc_config{transport=TMod, peer=OriginPeer} = Config, RemotePeer, Dots) ->
-    TMod:rpc(Config, RemotePeer, ?MODULE, rpc_sync_missing, [OriginPeer, Dots]).
+remote_sync_missing(#swc_config{group=SwcGroup, transport=TMod, peer=OriginPeer} = Config, RemotePeer, Dots) ->
+    TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_sync_missing, [OriginPeer, Dots]).
 
 -spec rpc_sync_missing(peer(), [dot()], config()) -> [{db_key(), object()}].
 rpc_sync_missing(OriginPeer, Dots, #swc_config{store=StoreName}) ->
@@ -156,8 +156,8 @@ node_clock(#swc_config{store=StoreName}) ->
     gen_server:call(StoreName, get_node_clock, infinity).
 
 -spec remote_node_clock(config(), peer()) -> nodeclock().
-remote_node_clock(#swc_config{transport=TMod} = Config, RemotePeer) ->
-    TMod:rpc(Config, RemotePeer, ?MODULE, rpc_node_clock, []).
+remote_node_clock(#swc_config{group=SwcGroup, transport=TMod} = Config, RemotePeer) ->
+    TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_node_clock, []).
 
 -spec rpc_node_clock(config()) -> nodeclock().
 rpc_node_clock(#swc_config{} = Config) ->
@@ -168,8 +168,8 @@ watermark(Config) ->
     get_watermark(Config).
 
 -spec remote_watermark(config(), peer()) -> watermark().
-remote_watermark(#swc_config{transport=TMod} = Config, RemotePeer) ->
-    TMod:rpc(Config, RemotePeer, ?MODULE, rpc_watermark, []).
+remote_watermark(#swc_config{group=SwcGroup, transport=TMod} = Config, RemotePeer) ->
+    TMod:rpc(SwcGroup, RemotePeer, ?MODULE, rpc_watermark, []).
 
 -spec rpc_watermark(config()) -> watermark().
 rpc_watermark(#swc_config{} = Config) ->
@@ -276,10 +276,10 @@ handle_call({batch, Batch}, _From, #state{config=Config,
     r_o_w_cache_clear(Config),
     case IsBroadcastEnabled of
         true ->
-            #swc_config{transport=TMod} = Config,
+            #swc_config{group=SwcGroup, transport=TMod} = Config,
             lists:foreach(
               fun(Peer) ->
-                      TMod:rpc_cast(Config, Peer, ?MODULE, rpc_broadcast, [Id, lists:reverse(ReplicateObjects)])
+                      TMod:rpc_cast(SwcGroup, Peer, ?MODULE, rpc_broadcast, [Id, lists:reverse(ReplicateObjects)])
               end, Peers);
         _ ->
             ok

--- a/apps/vmq_swc/src/vmq_swc_store_sup.erl
+++ b/apps/vmq_swc/src/vmq_swc_store_sup.erl
@@ -36,7 +36,7 @@
 %% @end
 %%--------------------------------------------------------------------
 start_link(SwcGroup) ->
-    start_link(SwcGroup, [{membership_strategy, plumtree}]).
+    start_link(SwcGroup, [{membership_strategy, auto}]).
 
 start_link(SwcGroup, Opts) ->
     SupName = list_to_atom("vmq_swc_store_sup_" ++ atom_to_list(SwcGroup)),
@@ -61,7 +61,7 @@ start_link(SwcGroup, Opts) ->
 %%--------------------------------------------------------------------
 init([SwcGroup, Opts]) ->
 
-    MembershipStrategy = proplists:get_value(membership_strategy, Opts, plumtree),
+    MembershipStrategy = proplists:get_value(membership_strategy, Opts, auto),
 
     PeerName = node(),
 

--- a/apps/vmq_swc/src/vmq_swc_store_sup.erl
+++ b/apps/vmq_swc/src/vmq_swc_store_sup.erl
@@ -17,7 +17,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/1]).
+-export([start_link/1, start_link/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -36,8 +36,11 @@
 %% @end
 %%--------------------------------------------------------------------
 start_link(SwcGroup) ->
+    start_link(SwcGroup, [{membership_strategy, plumtree}]).
+
+start_link(SwcGroup, Opts) ->
     SupName = list_to_atom("vmq_swc_store_sup_" ++ atom_to_list(SwcGroup)),
-    supervisor:start_link({local, SupName}, ?MODULE, [SwcGroup]).
+    supervisor:start_link({local, SupName}, ?MODULE, [SwcGroup, Opts]).
 
 %%%===================================================================
 %%% Supervisor callbacks
@@ -56,15 +59,20 @@ start_link(SwcGroup) ->
 %%                     {error, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init([SwcGroup]) ->
+init([SwcGroup, Opts]) ->
+
+    MembershipStrategy = proplists:get_value(membership_strategy, Opts, plumtree),
 
     PeerName = node(),
+
     DbBackend =
-    case application:get_env(vmq_swc, db_backend) of
-        {ok, rocksdb} -> vmq_swc_db_rocksdb;
-        {ok, leveled} -> vmq_swc_db_leveled;
-        {ok, leveldb} -> vmq_swc_db_leveldb
+    case proplists:get_value(db_backend, Opts, application:get_env(vmq_swc, db_backend, leveldb)) of
+        rocksdb -> vmq_swc_db_rocksdb;
+        leveled -> vmq_swc_db_leveled;
+        leveldb -> vmq_swc_db_leveldb
     end,
+
+    DbOpts = proplists:get_value(db_opts, Opts, []),
 
     Config = config(PeerName, SwcGroup, DbBackend, vmq_swc_edist_srv),
     % this table is created by the root supervisor
@@ -77,7 +85,7 @@ init([SwcGroup]) ->
     TransportChildSpec = #{id => {vmq_swc_edist_srv, SwcGroup},
                            start => {vmq_swc_edist_srv, start_link, [Config]}},
 
-    DBChildSpecs = vmq_swc_db:childspecs(DbBackend, Config, []),
+    DBChildSpecs = vmq_swc_db:childspecs(DbBackend, Config, DbOpts),
 
     BatcherChildSpec = #{id => {vmq_swc_store_batcher, SwcGroup},
                          start => {vmq_swc_store_batcher, start_link, [Config]}},
@@ -87,7 +95,7 @@ init([SwcGroup]) ->
 
     MembershipChildSpec = #{id => {vmq_swc_group_membership, SwcGroup},
                             start => {vmq_swc_group_membership, start_link,
-                                      [Config, plumtree, {vmq_swc_edist_srv, []}]}},
+                                      [Config, MembershipStrategy, {vmq_swc_edist_srv, []}]}},
 
 
     RestartStrategy = one_for_one,

--- a/apps/vmq_swc/src/vmq_swc_sup.erl
+++ b/apps/vmq_swc/src/vmq_swc_sup.erl
@@ -45,12 +45,12 @@ init([]) ->
     ets:new(vmq_swc_group_config, [named_table, public, {read_concurrency, true}]),
     MetricsWorker = #{id => vmq_swc_metrics,
                      start => {vmq_swc_metrics, start_link, []}},
-    GossipWorker = #{id => vmq_swc_plumtree_peer_service_gossip,
-                     start => {vmq_swc_plumtree_peer_service_gossip, start_link, []}},
-    EventsWorker = #{id => vmq_swc_plumtree_peer_service_events,
-                     start => {vmq_swc_plumtree_peer_service_events, start_link, []}},
+    GossipWorker = #{id => vmq_swc_peer_service_gossip,
+                     start => {vmq_swc_peer_service_gossip, start_link, []}},
+    EventsWorker = #{id => vmq_swc_peer_service_events,
+                     start => {vmq_swc_peer_service_events, start_link, []}},
 
-    _State = vmq_swc_plumtree_peer_service_manager:init(),
+    _State = vmq_swc_peer_service_manager:init(),
 
     {ok, { {one_for_one, 1000, 3600}, [MetricsWorker, GossipWorker, EventsWorker]} }.
 

--- a/apps/vmq_swc/test/vmq_swc_store_SUITE.erl
+++ b/apps/vmq_swc/test/vmq_swc_store_SUITE.erl
@@ -113,7 +113,7 @@ basic_store_test(_Config) ->
 
 read_write_delete_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
@@ -132,7 +132,7 @@ read_write_delete_test(Config) ->
 
 partitioned_cluster_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
@@ -157,7 +157,7 @@ partitioned_cluster_test(Config) ->
 
 partitioned_delete_test(Config) ->
     [Node1, Node2] = Nodes = proplists:get_value(nodes, Config),
-    ?assertEqual(ok, rpc:call(Node1, vmq_swc_plumtree_peer_service, join, [Node2])),
+    ?assertEqual(ok, rpc:call(Node1, vmq_swc_peer_service, join, [Node2])),
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
     [?assertEqual({Node, Expected}, {Node,
@@ -211,7 +211,7 @@ partitioned_delete_test(Config) ->
 
 siblings_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
@@ -259,7 +259,7 @@ cluster_join_test(Config) ->
     % we form two clusters, fill them with data, let the log GC cleanup
     % all history and let them join, as a result all nodes should have all the data.
     [OtherNode, Node1 | OtherNodes] = AllNodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Nodes0 = [Node1 | OtherNodes],
     Expected0 = lists:sort(Nodes0),
@@ -275,7 +275,7 @@ cluster_join_test(Config) ->
     ok = wait_until_converged(Nodes0, {foo, bar}, canary, 1),
 
     % join the two clusters
-    ?assertEqual(ok, rpc:call(OtherNode, vmq_swc_plumtree_peer_service, join, [Node1])),
+    ?assertEqual(ok, rpc:call(OtherNode, vmq_swc_peer_service, join, [Node1])),
     Expected1 = lists:sort(AllNodes),
     ok = vmq_swc_test_utils:wait_until_joined(AllNodes, Expected1),
     ok = wait_until_converged(AllNodes, {foo, bar}, baz, quux),
@@ -283,7 +283,7 @@ cluster_join_test(Config) ->
 
 cluster_leave_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
@@ -297,7 +297,7 @@ cluster_leave_test(Config) ->
     ok = wait_until_converged(Nodes, {foo, bar}, canary, 1),
 
     % remove Node1
-    ok = rpc:call(Node1, vmq_swc_plumtree_peer_service, leave, [[]]),
+    ok = rpc:call(Node1, vmq_swc_peer_service, leave, [[]]),
     [Node2|_] = Nodes1 = Nodes -- [Node1],
 
     % put some new data
@@ -306,7 +306,7 @@ cluster_leave_test(Config) ->
 
 events_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
     Expected = lists:sort(Nodes),
     ok = vmq_swc_test_utils:wait_until_joined(Nodes, Expected),
@@ -343,7 +343,7 @@ events_test(Config) ->
 full_sync_test(Config) ->
     [LastNode|Nodes] = proplists:get_value(nodes, Config),
     [Node1|OtherNodes] = Nodes,
-    [?assertEqual(ok, rpc:call(Node, vmq_swc_plumtree_peer_service, join, [Node1]))
+    [?assertEqual(ok, rpc:call(Node, vmq_swc_peer_service, join, [Node1]))
      || Node <- OtherNodes],
 
     Expected = lists:sort(Nodes),
@@ -363,7 +363,7 @@ full_sync_test(Config) ->
                    end, Objects),
 
     % let's join the LastNode,
-    ?assertEqual(ok, rpc:call(LastNode, vmq_swc_plumtree_peer_service, join, [Node1])),
+    ?assertEqual(ok, rpc:call(LastNode, vmq_swc_peer_service, join, [Node1])),
 
     % insert some more entries while joining the cluster
     Objects1 = [{crypto:strong_rand_bytes(100), I + 100} || I <- lists:seq(1,100)], % use something where insertion order doesn't reflect key ordering.

--- a/apps/vmq_swc/test/vmq_swc_test_utils.erl
+++ b/apps/vmq_swc/test/vmq_swc_test_utils.erl
@@ -115,7 +115,7 @@ start_node(Name, Config, Case) ->
 
             {ok, _} = rpc:call(Node, vmq_swc, start, [SwcGroup]),
             ok = wait_until(fun() ->
-                            case rpc:call(Node, vmq_swc_plumtree_peer_service_manager, get_local_state, []) of
+                            case rpc:call(Node, vmq_swc_peer_service_manager, get_local_state, []) of
                                 {ok, _Res} -> true;
                                 _ -> false
                             end

--- a/changelog.md
+++ b/changelog.md
@@ -41,7 +41,7 @@
   incoming publishes.
 - Enable to define the MQTT protocol version to be used by vmq_bridge (4 or 3).
 - Fix vmq_bridge dynamic configuration handling.
-- Fix multiple minor issues with vmq_swc.
+- Fix multiple minor issues in vmq_swc.
 
 ## VerneMQ 1.9.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,7 @@
   incoming publishes.
 - Enable to define the MQTT protocol version to be used by vmq_bridge (4 or 3).
 - Fix vmq_bridge dynamic configuration handling.
+- Fix multiple minor issues with vmq_swc.
 
 ## VerneMQ 1.9.2
 


### PR DESCRIPTION
Refactorings:
- The references to Plumtree are deleted, as vmq_swc only uses the peer membership functionality from the origin Plumtree project, which aren't related to the actual Plumtree algorithm. We now use the 'auto' membership strategy instead of 'plumtree'.
- The transport module doesn't require the `swc_config` record for initiating a RPC, this enables that the RPC mechanism could be easier reused outside of `vmq_swc`
- The group membership server is now able to handle different 'membership_strategies', the default one is 'auto' (previously known as plumtree) . Alternatively it is now possible to set it to 'manual', enabling that an external process manages the peer membership.

Bug fixes:
- vmq_swc PUT operations didn't pass the old object context, they do now.