### PR TITLE
Fix bridge plugin reloading

### DIFF
--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -19,7 +19,8 @@
 
 register_cli() ->
     clique:register_usage(["vmq-admin", "bridge"], bridge_usage()),
-    show_cmd().
+    show_cmd(),
+    start_cmd().
 
 show_cmd() ->
     Cmd = ["vmq-admin", "bridge", "show"],
@@ -43,11 +44,26 @@ show_cmd() ->
         end,
     clique:register_command(Cmd, [], [], Callback).
 
+start_cmd() ->
+    Cmd = ["vmq-admin", "bridge", "start"],
+    Callback =
+        fun(_, [], []) ->
+            Config = application:get_all_env(vmq_bridge),
+            vmq_bridge_sup:change_config([{vmq_bridge, Config}]),
+            Text = clique_status:text("VerneMQ Bridges restarted."),
+            [clique_status:alert([Text])];
+        (_, _, _) ->
+            Text = clique_status:text(bridge_usage()),
+            [clique_status:alert([Text])]
+        end,
+    clique:register_command(Cmd, [], [], Callback).
+
 bridge_usage() ->
     ["vmq-admin bridge <sub-command>\n\n",
      "  Manage MQTT bridges.\n\n",
      "  Sub-commands:\n",
      "    show        Show information about bridges\n\n",
+     "    start       Start the VerneMQ bridges. Useful after enabling the bridge plugin dynamically. \n\n"
      "  Use --help after a sub-command for more details.\n"
     ].
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 - Add new `on_session_expired/1` hook to `vmq_diversity` and `vmq_webhooks`.
 - Add datetime prefix to the tracer output. The datetimes are expressed in UTC with
  [iso-8601](https://www.w3.org/TR/NOTE-datetime) format (eg '2020-04-29T21:19:39Z'). (#782)
-- Add Observer CLI tool for realtime info
+- Add Observer CLI tool for realtime info.
+- Add start command to Bridge CLI.
 
 ## VerneMQ 1.10.2
 


### PR DESCRIPTION
This is hopefully a quick fix for https://github.com/vernemq/vernemq/issues/1477,
by adding a `vmq-admin bridge start` command that will start all bridges, after the bridge plugin has been enabled dynamically by using `vmq-admin plugin enable --name=vmq_bridge`