### PR TITLE
Ensure_that_MQTT_v5_user_properties_are_stored_to_disk/DB_#1560

### DIFF
--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
@@ -54,7 +54,7 @@
 
 %% Subsequent formats should always extend by adding new elements to
 %% the end of the record or tuple.
--type p_msg_val_pre() :: {routing_key(), payload()}.
+-type p_msg_val_pre() :: {routing_key(), payload() | tuple()}.
 -record(p_idx_val, {
           ts  :: erlang:timestamp(),
           dup :: flag(),

--- a/apps/vmq_generic_msg_store/test/vmq_generic_msg_store_SUITE.erl
+++ b/apps/vmq_generic_msg_store/test/vmq_generic_msg_store_SUITE.erl
@@ -271,7 +271,7 @@ generate_msgs(N, Acc) ->
                    mountpoint = "",
                    dup = random_flag(),
                    qos = random_qos(),
-                   properties=#{},
+                   properties=#{"CorrelationData" => rand_bytes(8)},
                    persisted=true},
     generate_msgs(N - 1, [Msg|Acc]).
 


### PR DESCRIPTION
…age_#1560

## Proposed Changes

Changes to vmq_generic_msg_store_utils.erl to read and write properties from the store. Payload and Properties are combined into a single tuple before writing. 

The change is backwards compatible in case the store contains messages persisted by an earlier version 

I modified an existing test so that test messages contain properties

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes issue #1560 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CODE_OF_CONDUCT.md` document
- [x ] All tests pass locally with my changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [x ] I have squashed all my commits into one before merging

## Further Comments

This is my first attempt at erlang code so probably the style isnt great
