### PR TITLE
Update on_deliver* and add new on_session_expired hook to vmq_webhooks and vmq_diversity

### DIFF
--- a/apps/vmq_diversity/priv/auth/auth_commons.lua
+++ b/apps/vmq_diversity/priv/auth/auth_commons.lua
@@ -75,6 +75,9 @@ end
 function on_client_offline(c)
 end
 
+function on_session_expired(c)
+end
+
 -- set for every DB auth handler
 num_states = 10
 keep_state = false

--- a/apps/vmq_diversity/priv/auth/cockroachdb.lua
+++ b/apps/vmq_diversity/priv/auth/cockroachdb.lua
@@ -37,6 +37,7 @@ hooks = {
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
     on_client_offline = on_client_offline,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_publish_m5 = auth_on_publish_m5,

--- a/apps/vmq_diversity/priv/auth/mongodb.lua
+++ b/apps/vmq_diversity/priv/auth/mongodb.lua
@@ -98,6 +98,7 @@ hooks = {
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
     on_client_offline = on_client_offline,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_publish_m5 = auth_on_publish_m5,

--- a/apps/vmq_diversity/priv/auth/mysql.lua
+++ b/apps/vmq_diversity/priv/auth/mysql.lua
@@ -100,6 +100,7 @@ hooks = {
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
     on_client_offline = on_client_offline,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_publish_m5 = auth_on_publish_m5,

--- a/apps/vmq_diversity/priv/auth/postgres.lua
+++ b/apps/vmq_diversity/priv/auth/postgres.lua
@@ -37,6 +37,7 @@ hooks = {
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
     on_client_offline = on_client_offline,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_publish_m5 = auth_on_publish_m5,

--- a/apps/vmq_diversity/priv/auth/redis.lua
+++ b/apps/vmq_diversity/priv/auth/redis.lua
@@ -64,6 +64,7 @@ hooks = {
     on_unsubscribe = on_unsubscribe,
     on_client_gone = on_client_gone,
     on_client_offline = on_client_offline,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     auth_on_publish_m5 = auth_on_publish_m5,

--- a/apps/vmq_diversity/src/vmq_diversity.app.src
+++ b/apps/vmq_diversity/src/vmq_diversity.app.src
@@ -37,7 +37,7 @@
         {vmq_diversity_plugin, on_publish, 6, []},
         {vmq_diversity_plugin, on_subscribe, 3, []},
         {vmq_diversity_plugin, on_unsubscribe, 3, []},
-        {vmq_diversity_plugin, on_deliver, 4, []},
+        {vmq_diversity_plugin, on_deliver, 6, []},
 
         {vmq_diversity_plugin, auth_on_register_m5, 6, []},
         {vmq_diversity_plugin, auth_on_publish_m5, 7, []},
@@ -46,13 +46,14 @@
         {vmq_diversity_plugin, on_publish_m5, 7, []},
         {vmq_diversity_plugin, on_subscribe_m5, 4, []},
         {vmq_diversity_plugin, on_unsubscribe_m5, 4, []},
-        {vmq_diversity_plugin, on_deliver_m5, 5, []},
+        {vmq_diversity_plugin, on_deliver_m5, 7, []},
         {vmq_diversity_plugin, on_auth_m5, 3, []},
 
         {vmq_diversity_plugin, on_offline_message, 5, []},
         {vmq_diversity_plugin, on_client_wakeup, 1, []},
         {vmq_diversity_plugin, on_client_offline, 1, []},
-        {vmq_diversity_plugin, on_client_gone, 1, []}]},
+        {vmq_diversity_plugin, on_client_gone, 1, []},
+        {vmq_diversity_plugin, on_session_expired, 1, []}]},
       {db_config, [
               {postgres, [
                           {host, "localhost"},

--- a/apps/vmq_diversity/src/vmq_diversity_plugin.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_plugin.erl
@@ -29,6 +29,7 @@
 -behaviour(on_client_wakeup_hook).
 -behaviour(on_client_offline_hook).
 -behaviour(on_client_gone_hook).
+-behaviour(on_session_expired_hook).
 
 -behaviour(auth_on_register_m5_hook).
 -behaviour(on_register_m5_hook).
@@ -45,16 +46,17 @@
          on_publish/6,
          on_subscribe/3,
          on_unsubscribe/3,
-         on_deliver/4,
+         on_deliver/6,
          on_offline_message/5,
          on_client_wakeup/1,
          on_client_offline/1,
          on_client_gone/1,
+         on_session_expired/1,
          auth_on_register_m5/6,
          on_register_m5/4,
          auth_on_publish_m5/7,
          on_publish_m5/7,
-         on_deliver_m5/5,
+         on_deliver_m5/7,
          auth_on_subscribe_m5/4,
          on_subscribe_m5/4,
          on_unsubscribe_m5/4,
@@ -304,13 +306,15 @@ on_publish_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
                         {retain, IsRetain},
                         {properties, conv_args_props(Props)}]).
 
-on_deliver_m5(UserName, SubscriberId, Topic, Payload, Props) ->
+on_deliver_m5(UserName, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all_till_ok(on_deliver_m5, [{username, nilify(UserName)},
                                 {mountpoint, MP},
                                 {client_id, ClientId},
+                                {qos, QoS},
                                 {topic, unword(Topic)},
                                 {payload, Payload},
+                                {retain, IsRetain},
                                 {properties, conv_args_props(Props)}]).
 
 auth_on_subscribe(UserName, SubscriberId, Topics) ->
@@ -504,13 +508,15 @@ on_unsubscribe(UserName, SubscriberId, Topics) ->
                                                    || T <- Topics]}])
     end.
 
