### PR TITLE
Fix compilation in OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vars.generated
 vars/dev*_vars.config
 *.deb
 *.rpm
+*.crashdump
 
 .ropeproject
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - memcached
 
 before_install:
+  - sudo apt-get -y install libsnappy-dev
   - mysql -e "CREATE DATABASE vmq_test_database;" -uroot
   - mysql -e "CREATE USER 'vmq_test_user' IDENTIFIED BY 'vmq_test_password';" -uroot
   - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'vmq_test_user';" -uroot

--- a/apps/vmq_generic_msg_store/rebar.config
+++ b/apps/vmq_generic_msg_store/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 {deps, [
         lager,
-        {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
+        {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", {branch, "develop"}}},
         {sext, "1.5.0"}
        ]}.
 

--- a/apps/vmq_swc/rebar.config
+++ b/apps/vmq_swc/rebar.config
@@ -3,7 +3,7 @@
         lager,
         {sext, "1.5.0"},
         {swc, {git, "git://github.com/vernemq/ServerWideClocks.git", "master"}},
-        {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
+        {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", {branch, "develop"}}},
         riak_dt
        ]}.
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Fix bug where vmq_metrics crashes because external metric providers haven't
   started yet.
 - Fix bug in vmq_swc where a cluster leave didn't properly cleanup the node clock.
+- Fix compilation on OSX Mojave and Catalina. Requires running `brew install openssl snappy`.
 
 ## VerneMQ 1.10.0
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -29,7 +29,7 @@
   1},
  {<<"eleveldb">>,
   {git,"git://github.com/vernemq/eleveldb.git",
-       {ref,"751961c905764ef947330773d6678cac5991d98f"}},
+       {ref,"06fefb8102b7fd344c3c56810dee8a2f2c9691d7"}},
   0},
  {<<"emysql">>,
   {git,"git://github.com/djustinek/Emysql.git",


### PR DESCRIPTION
Fixes #1391

**This PR adds:**

- Temporarily upgraded `eleveldb` dependency to compile in OSX.

- Fix for OSX compilation due to recent [Homebrew changes](https://github.com/Homebrew/homebrew-core/pull/46876) that added OpenSSL 1.1 and deprecated 1.0, this new way will ensure that compilation always use the latest OpenSSL installed by Homebrew, making it more resilient to changes. Still could be issues on systems that had the previous OpenSSL version and static libraries are still hanging around (The error looks like `dyld: Library not loaded: /usr/local/opt/openssl@1.1/lib/libcrypto.1.0.0.dylib`), the best on this case is to run:

```shell
$ brew update
$ brew uninstall --ignore-dependencies openssl
$ brew install openssl
```