### PR TITLE
Adds usage information for vmq-admin retain command (#1)

### DIFF
--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -551,6 +551,7 @@ usage() ->
      "    node        Manage this node\n",
      "    cluster     Manage this node's cluster membership\n",
      "    session     Retrieve session information\n",
+     "    retain      Show and filter MQTT retained messages\n",
      "    plugin      Manage plugin system\n",
      "    listener    Manage listener interfaces\n",
      "    metrics     Retrieve System Metrics\n",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Add retain command to vmq-admin usage output
 - Bridge Plugin: Continue to publish during netsplit (cluster not_ready)
 - Bridge Plugin: Make internal publish use the configured per-topic QoS
 - Upgrade package `bcrypt` to fix compilation in OSX (#1500).


### PR DESCRIPTION
* vmq-admin usage() includes retain command

* Update changelog.md

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