-on_deliver(UserName, SubscriberId, Topic, Payload) ->
+on_deliver(UserName, SubscriberId, QoS, Topic, Payload, IsRetain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
     all_till_ok(on_deliver, [{username, nilify(UserName)},
                              {mountpoint, MP},
                              {client_id, ClientId},
+                             {qos, QoS},
                              {topic, unword(Topic)},
-                             {payload, Payload}]).
+                             {payload, Payload},
+                             {retain, IsRetain}]).
 
 on_offline_message(SubscriberId, QoS, Topic, Payload, Retain) ->
     {MP, ClientId} = subscriber_id(SubscriberId),
@@ -537,6 +543,12 @@ on_client_gone(SubscriberId) ->
     vmq_diversity_cache:clear_cache(MP, ClientId),
     all(on_client_gone, [{mountpoint, MP},
                          {client_id, ClientId}]).
+
+on_session_expired(SubscriberId) ->
+    {MP, ClientId} = subscriber_id(SubscriberId),
+    vmq_diversity_cache:clear_cache(MP, ClientId),
+    all(on_session_expired, [{mountpoint, MP},
+                             {client_id, ClientId}]).
 
 %%%===================================================================
 %%% Internal functions

--- a/apps/vmq_diversity/test/plugin_test.lua
+++ b/apps/vmq_diversity/test/plugin_test.lua
@@ -124,9 +124,11 @@ end
 function on_deliver(pub)
     assert(pub.username == "test-user")
     assert(pub.client_id == "allowed-subscriber-id")
+    assert(pub.qos == 1)
     assert(pub.mountpoint == "")
     assert(pub.topic == "test/topic")
     assert(pub.payload == "hello world")
+    assert(pub.retain == false)
     print("on_deliver called")
     return true
 end
@@ -157,6 +159,12 @@ function on_client_gone(ev)
     assert(ev.client_id == "allowed-subscriber-id")
     assert(ev.mountpoint == "")
     print("on_client_gone called")
+end
+
+function on_session_expired(ev)
+    assert(ev.client_id == "allowed-subscriber-id")
+    assert(ev.mountpoint == "")
+    print("on_session_expired called")
 end
 
 function auth_on_register_m5(reg)
@@ -282,9 +290,11 @@ end
 function on_deliver_m5(pub)
    assert(pub.username == "test-user")
    assert(pub.client_id == "allowed-subscriber-id")
+   assert(pub.qos == 1)
    assert(pub.mountpoint == "")
    assert(pub.topic == "test/topic")
    assert(pub.payload == "hello world")
+   assert(pub.retain == false)
    assert(pub.properties)
    properties = pub.properties
    assert(properties.p_correlation_data == "correlation_data")
