### PR TITLE
Allow publish to topics started with `$`, except `$SYS` topic

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -395,7 +395,7 @@ connected(#mqtt5_publish{message_id=MessageId, topic=Topic,
     _ = vmq_metrics:incr(?MQTT5_PUBLISH_RECEIVED),
     Ret =
     case Topic of
-        [<<"$", _/binary>> |_] ->
+        [<<"$SYS", _/binary>> |_] ->
             %% $SYS
             [];
         _ ->

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -239,7 +239,7 @@ connected(#mqtt_publish{message_id=MessageId, topic=Topic,
     _ = vmq_metrics:incr_mqtt_publish_received(),
     Ret =
     case Topic of
-        [<<"$", _/binary>> |_] ->
+        [<<"$SYS", _/binary>> |_] ->
             %% $SYS
             [];
         _ ->


### PR DESCRIPTION
## Proposed Changes

Some IOT platforms uses topics started with `$` for own purposes.
The PR allow to publish to topics started with `$`, but still prevent publish to the `$SYS` topic.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging


