### PR TITLE
WIP: Improve the memory queue buffering messages in the Bridge client

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -377,7 +377,6 @@
          F = fun(Prefix, Suffix, Validator) ->
                      %% get the name value pairs
                      Prefix3 = lists:flatten([Prefix, ".$name"]),
-                 %   io:format("Prefix3 ~p~n", [Prefix3]),
                      Res =
                          [begin
                               case lists:prefix("topic", Suffix) of
@@ -393,7 +392,6 @@
                                       {AddrPortName, {topics, [Validator(Name, C) || C <- BrConfigs, C /= undefined]}};
                                   false ->
                                       Prefix4 = lists:flatten([Prefix, ".", Name, ".", Suffix]),
-                        %            io:format("Prefix4 ~p~n", [Prefix4]),
                                       Val = Validator(Name, cuttlefish:conf_get(Prefix4, Conf, undefined)),
                                      AddrPortName = lists:flatten([Name, ":", AddrPort]),
                                     {AddrPortName, {list_to_atom(Suffix), Val}}
@@ -405,7 +403,6 @@
                                                            end, Conf), not lists:member(Name, Mappings ++ SSLMapps)],
                      %% Remove duplicates as a value is generated for
                      %% each setting on a bridge definition.
-                 %    io:format("Res ~p~n", [lists:usort(Res)]),
                      lists:usort(Res)
              end,
 
@@ -465,8 +462,6 @@
                                        TCPMQTTProtos,
                                        TCPMaxBuffer,
                                        TCPTopics])),
-     %   io:format("TCP ~p~n", [TCP]),
-
 
          SSL = lists:zip(SSLIPs, MZip([SSLCleanSessions, 
                                        SSLClientIds, 

--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -368,7 +368,7 @@
                             cuttlefish:invalid("should be a string of the form 'pattern [[[ out | in | both ] qos-level] local-prefix remote-prefix]'")
                     end,
 
-         Mappings = ["clean_session", "client_id", "keepalive_interval", 
+         Mappings = ["cleansession", "client_id", "keepalive_interval", 
                     "username", "password", "restart_timeout", "try_private", "topic",
                      "max_outgoing_buffered_messages", "mqtt_version"],
                     %% SSL specific

--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -377,6 +377,7 @@
          F = fun(Prefix, Suffix, Validator) ->
                      %% get the name value pairs
                      Prefix3 = lists:flatten([Prefix, ".$name"]),
+                 %   io:format("Prefix3 ~p~n", [Prefix3]),
                      Res =
                          [begin
                               case lists:prefix("topic", Suffix) of
@@ -387,12 +388,15 @@
                                                      [Prefix, ".", Name, ".topic.", integer_to_list(I)]
                                                     ),
                                                cuttlefish:conf_get(P, Conf, undefined)
-                                           end || I <- lists:seq(1,100)],
-                                      {AddrPort, {topics, [Validator(Name, C) || C <- BrConfigs, C /= undefined]}};
+                                           end || I <- lists:seq(1,100)],                                     
+                                           AddrPortName = lists:flatten([Name, ":", AddrPort]),
+                                      {AddrPortName, {topics, [Validator(Name, C) || C <- BrConfigs, C /= undefined]}};
                                   false ->
                                       Prefix4 = lists:flatten([Prefix, ".", Name, ".", Suffix]),
+                        %            io:format("Prefix4 ~p~n", [Prefix4]),
                                       Val = Validator(Name, cuttlefish:conf_get(Prefix4, Conf, undefined)),
-                                      {AddrPort, {list_to_atom(Suffix), Val}}
+                                     AddrPortName = lists:flatten([Name, ":", AddrPort]),
+                                    {AddrPortName, {list_to_atom(Suffix), Val}}
                               end
                           end
                           || {[_, _, Name], AddrPort} <- lists:filter(
@@ -401,6 +405,7 @@
                                                            end, Conf), not lists:member(Name, Mappings ++ SSLMapps)],
                      %% Remove duplicates as a value is generated for
                      %% each setting on a bridge definition.
+                 %    io:format("Res ~p~n", [lists:usort(Res)]),
                      lists:usort(Res)
              end,
 
@@ -460,6 +465,8 @@
                                        TCPMQTTProtos,
                                        TCPMaxBuffer,
                                        TCPTopics])),