@@ -378,6 +388,7 @@ hooks = {
     on_client_wakeup = on_client_wakeup,
     on_client_offline = on_client_offline,
     on_client_gone = on_client_gone,
+    on_session_expired = on_session_expired,
 
     auth_on_register_m5 = auth_on_register_m5,
     on_register_m5 = on_register_m5,

--- a/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
+++ b/apps/vmq_diversity/test/vmq_diversity_plugin_SUITE.erl
@@ -47,6 +47,7 @@ all() ->
      on_client_wakeup_test,
      on_client_offline_test,
      on_client_gone_test,
+     on_session_expired_test,
      auth_on_register_undefined_creds_test,
      invalid_modifiers_test,
 
@@ -126,7 +127,7 @@ on_unsubscribe_test(_) ->
 
 on_deliver_test(_) ->
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [username(), allowed_subscriber_id(), topic(), payload()]).
+                                [username(), allowed_subscriber_id(), 1, topic(), payload(), false]).
 
 on_offline_message_test(_) ->
     [next] = vmq_plugin:all(on_offline_message, [allowed_subscriber_id(), 2,
@@ -137,6 +138,8 @@ on_client_offline_test(_) ->
     [next] = vmq_plugin:all(on_client_offline, [allowed_subscriber_id()]).
 on_client_gone_test(_) ->
     [next] = vmq_plugin:all(on_client_gone, [allowed_subscriber_id()]).
+on_session_expired_test(_) ->
+    [next] = vmq_plugin:all(on_session_expired, [allowed_subscriber_id()]).
 
 auth_on_register_undefined_creds_test(_) ->
     Username = undefined,
@@ -228,7 +231,7 @@ on_publish_m5_test(_) ->
     [next] = vmq_plugin:all(on_publish_m5, Args).
 
 on_deliver_m5_test(_) ->
-    Args = [username(), allowed_subscriber_id(), topic(), payload(),
+    Args = [username(), allowed_subscriber_id(), 1, topic(), payload(), false,
             #{?P_USER_PROPERTY =>
                   [{<<"k1">>, <<"v1">>},
                    {<<"k2">>, <<"v2">>}],

--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.app.src
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.app.src
@@ -19,7 +19,7 @@
          {vmq_mqtt5_demo_plugin, on_subscribe_m5, 4, []},
          {vmq_mqtt5_demo_plugin, on_unsubscribe_m5, 4, []},
          {vmq_mqtt5_demo_plugin, on_auth_m5, 3, []},
-         {vmq_mqtt5_demo_plugin, on_deliver_m5, 5, []}
+         {vmq_mqtt5_demo_plugin, on_deliver_m5, 7, []}
         ]
        }]},
   {modules, []},

--- a/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
+++ b/apps/vmq_mqtt5_demo_plugin/src/vmq_mqtt5_demo_plugin.erl
@@ -22,7 +22,7 @@
          on_subscribe_m5/4,
          on_unsubscribe_m5/4,
          on_auth_m5/3,
-         on_deliver_m5/5]).
+         on_deliver_m5/7]).
 
 %%====================================================================
 %% API functions
@@ -181,11 +181,11 @@ on_auth_m5_(_Username, _SubscriberId, _Props) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%% Delivery hooks %%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
-on_deliver_m5(Username,SubscriberId,Topic,Payload,Properties) ->
-    ?LOG([on_deliver_m5,Username,SubscriberId,Topic,Payload,Properties]),
-    on_deliver_m5_(Username,SubscriberId,Topic,Payload,Properties).
+on_deliver_m5(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties) ->
+    ?LOG([on_deliver_m5,Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties]),
+    on_deliver_m5_(Username,SubscriberId,QoS,Topic,Payload,IsRetain,Properties).
 
