### PR TITLE
WIP: Add custom clique writter using stdout_formatter

### DIFF
--- a/apps/vmq_server/src/vmq_cli_human_writer.erl
+++ b/apps/vmq_server/src/vmq_cli_human_writer.erl
@@ -46,8 +46,8 @@ write_table([]) ->
 write_table(Rows0) ->
     Header = [Name || {Name, _Val} <- hd(Rows0)],
     Rows = [[Val || {_Name, Val} <- Row] || Row <- Rows0],
-    Data = [#row{cells=Header, props=#{title=>true}}|Rows],
-    Table = stdout_formatter:to_string(#table{rows=Data, 
+    Table = stdout_formatter:to_string(
+        #table{rows=[#row{cells = Header, props=#{title => true}} | Rows], 
         props=#{cell_padding => {0,1}, border_drawing => ascii}}),
     io_lib:format("~ts~n", [Table]).
 

--- a/apps/vmq_server/src/vmq_cli_human_writer.erl
+++ b/apps/vmq_server/src/vmq_cli_human_writer.erl
@@ -1,0 +1,68 @@
+-module(vmq_cli_human_writer).
+
+%% @doc This module provides callback functions to the status parsing code in
+%% clique_status:parse/3. It specifically formats the output for a human at the
+%% console and handles an opaque context passed back during parsing.
+
+-behavior(clique_writer).
+
+%% API
+-export([write/1]).
+
+-include_lib("clique/include/clique_status_types.hrl").
+-include_lib("stdout_formatter/include/stdout_formatter.hrl").
+
+-record(context, {alert_set=false :: boolean(),
+                  output="" :: iolist()}).
+
+-spec write(status()) -> {iolist(), iolist()}.
+write(Status) ->
+    Ctx = clique_status:parse(Status, fun write_status/2, #context{}),
+    {Ctx#context.output, []}.
+
+%% @doc Write status information in console format.
+-spec write_status(elem(), #context{}) -> #context{}.
+write_status(alert, Ctx=#context{alert_set=false}) ->
+    Ctx#context{alert_set=true};
+write_status(alert, Ctx) ->
+    %% TODO: Should we just return an error instead?
+    throw({error, nested_alert, Ctx});
+write_status(alert_done, Ctx) ->
+    Ctx#context{alert_set=false};
+write_status({list, Data}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++write_list(Data)};
+write_status({list, Title, Data}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++write_list(Title, Data)};
+write_status({text, Text}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++Text++"\n"};
+write_status({table, Rows}, Ctx=#context{output=Output}) ->
+    Ctx#context{output=Output++write_table(Rows)};
+write_status(done, Ctx) ->
+    Ctx.
+
+-spec write_table([{iolist(), iolist()}]) -> iolist().
+write_table([]) ->
+    "";
+write_table(Rows0) ->
+    Header = [Name || {Name, _Val} <- hd(Rows0)],
+    Rows = [[Val || {_Name, Val} <- Row] || Row <- Rows0],
+    Data = [#row{cells=Header, props=#{title=>true}}|Rows],
+    Table = stdout_formatter:to_string(#table{rows=Data, 
+        props=#{cell_padding => {0,1}, border_drawing => ascii}}),
+    io_lib:format("~ts~n", [Table]).
+
+%% @doc Write a list horizontally
+write_list(Title, Items) when is_atom(Title) ->
+    write_list(atom_to_list(Title), Items);
+%% Assume all items are of same type
+write_list(Title, Items) when is_atom(hd(Items)) ->
+    Items2 = [atom_to_list(Item) || Item <- Items],
+    write_list(Title, Items2);
+write_list(Title, Items) ->
+    %% Todo: add bold/color for Title when supported
+    Title ++ ":" ++ write_list(Items) ++ "\n".
+
+write_list(Items) ->
+    lists:foldl(fun(Item, Acc) ->
+                    Acc++" "++Item
+                end, "", Items).

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -17,7 +17,8 @@
                   vmq_plugin,
                   clique,
                   jsx,
-                  gen_server2
+                  gen_server2,
+                  stdout_formatter
                  ]},
   {mod, { vmq_server_app, []}},
   {env, [

--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -26,6 +26,7 @@ init_registry() ->
     F = fun() -> vmq_cluster:nodes() end,
     clique:register_node_finder(F),
     clique:register([?MODULE, vmq_plugin_cli]),
+    clique_writer:register("human", vmq_cli_human_writer),
     clique_writer:register("json", vmq_cli_json_writer).
 
 command(Cmd) ->

--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,7 @@
         {recon, "2.3.2"},
         observer_cli,
         {lager, "3.8.0"},
+        {stdout_formatter, "0.2.3"},
         %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
         {cuttlefish, {git, "git://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
         {vernemq_dev, {git, "git://github.com/vernemq/vernemq_dev.git", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -85,6 +85,7 @@
  {<<"riak_sysmon">>,{pkg,<<"riak_sysmon">>,<<"2.1.2">>},0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.5.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},1},
+ {<<"stdout_formatter">>,{pkg,<<"stdout_formatter">>,<<"0.2.3">>},0},
  {<<"swc">>,
   {git,"git://github.com/vernemq/ServerWideClocks.git",
        {ref,"4835239dca5a5f4ac7202dd94d7effcaa617d575"}},
@@ -122,5 +123,6 @@
  {<<"riak_sysmon">>, <<"24F804606D65DE1F020138F5E6E3E17BE4C5A41567D5170306378253E3705BAE">>},
  {<<"sext">>, <<"07D5D516DAA4C437B2F7DB99F6B2728C8AF939313479B1BEDC1995BB15936236">>},
  {<<"ssl_verify_fun">>, <<"6EAF7AD16CB568BB01753DBBD7A95FF8B91C7979482B95F38443FE2C8852A79B">>},
+ {<<"stdout_formatter">>, <<"EC24868D8619757A68F0798357C7190807A1CFC42CE90C18C23760E59249A21A">>},
  {<<"unicode_util_compat">>, <<"D869E4C68901DD9531385BB0C8C40444EBF624E60B6962D95952775CAC5E90CD">>}]}
 ].


### PR DESCRIPTION
Potential fixes for https://github.com/vernemq/vernemq/issues/1496,  https://github.com/vernemq/vernemq/issues/1200 and https://github.com/vernemq/vernemq/issues/1290

Still WIP proof of concept using the [stdout_formatter](https://github.com/rabbitmq/stdout_formatter) library from the RabbitMQ Team for shown CLI tables. So far very nice results:

* Tweaked it to look like the original clique human writer
* API remains the same so data structures don't need to change.
* It doesn't hide information on the screen

**TODO:**

- Test it more and see what I could have broken 😬 .
-  Still tweaking it a bit more to wrap large texts over a certain length (client ids for example). 
- Implement some of the messages, user feedback suggested by @puresilk on #1290

**The Fancy stuff:**

<img width="1183" alt="Screen Shot 2020-05-11 at 11 24 43 PM" src="https://user-images.githubusercontent.com/168440/81635613-9bda8180-93df-11ea-9c4c-d856f70dccf7.png">