+     %   io:format("TCP ~p~n", [TCP]),
+
 
          SSL = lists:zip(SSLIPs, MZip([SSLCleanSessions, 
                                        SSLClientIds, 

--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -67,7 +67,11 @@ info(Pid) ->
     gen_server:call(Pid, info, infinity).
 
 get_metrics(Pid) ->
-    gen_server:call(Pid, get_metrics, infinity).
+    gen_server:call(Pid, get_metrics, 1000). % With the Bridge plugin running, the metrics system will call in here.
+                                             % We'll wait for a maximum of 1 second for the Bridge metrics to not
+                                             % delay other metrics. If the Bridge is not able to deliver
+                                             % the metrics in 1 second,  Bridge metrics will not be included in the metrics call.
+                                             % (like 'vmq-admin metrics show' etc.)
 
 %%%===================================================================
 %%% gen_mqtt_client callbacks

--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -27,13 +27,14 @@ show_cmd() ->
     Callback =
         fun(_, [], []) ->
                 Table =
-                    [[
+                    [[{'name', Name},
                       {endpoint, iolist_to_binary([Host, $:, integer_to_binary(Port)])},
                       {'buffer size', Size},
                       {'buffer max', Max},
                       {'buffer dropped msgs', Dropped},
                       {'MQTT process mailbox len', MailboxSize}] ||
-                        #{host := Host,
+                        #{name := Name,
+                          host := Host,
                           port := Port,
                           out_buffer_size := Size,
                           out_buffer_max_size := Max,

--- a/apps/vmq_bridge/src/vmq_bridge_cli.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_cli.erl
@@ -31,12 +31,14 @@ show_cmd() ->
                       {endpoint, iolist_to_binary([Host, $:, integer_to_binary(Port)])},
                       {'buffer size', Size},
                       {'buffer max', Max},
-                      {'buffer dropped msgs', Dropped}] ||
+                      {'buffer dropped msgs', Dropped},
+                      {'MQTT process mailbox len', MailboxSize}] ||
                         #{host := Host,
                           port := Port,
                           out_buffer_size := Size,
                           out_buffer_max_size := Max,
-                          out_buffer_dropped := Dropped} <- bridge_info()],
+                          out_buffer_dropped := Dropped,
+                          process_mailbox_size := MailboxSize} <- bridge_info()],
                 [clique_status:table(Table)];
            (_, _, _) ->
                 Text = clique_status:text(bridge_usage()),

--- a/apps/vmq_bridge/src/vmq_bridge_sup.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_sup.erl
@@ -109,8 +109,9 @@ reconfigure_bridges(_, _, []) -> ok.
 
 start_bridge(Type, Ref, Host, Port, Opts) ->
     {ok, RegistryMFA} = application:get_env(vmq_bridge, registry_mfa),
+    {_, Name, _, _} = Ref,
     ChildSpec = {Ref,
-                 {vmq_bridge, start_link, [Type, Host, Port, RegistryMFA, Opts]},
+                 {vmq_bridge, start_link, [Type, Host, Port, RegistryMFA, [{name, Name}|Opts]]},
                  permanent, 5000, worker, [vmq_bridge]},
     case supervisor:start_child(?MODULE, ChildSpec) of
         {ok, Pid} ->

--- a/apps/vmq_bridge/src/vmq_bridge_sup.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_sup.erl
@@ -169,7 +169,7 @@ metrics() ->
         end, [], vmq_bridge_meta),
 
         lists:foldl(
-            fun({{_, _Name, _Host, _Port}, BridgePid, _, _}, Acc2) ->
+            fun({{_, Name, _Host, _Port}, BridgePid, _, _}, Acc2) ->
                 case vmq_bridge:get_metrics(BridgePid) of
                     undefined -> Acc2;
                     {ok, #{vmq_bridge_publish_out_0 := PO0,
@@ -180,12 +180,15 @@ metrics() ->
                     vmq_bridge_publish_in_2 := PI2}} -> 
 
                     lists:flatten([[[
-                    {counter, [], {vmq_bridge_publish_out_0, BridgePid}, vmq_bridge_publish_out_0, <<"The number of QoS 0 messages the bridge has (re)-published (TCP)">>, PO0},
-                    {counter, [], {vmq_bridge_publish_out_1, BridgePid}, vmq_bridge_publish_out_1, <<"The number of QoS 1 messages the bridge has (re)-published (TCP)">>, PO1},
-                    {counter, [], {vmq_bridge_publish_out_2, BridgePid}, vmq_bridge_publish_out_2, <<"The number of QoS 2 messages the bridge has (re)-published (TCP)">>, PO2},
-                    {counter, [], {vmq_bridge_publish_in_0, BridgePid}, vmq_bridge_publish_in_0, <<"The number of QoS 0 messages the bridge has consumed (TCP)">>, PI0},
-                    {counter, [], {vmq_bridge_publish_in_1, BridgePid}, vmq_bridge_publish_in_1, <<"The number of QoS 1 messages the bridge has consumed (TCP)">>, PI1},
-                    {counter, [], {vmq_bridge_publish_in_2, BridgePid}, vmq_bridge_publish_in_2, <<"The number of QoS 2 messages the bridge has consumed (TCP)">>, PI2}]
+                    {counter, [], {vmq_bridge_publish_out_0, BridgePid}, label(Name, vmq_bridge_publish_out_0), <<"The number of QoS 0 messages the bridge has (re)-published (TCP)">>, PO0},
+                    {counter, [], {vmq_bridge_publish_out_1, BridgePid}, label(Name, vmq_bridge_publish_out_1), <<"The number of QoS 1 messages the bridge has (re)-published (TCP)">>, PO1},
+                    {counter, [], {vmq_bridge_publish_out_2, BridgePid}, label(Name, vmq_bridge_publish_out_2), <<"The number of QoS 2 messages the bridge has (re)-published (TCP)">>, PO2},
+                    {counter, [], {vmq_bridge_publish_in_0, BridgePid}, label(Name, vmq_bridge_publish_in_0), <<"The number of QoS 0 messages the bridge has consumed (TCP)">>, PI0},
+                    {counter, [], {vmq_bridge_publish_in_1, BridgePid}, label(Name, vmq_bridge_publish_in_1), <<"The number of QoS 1 messages the bridge has consumed (TCP)">>, PI1},
+                    {counter, [], {vmq_bridge_publish_in_2, BridgePid}, label(Name, vmq_bridge_publish_in_2), <<"The number of QoS 2 messages the bridge has consumed (TCP)">>, PI2}]
                     |Acc2]|Drops])             
                 end
       end, [], supervisor:which_children(vmq_bridge_sup)).
+
+    label(Name, Metric) ->
+            list_to_atom(lists:concat([Name, ".", Metric])). % this will create 6 labels (atoms) per bridge for the metrics above. atoms will be the same in every call after that. 

--- a/apps/vmq_bridge/src/vmq_bridge_sup.erl
+++ b/apps/vmq_bridge/src/vmq_bridge_sup.erl
@@ -46,16 +46,19 @@ bridge_info() ->
                         port => Port,
                         out_buffer_size => $-,
                         out_buffer_max_size => $-,
-                        out_buffer_dropped => $-
+                        out_buffer_dropped => $-,
+                        process_mailbox_size => $-
                        };
                   {ok, #{out_queue_size := Size,
                          out_queue_max_size := Max,
-                         out_queue_dropped := Dropped}} ->
+                         out_queue_dropped := Dropped,
+                         process_mailbox_size := MailboxSize}} ->
                       #{host => Host,
                         port => Port,
                         out_buffer_size => Size,
                         out_buffer_max_size => Max,
-                        out_buffer_dropped => Dropped
+                        out_buffer_dropped => Dropped,
+                        process_mailbox_size => MailboxSize
                        }
               end
       end,