-on_deliver_m5_(<<"remove_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
+on_deliver_m5_(<<"remove_props_on_deliver_m5">>,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,
                #{?P_PAYLOAD_FORMAT_INDICATOR := _,
                  ?P_CONTENT_TYPE := _,
                  ?P_USER_PROPERTY := _,
@@ -193,7 +193,7 @@ on_deliver_m5_(<<"remove_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
                  ?P_RESPONSE_TOPIC := _}) ->
     NewProps = #{},
     {ok, #{properties => NewProps}};
-on_deliver_m5_(<<"modify_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
+on_deliver_m5_(<<"modify_props_on_deliver_m5">>,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,
                #{?P_PAYLOAD_FORMAT_INDICATOR := unspecified,
                  ?P_CONTENT_TYPE := <<"type1">>,
                  ?P_USER_PROPERTY := UserProperties,
@@ -207,5 +207,5 @@ on_deliver_m5_(<<"modify_props_on_deliver_m5">>,_SubscriberId,_Topic,_Payload,
                  ?P_RESPONSE_TOPIC => <<"modified_",  RT/binary>>},
     {ok, #{properties => NewProps}};
 
-on_deliver_m5_(_Username,_SubscriberId,_Topic,_Payload,_Properties) ->
+on_deliver_m5_(_Username,_SubscriberId,_QoS,_Topic,_Payload,_IsRetain,_Properties) ->
     ok.

--- a/apps/vmq_webhooks/src/vmq_webhooks.app.src
+++ b/apps/vmq_webhooks/src/vmq_webhooks.app.src
@@ -27,7 +27,7 @@
       {vmq_webhooks_plugin, on_publish, 6, []},
       {vmq_webhooks_plugin, on_subscribe, 3, []},
       {vmq_webhooks_plugin, on_unsubscribe, 3, []},
-      {vmq_webhooks_plugin, on_deliver, 4, []},
+      {vmq_webhooks_plugin, on_deliver, 6, []},
 
       {vmq_webhooks_plugin, auth_on_register_m5, 6, []},
       {vmq_webhooks_plugin, auth_on_publish_m5, 7, []},
@@ -36,12 +36,13 @@
       {vmq_webhooks_plugin, on_publish_m5, 7, []},
       {vmq_webhooks_plugin, on_subscribe_m5, 4, []},
       {vmq_webhooks_plugin, on_unsubscribe_m5, 4, []},
-      {vmq_webhooks_plugin, on_deliver_m5, 5, []},
+      {vmq_webhooks_plugin, on_deliver_m5, 7, []},
       {vmq_webhooks_plugin, on_auth_m5, 3, []},
 
       {vmq_webhooks_plugin, on_offline_message, 5, []},
       {vmq_webhooks_plugin, on_client_wakeup, 1, []},
       {vmq_webhooks_plugin, on_client_offline, 1, []},
+      {vmq_webhooks_plugin, on_session_expired, 1, []},
       {vmq_webhooks_plugin, on_client_gone, 1, []}]}
   ]},
   {modules, []},

--- a/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_cli.erl
@@ -169,6 +169,7 @@ hook_keyspec() ->
                                         "on_client_wakeup",
                                         "on_client_offline",
                                         "on_client_gone",
+					"on_session_expired",
                                         "auth_on_register_m5",
                                         "auth_on_publish_m5",
                                         "auth_on_subscribe_m5",

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -64,6 +64,7 @@ all() ->
      on_client_wakeup_test,
      on_client_offline_test,
      on_client_gone_test,
+     on_session_expired_test,
      base64payload_test,
      auth_on_register_undefined_creds_test,
      cache_auth_on_register,
@@ -236,7 +237,7 @@ on_deliver_test(_) ->
     register_hook(on_deliver, ?ENDPOINT),
     Self = pid_to_bin(self()),
     ok = vmq_plugin:all_till_ok(on_deliver,
-                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?TOPIC, ?PAYLOAD]),
+                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false]),
     ok = exp_response(on_deliver_ok),
     deregister_hook(on_deliver, ?ENDPOINT).
 
