### PR TITLE
README: add libsnappy requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ started, you need to first build VerneMQ.
 
 ### Building VerneMQ
 
-Note: VerneMQ requires Erlang/OTP 21.2 or newer.
+Note: VerneMQ requires Erlang/OTP 21.2 or newer and `libsnappy-dev` installed in your system.
 
 Assuming you have a working Erlang installation, building VerneMQ should be as
 simple as:


### PR DESCRIPTION
I was trying to compile VerneMQ 1.10.2 locally and it failed while compiling `eleveldb`.

I found the reason in [this comment](https://github.com/vernemq/eleveldb/pull/5#issuecomment-571895630), but since it's a little bit buried (and the error doesn't mention `libsnappy-dev`) I think it's better to add it to the README.