--- a/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
@@ -324,9 +324,9 @@ buffer_outgoing_test(Cfg) ->
     {ok, #{out_queue_dropped := 2,
            out_queue_max_size := 10,
            out_queue_size := 10}} = vmq_bridge:info(BridgePid),
-
-    [{counter, [], {vmq_bridge_queue_drop, _}, vmq_bridge_dropped_msgs,
-      <<"The number of dropped messages (queue full)">>, 2}] = vmq_bridge_sup:metrics(),
+      
+  [{counter, [], {vmq_bridge_queue_drop, _}, vmq_bridge_dropped_msgs,
+      <<"The number of dropped messages (queue full)">>, 2}] = vmq_bridge_sup:metrics_for_tests(),
 
     %% Reply with the connack
     Connack = packet:gen_connack(0),
@@ -386,7 +386,7 @@ start_bridge_plugin(Opts) ->
     application:set_env(vmq_bridge, config,
                         {[
                           %% TCP Bridges
-                          {"localhost:1890", [{topics, Topics},
+                          {"br0:localhost:1890", [{topics, Topics},
                                               {restart_timeout, 5},
                                               {retry_interval, 1},
                                               {client_id, "bridge-test"},
@@ -416,7 +416,7 @@ bridge_rec(Msg, Timeout) ->
     end.
 
 get_bridge_pid() ->
-    [{{vmq_bridge,"localhost",1890},Pid,worker,[vmq_bridge]}] =
+    [{{vmq_bridge, _Name, "localhost",1890},Pid,worker,[vmq_bridge]}] =
         supervisor:which_children(vmq_bridge_sup),
     Pid.
 

--- a/apps/vmq_commons/src/gen_mqtt_client.erl
+++ b/apps/vmq_commons/src/gen_mqtt_client.erl
@@ -547,10 +547,12 @@ handle_event(Event, StateName, State) ->
 
 handle_sync_event(info, _From, StateName,
                   #state{o_queue=#queue{size=Size,drop=Drop,max=Max}}=State) ->
+    {message_queue_len, Len} = erlang:process_info(self(), message_queue_len),
     Info =
         #{out_queue_size=>Size,
           out_queue_dropped=>Drop,
-          out_queue_max_size=>Max},
+          out_queue_max_size=>Max,
+          process_mailbox_size => Len},
     {reply, {ok, Info}, StateName, State};
 handle_sync_event(Req, From, StateName, State) ->
     wrap_res(StateName, handle_call, [Req, From], State).

--- a/apps/vmq_server/src/vmq_systree.erl
+++ b/apps/vmq_server/src/vmq_systree.erl
@@ -163,7 +163,10 @@ handle_info(timeout, true) ->
             {noreply, true, Interval};
         false ->
             {noreply, false, 30000}
-    end.
+    end;
+handle_info(Info, State) ->
+    lager:warning("vmq_systree received unexpected message ~p~n", [Info]),
+    {noreply, State}.
 
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
- [x] ensure new incoming messages are added to buffer when buffer size is > 0 (to ensure message order). When buffer is deactivated, publish directly.
- [ ] add tests for above
- [x] ensure `vmq-admin bridge show` shows correct size and drop sizes for bridge at all times & add MQTT client mailbox size info to output
- [ ] add more detailed tests for buffer & test to ensure correct handling of waiting acks and packet ids.
- [x] expand the pluggable_metrics with counters on how many messages the bridge has consumed and published, separated by QoS
- [ ] New feature: add re-publisher to persistent queue (or similar feature) on bridge source broker, as an alternative to memory only buffering.
- [x] Handle Subscribe failure, by some form of re-subscribe strategy when encountering a return code 128 (fail to subscribe).
EDIT: Note: logging a warning for failed subs is good enough for now. `restart_timeout` in source broker should not be too low, so that chances are minimised we're hitting a starting up remote broker, can connect, but encountered failed subscriptions due to broker not fully initialised.
- [x] Allow multiple bridges between 2 same nodes, by identifying bridges by {Name, Host, Port} instead of {Host, Port} only.