### PR TITLE
Feature/set mqtt connect timeout

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -333,7 +333,7 @@
                                                                          ]}.
 
 %% @doc specifies the connect timeout.
-{mapping, "connect_timeout", "vmq_server.connect_timeout", [
+{mapping, "mqtt_connect_timeout", "vmq_server.mqtt_connect_timeout", [
                                                             {default, 5000},
                                                             {datatype, integer},
                                                             hidden

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -59,7 +59,7 @@ register_config_() ->
      "receive_max_broker",
      "suppress_lwt_on_session_takeover",
      "coordinate_registrations",
-     "connect_timeout"
+     "mqtt_connect_timeout"
     ],
     _ = [clique:register_config([Key], fun register_config_callback/3)
          || Key <- ConfigKeys],

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -25,7 +25,6 @@
 
 -export([msg_ref/0]).
 
--define(CLOSE_AFTER, 5000).
 -define(FC_RECEIVE_MAX, 16#FFFF).
 -define(EXPIRY_INT_MAX, 16#FFFFFFFF).
 -define(MAX_PACKET_SIZE, 16#FFFFFFF).

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -121,9 +121,6 @@ init(Peer, Opts, #mqtt_connect{keep_alive=KeepAlive,
     DOpts0 = set_defopt(suppress_lwt_on_session_takeover, false, #{}),
     DOpts1 = set_defopt(coordinate_registrations, ?COORDINATE_REGISTRATIONS, DOpts0),
 
-    ConnectTimeout = vmq_config:get_env(connect_timeout, 5000),
-    TRef = vmq_mqtt_fsm_util:send_after(ConnectTimeout, close_timeout),
-
     maybe_initiate_trace(ConnectFrame, TraceFun),
 
     set_max_msg_size(MaxMessageSize),

--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -24,8 +24,6 @@
          data_in/2,
          msg_in/2]).
 
--define(CLOSE_AFTER, 5000).
-
 -record(state, {
           peer         :: peer(),
           opts         :: list(),
@@ -34,7 +32,8 @@
          }).
 
 init(Peer, Opts) ->
-    TRef = erlang:send_after(?CLOSE_AFTER, self(), close_timeout),
+    ConnectTimeout = vmq_config:get_env(connect_timeout, 5000),
+    TRef = erlang:send_after(ConnectTimeout, self(), close_timeout),
     State = #state{peer=Peer,
                    opts=Opts,
                    max_message_size=vmq_config:get_env(max_message_size, 0),

--- a/apps/vmq_server/src/vmq_mqtt_pre_init.erl
+++ b/apps/vmq_server/src/vmq_mqtt_pre_init.erl
@@ -32,7 +32,7 @@
          }).
 
 init(Peer, Opts) ->
-    ConnectTimeout = vmq_config:get_env(connect_timeout, 5000),
+    ConnectTimeout = vmq_config:get_env(mqtt_connect_timeout, 5000),
     TRef = erlang:send_after(ConnectTimeout, self(), close_timeout),
     State = #state{peer=Peer,
                    opts=Opts,

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
  [iso-8601](https://www.w3.org/TR/NOTE-datetime) format (eg '2020-04-29T21:19:39Z'). (#782)
 - Add Observer CLI tool for realtime info.
 - Add start command to Bridge CLI.
+- Fix options passed to PublishFun for plugins (#1516)
 
 ## VerneMQ 1.10.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Add Observer CLI tool for realtime info.
 - Add start command to Bridge CLI.
 - Fix options passed to PublishFun for plugins (#1516)
+- Add configurable connect time (mqtt_connect_timeout) between establishing the connection and sending CONNECT (#735, #824).
 
 ## VerneMQ 1.10.2
 


### PR DESCRIPTION
This is a fix for #735 and #824 to make the mqtt connection timeout configurable. The timeout is the time between setting up the TCP or TLS connection and sending the 'CONNECT' message. The timeout time can be specified by setting the mqtt_connect_timeout in the vernemq.conf configuration file. The default is still 5000ms. 