### PR TITLE
Fix to allow equal signs on parameter values on vmq-admin commands

### DIFF
--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -70,7 +70,8 @@ all() ->
      cache_auth_on_register,
      cache_auth_on_publish,
      cache_auth_on_subscribe,
-     cache_expired_entry
+     cache_expired_entry,
+     cli_allow_query_parameters_test
     ].
 
 
@@ -492,6 +493,12 @@ auth_on_register_undefined_creds_test(_) ->
     ok = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, <<"undefined_creds">>}, Username, Password, true]),
     deregister_hook(auth_on_register, ?ENDPOINT).
+
+%% Test for https://github.com/vernemq/vernemq/issues/740
+cli_allow_query_parameters_test(_) ->
+    EndpointWithParams = ?ENDPOINT ++ "/hook?key=value",
+    ok = register_hook(auth_on_register, EndpointWithParams),
+    [] = deregister_hook(auth_on_register, EndpointWithParams).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% helper functions

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 - Add compatibility with [Erlang/OTP 23](http://blog.erlang.org/OTP-23-Highlights/). This release requires Erlang/OTP 21.3 or later.
 - Upgrade package `bcrypt` to version 1.1.0.
 - Upgrade package `hackney` to version 1.16.0 (dependencies of `hackney` were updated as well).
+- Fix to allow equal signs on parameter values on `vmq-admin` commands (#740).
+
+ URL parameters on webhooks
 
 ## VerneMQ 1.10.3
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,7 +7,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.2">>},1},
  {<<"clique">>,
   {git,"git://github.com/vernemq/clique.git",
-       {ref,"ff2e86e891504b0c518bdd5e79979d7abc76a183"}},
+       {ref,"88b2784f32d2f6e1d738ad9b330875e51a9c1888"}},
   0},
  {<<"corman">>,
   {git,"git://github.com/EchoTeam/corman.git",


### PR DESCRIPTION
Fixes #740 

Proof:
<img width="1022" alt="Screen Shot 2020-06-17 at 11 20 31 AM" src="https://user-images.githubusercontent.com/168440/84916971-bf52b500-b08c-11ea-8998-214e26c2260d.png">
