### PR TITLE
Quickfix for "vmq-admin bridge show" timeouts in overloaded bridges

### DIFF
--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -60,7 +60,7 @@ start_link(Type, Host, Port, RegistryMFA, Opts) ->
     gen_server:start_link(?MODULE, [Type, Host, Port, RegistryMFA, Opts], []).
 
 info(Pid) ->
-    gen_server:call(Pid, info).
+    gen_server:call(Pid, info, infinity).
 
 %%%===================================================================
 %%% gen_mqtt_client callbacks
@@ -106,12 +106,12 @@ init([{coord, _CoordinatorPid} = State]) ->
     {ok, State}.
 
 handle_call(info, _From, #state{client_pid = Pid} = State) ->
-    {ok, Info} = case Pid of
+    {ResponseType, Info} = case Pid of
                      undefined ->
                          {error, not_started};
                      Pid -> gen_mqtt_client:info(Pid)
                  end,
-    {reply, {ok, Info}, State};
+    {reply, {ResponseType, Info}, State};
 handle_call(_Req, _From, State) ->
     {reply, ok, State}.
 

--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -68,4 +68,7 @@ bridge_usage() ->
     ].
 
 bridge_info() ->
-    vmq_bridge_sup:bridge_info().
+    case vmq_bridge_sup:bridge_info() of
+        {timeout, _} -> [];
+        Info -> Info
+    end.

--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -68,7 +68,4 @@ bridge_usage() ->
     ].
 
 bridge_info() ->
-    case vmq_bridge_sup:bridge_info() of
-        {timeout, _} -> [];
-        Info -> Info
-    end.
+    vmq_bridge_sup:bridge_info().

--- a/apps/vmq_commons/src/gen_mqtt_client.erl
+++ b/apps/vmq_commons/src/gen_mqtt_client.erl
@@ -162,7 +162,7 @@ start(Name, Module, Args, Opts) ->
     gen_fsm:start(Name, ?MODULE, [Module, Args, Opts], GenFSMOpts).
 
 info(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, info).
+    gen_fsm:sync_send_all_state_event(Pid, info, infinity).
 
 stats(Pid) ->
     case erlang:process_info(Pid, [dictionary]) of


### PR DESCRIPTION
This is a quickfix to protect caller and FSM in overloaded bridges where the FSM timeout could be triggered.
The `vmq-admin bridge show` command will wait in the console, but can be safely terminated with ctrl+c. (in addition, the RPC itself will timeout)

I'd like to have a cleaner Error Kernel in the bridge in the future.