### PR TITLE
Expose cert chaing depth & Support multilevel bridge prefixes

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -266,6 +266,12 @@
                                                            {include_default, "sbr0"},
                                                            {commented, ""}
                                                           ]}. 
+%% @doc Setting the depth for intermediate chains
+{mapping, "vmq_bridge.ssl.$name.depth", "vmq_bridge.config", [
+                                                           {default, 1},
+                                                           {datatype, integer},
+                                                           hidden
+                                                          ]}.                   
 
 {mapping, "vmq_bridge.registry_mfa", "vmq_bridge.registry_mfa", 
  [
@@ -352,7 +358,7 @@
                     "username", "password", "restart_timeout", "try_private", "topic",
                      "max_outgoing_buffered_messages", "mqtt_version"],
                     %% SSL specific
-         SSLMapps = ["cafile", "certfile", "keyfile", "insecure", "tls_version", "identity", "psk"],
+         SSLMapps = ["cafile", "certfile", "keyfile", "insecure", "tls_version", "identity", "psk", "depth"],
          F = fun(Prefix, Suffix, Validator) ->
                      %% get the name value pairs
                      Prefix3 = lists:flatten([Prefix, ".$name"]),
@@ -425,6 +431,7 @@
          {SSLIPs, SSLVersions} = lists:unzip(F("vmq_bridge.ssl", "tls_version", AtomVal)),
          {SSLIPs, SSLIdentities} = lists:unzip(F("vmq_bridge.ssl", "identity", StringVal)),
          {SSLIPs, SSLPSKs} = lists:unzip(F("vmq_bridge.ssl", "psk", StringVal)),
+         {SSLIPS, SSLDepths} = lists:unzip(F("vmq_bridge.ssl", "depth", IntVal)),
 
          TCP = lists:zip(TCPIPs, MZip([TCPCleanSessions, 
                                        TCPClientIds, 
@@ -453,7 +460,8 @@
                                        SSLInsecures, 
                                        SSLVersions, 
                                        SSLIdentities, 
-                                       SSLPSKs])),
+                                       SSLPSKs,
+                                       SSLDepths])),
          DropUndef = fun(L) ->
                              [{K, [I || {_, V} = I  <- SubL, V /= undefined]} || {K, SubL} <- L]
                      end,

--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -295,6 +295,7 @@ client_opts(ssl, Host, Port, Opts) ->
     SSLOpts = [{certfile, proplists:get_value(certfile, Opts)},
                {cacertfile, proplists:get_value(cafile, Opts)},
                {keyfile, proplists:get_value(keyfile, Opts)},
+               {depth, proplists:get_value(depth, Opts)},
                {verify, case proplists:get_value(insecure, Opts) of
                             true -> verify_none;
                             _ -> verify_peer

--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -257,6 +257,9 @@ add_prefix(undefined, Topic) -> Topic;
 add_prefix(Prefix, Topic) -> lists:flatten([Prefix, Topic]).
 
 remove_prefix(undefined, Topic) -> Topic;
+remove_prefix([], Topic) -> Topic;
+remove_prefix([H|Prefix], [H|Topic]) ->
+    remove_prefix(Prefix, Topic);
 remove_prefix([Prefix], Topic) ->
     remove_prefix(Prefix, Topic);
 remove_prefix(Prefix, [Prefix|Rest]) ->  Rest.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Support multilevel bridge prefixes.
+- Make SSL cert depth configurable for bridges.
 
 ## VerneMQ 1.10.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## VerneMQ 1.10.1
+
 - Upgrade the Plumtree metadata backend to include a fix for a crash which could
   occur during metadata exchange with a remote node if the remote node becomes
   unavailable.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Support multilevel bridge prefixes.
+
 ## VerneMQ 1.10.1
 
 - Upgrade the Plumtree metadata backend to include a fix for a crash which could


### PR DESCRIPTION
WIP. Adds:

- Configuration of cert depth for TLS bridges in the vernemq.conf file: `vmq_bridge.ssl.sbr0.depth =  4`
- Support for multilevel prefixes both for local and remote prefix, in configuring topics for bridges.

Note that you should not configure bridge topics with overlapping local subscriptions:
a/b/c and +/b/+ will both match for messages published to a/b/c.

TODO:
- [ ] tests
- [ ] check whether overlapping subscription cases work correctly
