### PR TITLE
Add Subscriber trie/event handler readiness check to handle fast subs…

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -77,7 +77,7 @@ subscribe(false, SubscriberId, Topics) ->
     vmq_cluster:if_ready(fun subscribe_op/2, [SubscriberId, Topics]);
 subscribe(true, SubscriberId, Topics) ->
     %% trade consistency for availability
-    subscribe_op(SubscriberId, Topics).
+    if_ready(fun subscribe_op/2, [SubscriberId, Topics]).
 
 subscribe_op(SubscriberId, Topics) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),
@@ -965,3 +965,13 @@ retain_pre(FutureRetain) when is_tuple(FutureRetain),
                               is_integer(element(2, FutureRetain)),
                               element(2, FutureRetain) > ?RETAIN_PRE_V ->
     element(3, FutureRetain).
+
+
+-spec if_ready(_, _) -> any().
+if_ready(Fun, Args) ->
+    case persistent_term:get(subscriber_trie_ready, 0) of
+        1 ->
+            apply(Fun, Args);
+        0 ->
+            {error, not_ready}
+    end.

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -201,6 +201,7 @@ handle_info(subscribers_loaded, #state{event_handler=Handler,
                           handle_event(Handler, Event)
                   end, queue:to_list(Q)),
     NrOfSubscribers = ets:info(vmq_trie_subs, size),
+    persistent_term:put(subscribe_trie_ready, 1),
     lager:info("loaded ~p subscriptions into ~p", [NrOfSubscribers, ?MODULE]),
     {noreply, State#state{status=ready, event_queue=undefined}};
 handle_info(Event, #state{status=init, event_queue=Q} = State) ->

--- a/apps/vmq_server/src/vmq_server_sup.erl
+++ b/apps/vmq_server/src/vmq_server_sup.erl
@@ -42,7 +42,7 @@ start_link() ->
                            permanent, pos_integer(), worker, [atom()]}]}}.
 init([]) ->
     maybe_change_nodename(),
-
+    persistent_term:put(subscribe_trie_ready, 0),
     {ok, { {one_for_one, 5, 10},
            [
                ?CHILD(vmq_config, worker, []),


### PR DESCRIPTION
…cribers after a node reboot

Fixes https://github.com/vernemq/vernemq/issues/1555
Similar to the check for CAP settings and cluster readiness for subscribes, this introduces a readiness check for the trie.

During the window after a node reboot, the server will answer with 128 failure code to subscription attempts.