@@ -383,14 +384,14 @@ on_deliver_m5_test(_) ->
     register_hook(on_deliver_m5, ?ENDPOINT),
     Self = pid_to_bin(self()),
     ok = vmq_plugin:all_till_ok(on_deliver_m5,
-                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?TOPIC, ?PAYLOAD, #{}]),
+                                [Self, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, 1, ?TOPIC, ?PAYLOAD, false, #{}]),
     ok = exp_response(on_deliver_m5_ok),
     deregister_hook(on_deliver_m5, ?ENDPOINT).
 
 on_deliver_m5_modify_props_test(_) ->
     register_hook(on_deliver_m5, ?ENDPOINT),
     Self = pid_to_bin(self()),
-    Args = [Self, {?MOUNTPOINT, <<"modify_props">>}, ?TOPIC, ?PAYLOAD,
+    Args = [Self, {?MOUNTPOINT, <<"modify_props">>}, 1,  ?TOPIC, ?PAYLOAD, false,
             #{?P_USER_PROPERTY =>
                   [{<<"k1">>, <<"v1">>},
                    {<<"k2">>, <<"v2">>}],
@@ -450,6 +451,13 @@ on_client_gone_test(_) ->
     [next] = vmq_plugin:all(on_client_gone, [{?MOUNTPOINT, Self}]),
     ok = exp_response(on_client_gone_ok),
     deregister_hook(on_client_gone, ?ENDPOINT).
+
+on_session_expired_test(_) ->
+    register_hook(on_session_expired, ?ENDPOINT),
+    Self = pid_to_bin(self()),
+    [next] = vmq_plugin:all(on_session_expired, [{?MOUNTPOINT, Self}]),
+    ok = exp_response(on_session_expired_ok),
+    deregister_hook(on_session_expired, ?ENDPOINT).
 
 base64payload_test(_) ->
     ok = clique:run(["vmq-admin", "webhooks", "register",

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -392,8 +392,10 @@ on_unsubscribe_m5(#{client_id := ?CHANGED_CLIENT_ID}) ->
 on_deliver(#{username := BinPid,
              mountpoint := ?MOUNTPOINT_BIN,
              client_id := ?ALLOWED_CLIENT_ID,
+             qos := 1,
              topic := ?TOPIC,
-             payload := ?PAYLOAD}) ->
+             payload := ?PAYLOAD,
+             retain := false}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_deliver_ok,
     {200, #{result => <<"ok">>}}.
@@ -401,8 +403,10 @@ on_deliver(#{username := BinPid,
 on_deliver_m5(#{username := BinPid,
                 mountpoint := ?MOUNTPOINT_BIN,
                 client_id := ?ALLOWED_CLIENT_ID,
+                qos := 1,
                 topic := ?TOPIC,
-                payload := ?PAYLOAD}) ->
+                payload := ?PAYLOAD,
+                retain := false}) ->
     Pid = list_to_pid(binary_to_list(BinPid)),
     Pid ! on_deliver_m5_ok,
     {200, #{result => <<"ok">>}};
@@ -454,6 +458,12 @@ on_client_gone(#{mountpoint := ?MOUNTPOINT_BIN,
     Pid ! on_client_gone_ok,
     {200, #{}}.
 
+on_session_expired(#{mountpoint := ?MOUNTPOINT_BIN,
+                     client_id := BinPid}) ->
+    Pid = list_to_pid(binary_to_list(BinPid)),
+    Pid ! on_session_expired_ok,
+    {200, #{}}.
+
 on_auth_m5(#{properties :=
                  #{?P_AUTHENTICATION_METHOD := <<"AUTH_METHOD">>,
                    ?P_AUTHENTICATION_DATA := <<"QVVUSF9EQVRBMA==">>}, %% b64(<<"AUTH_DATA0">>)
@@ -494,6 +504,8 @@ process_hook(<<"on_client_offline">>, Body) ->
     on_client_offline(Body);
 process_hook(<<"on_client_gone">>, Body) ->
     on_client_gone(Body);
+process_hook(<<"on_session_expired">>, Body) ->
+    on_session_expired(Body);
 
 process_hook(<<"auth_on_register_m5">>, Body) ->
     auth_on_register_m5(Body);

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add new `on_session_expired/1` hook to `vmq_diversity` and `vmq_webhooks`.
+
 ## VerneMQ 1.10.2
 
 - Support multilevel bridge prefixes.

--- a/rebar.lock
+++ b/rebar.lock
@@ -95,7 +95,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},2},
  {<<"vernemq_dev">>,
   {git,"git://github.com/vernemq/vernemq_dev.git",
-       {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
+       {ref,"9afa661feaf15f73e2a64cd81166cf335329882e"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
As mentioned in #1299 the new on_deliver and on_session_expired hooks should be supported in the plugins and properly documented. These changes fix https://github.com/vernemq/vernemq/issues/1346

- [x] update webhooks
- [x] update diversity
- [x] update plugin hook

I still have the documentation update left.