### PR TITLE
WIP: handling (some) LevelDB corruption errors automatically

### DIFF
--- a/apps/vmq_generic_msg_store/src/engines/vmq_storage_engine_leveldb.erl
+++ b/apps/vmq_generic_msg_store/src/engines/vmq_storage_engine_leveldb.erl
@@ -139,23 +139,58 @@ config_value(Key, Config, Default) ->
 open_db(_Opts, _State0, 0, LastError) ->
     {error, LastError};
 open_db(Opts, State0, RetriesLeft, _) ->
-    case eleveldb:open(State0#state.data_root, State0#state.open_opts) of
+    DataRoot = State0#state.data_root,
+    case eleveldb:open(DataRoot, State0#state.open_opts) of
         {ok, Ref} ->
+            lager:info("Opening LevelDB database at ~p~n", [DataRoot]),
             {ok, State0#state { ref = Ref }};
         %% Check specifically for lock error, this can be caused if
         %% a crashed instance takes some time to flush leveldb information
         %% out to disk.  The process is gone, but the NIF resource cleanup
         %% may not have completed.
         {error, {db_open, OpenErr}=Reason} ->
-            case lists:prefix("IO error: lock ", OpenErr) of
+            case lists:prefix("Corruption: truncated record ", OpenErr) of
                 true ->
-                    SleepFor = proplists:get_value(open_retry_delay, Opts, 2000),
-                    lager:debug("VerneMQ LevelDB backend retrying ~p in ~p ms after error ~s\n",
-                                [State0#state.data_root, SleepFor, OpenErr]),
-                    timer:sleep(SleepFor),
-                    open_db(Opts, State0, RetriesLeft - 1, Reason);
+                    lager:info("VerneMQ LevelDB backend repair attempt for store ~p, after error ~s\n",
+                            [DataRoot, OpenErr]),
+                    case eleveldb:repair(DataRoot, []) of
+                        ok -> % LevelDB will put unusable .log and MANIFEST files in 'lost' folder.
+                            open_db(Opts, State0, RetriesLeft - 1, Reason);
+                        {error, Reason} -> {error, Reason}
+                    end;
+                
                 false ->
-                    {error, Reason}
+                    case lists:prefix("IO error: lock ", OpenErr) of
+                        true ->
+                            SleepFor = proplists:get_value(open_retry_delay, Opts, 2000),
+                            lager:info("VerneMQ LevelDB backend retrying ~p in ~p ms after error ~s\n",
+                                        [DataRoot, SleepFor, OpenErr]),
+                            timer:sleep(SleepFor),
+                            open_db(Opts, State0, RetriesLeft - 1, Reason);
+                    false ->
+                        case lists:prefix("Corruption: bad record length", OpenErr) of
+                            true ->
+                                lager:info("VerneMQ LevelDB backend repair attempt for store ~p, after error ~s\n",
+                                        [DataRoot, OpenErr]),
+                                case eleveldb:repair(DataRoot, []) of
+                                    ok -> % LevelDB will put unusable .log and MANIFEST files in 'lost' folder.
+                                        open_db(Opts, State0, RetriesLeft - 1, Reason);
+                                    {error, Reason} -> {error, Reason} 
+                                end;
+                            false ->  
+                            case lists:prefix("Corruption: checksum mismatch", OpenErr) of
+                            true ->
+                                lager:info("VerneMQ LevelDB backend repair attempt for store ~p, after error ~s\n",
+                                        [DataRoot, OpenErr]),
+                                case eleveldb:repair(DataRoot, []) of
+                                    ok -> % LevelDB will put unusable .log and MANIFEST files in 'lost' folder.
+                                        open_db(Opts, State0, RetriesLeft - 1, Reason);
+                                    {error, Reason} -> {error, Reason} 
+                                end;
+                            false -> {error, Reason}
+                        end
+                    end
+                end
             end;
         {error, Reason} ->
             {error, Reason}

--- a/apps/vmq_swc/src/vmq_swc_db_leveldb.erl
+++ b/apps/vmq_swc/src/vmq_swc_db_leveldb.erl
@@ -219,23 +219,36 @@ open_db(Opts, State) ->
 open_db(_Opts, _State0, 0, LastError) ->
     {error, LastError};
 open_db(Opts, State0, RetriesLeft, _) ->
-    case eleveldb:open(State0#state.data_root, State0#state.open_opts) of
+    DataRoot = State0#state.data_root,
+    case eleveldb:open(DataRoot, State0#state.open_opts) of
         {ok, Ref} ->
+            lager:info("Opening LevelDB SWC database at ~p~n", [DataRoot]),
             {ok, State0#state { ref = Ref }};
         %% Check specifically for lock error, this can be caused if
         %% a crashed instance takes some time to flush leveldb information
         %% out to disk.  The process is gone, but the NIF resource cleanup
         %% may not have completed.
         {error, {db_open, OpenErr}=Reason} ->
-            case lists:prefix("IO error: lock ", OpenErr) of
+            case lists:prefix("Corruption: truncated record ", OpenErr) of
                 true ->
-                    SleepFor = proplists:get_value(open_retry_delay, Opts, 2000),
-                    lager:debug("VerneMQ SWC LevelDB backend retrying ~p in ~p ms after error ~s\n",
-                                [State0#state.data_root, SleepFor, OpenErr]),
-                    timer:sleep(SleepFor),
-                    open_db(Opts, State0, RetriesLeft - 1, Reason);
+                    lager:info("VerneMQ LevelDB SWC Store backend repair attempt for store ~p, after error ~s. LevelDB will put unusable .log and MANIFEST filest in 'lost' folder.\n",
+                            [DataRoot, OpenErr]),
+                    case eleveldb:repair(DataRoot, []) of
+                        ok -> % LevelDB will put unusable .log and MANIFEST files in 'lost' folder.
+                            open_db(Opts, State0, RetriesLeft - 1, Reason);
+                        {error, Reason} -> {error, Reason}
+                    end;
                 false ->
-                    {error, Reason}
+                    case lists:prefix("IO error: lock ", OpenErr) of
+                        true ->
+                            SleepFor = proplists:get_value(open_retry_delay, Opts, 2000),
+                            lager:info("VerneMQ LevelDB SWC Store backend retrying ~p in ~p ms after error ~s\n",
+                                        [DataRoot, SleepFor, OpenErr]),
+                            timer:sleep(SleepFor),
+                            open_db(Opts, State0, RetriesLeft - 1, Reason);
+                        false ->
+                            {error, Reason}
+                    end
             end;
         {error, Reason} ->
             {error, Reason}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Handle LevelDB truncated record corruption more automatically in LevelDB SWC and Messagestore backends.
 - Add compatibility with [Erlang/OTP 23](http://blog.erlang.org/OTP-23-Highlights/). This release requires Erlang/OTP 21.3 or later.
 - Upgrade package `bcrypt` to version 1.1.0.
 - Upgrade package `hackney` to version 1.16.0 (dependencies of `hackney` were updated as well).


### PR DESCRIPTION
I couldn't trigger the "truncated record at end of file" error, so I added a couple others I encountered (just for testing, will probably have to remove them).

But this approach works so far. When VerneMQ encounters LevelDB corruption, it can run `eleveldb:repair/2` automatically. 
Whether the NIF into the actual LevelDB repair functions does something smarter than just throwing corrupted files into a `lost` folder... I'm not so sure :)

EDIT: this is for the message store only, currently. Will add the same to metadata layer.