### PR TITLE
Fix status page when behind proxy

### DIFF
--- a/apps/vmq_server/priv/static/js/status.js
+++ b/apps/vmq_server/priv/static/js/status.js
@@ -18,7 +18,7 @@ $(function() {
         template: $("#node_list_template").html(),
         target: $("#node_list"),
         cluster_status: {
-            url: "/status.json",
+            url: "status.json",
             last_calculated: Date.now(),
             rates: {}
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Upgrade package `bcrypt` to fix compilation in OSX (#1500).
+- Fix issue with loading status dashboard from behind a proxy with a basepath set
 
 ## VerneMQ 1.10.5
 


### PR DESCRIPTION
## Proposed Changes

Currently if running VMQ behind a proxy with say base-path being /vmq the status page fails to load.  The goal here is to request status.json relative to current path.  Currently we work around this using `sed` in our dockerfile but its a bit gross and this is such a small change figure open a PR for it.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging
