### PR TITLE
Fix SWC cleanup during cluster leave

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
   unavailable.
 - Fix bug where vmq_metrics crashes because external metric providers haven't
   started yet.
+- Fix bug in vmq_swc where a cluster leave didn't properly cleanup the node clock.
 
 ## VerneMQ 1.10.0
 


### PR DESCRIPTION
This should fix the part of #1363 with the SWC AE sync logs indicating that SWC is repeatedly syncing the same objects in every AE round. 

@ertanden could you please test with this PR? Thanks!