### PR TITLE
Minor fixes for things not neede in supported OTP versions

### DIFF
--- a/apps/vmq_commons/src/vmq_types_common.hrl
+++ b/apps/vmq_commons/src/vmq_types_common.hrl
@@ -20,8 +20,7 @@
           mountpoint            :: mountpoint(),
           persisted=false       :: flag(),
           sg_policy=prefer_local:: shared_sub_policy(),
-          %% TODOv5: need to import the mqtt5 property typespec?
-          properties=#{}        :: map(),
+          properties=#{}        :: properties(),
           expiry_ts             :: undefined
                                  | msg_expiry_ts()
          }).

--- a/apps/vmq_server/src/vmq_metrics_http.erl
+++ b/apps/vmq_server/src/vmq_metrics_http.erl
@@ -90,7 +90,7 @@ line(BinMetric, Node, Labels, BinVal) ->
      <<"} ">>, BinVal, <<"\n">>].
 
 labels(Labels) ->
-    join($,,
+    lists:join($,,
          lists:map(fun({Key, Val}) ->
                            label(Key, Val)
                    end, Labels)).
@@ -112,10 +112,3 @@ type(counter) ->
     <<" counter\n">>;
 type(histogram) ->
     <<" histogram\n">>.
-
-%% backported to support OTP18. TODO: replace with lists:join/2 when
-%% dropping OTP18.
-join(Sep, [H|T]) -> [H|join_prepend(Sep, T)].
-
-join_prepend(_Sep, []) -> [];
-join_prepend(Sep, [H|T]) -> [Sep,H|join_prepend(Sep,T)].


### PR DESCRIPTION
Just some cleanups for things that were needed in OTP18