### PR TITLE
Fix size for database pools not being honored

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_sup.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_sup.erl
@@ -74,7 +74,7 @@ start_all_pools([{mysql, ProviderConfig}|Rest], Acc) ->
 start_all_pools([{pgsql, ProviderConfig}|Rest], Acc) ->
     PoolId = proplists:get_value(id, ProviderConfig),
     PoolOpts = proplists:get_value(opts, ProviderConfig, []),
-    Size = proplists:get_value(size, ProviderConfig, 10),
+    Size = proplists:get_value(size, PoolOpts, 5),
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = lists:keydelete(size, 1,
                                  lists:keydelete(max_overflow, 1, PoolOpts)),
@@ -106,7 +106,7 @@ start_all_pools([{pgsql, ProviderConfig}|Rest], Acc) ->
 start_all_pools([{mongodb, ProviderConfig}|Rest], Acc) ->
     PoolId = proplists:get_value(id, ProviderConfig),
     PoolOpts = proplists:get_value(opts, ProviderConfig, []),
-    Size = proplists:get_value(size, ProviderConfig, 10),
+    Size = proplists:get_value(size, PoolOpts, 5),
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = lists:keydelete(size, 1,
                                  lists:keydelete(max_overflow, 1, PoolOpts)),
@@ -129,7 +129,7 @@ start_all_pools([{mongodb, ProviderConfig}|Rest], Acc) ->
 start_all_pools([{redis, ProviderConfig}|Rest], Acc) ->
     PoolId = proplists:get_value(id, ProviderConfig),
     PoolOpts = proplists:get_value(opts, ProviderConfig, []),
-    Size = proplists:get_value(size, ProviderConfig, 10),
+    Size = proplists:get_value(size, PoolOpts, 5),
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = lists:keydelete(size, 1,
                                  lists:keydelete(max_overflow, 1, PoolOpts)),
@@ -143,7 +143,7 @@ start_all_pools([{redis, ProviderConfig}|Rest], Acc) ->
 start_all_pools([{memcached, ProviderConfig}|Rest], Acc) ->
     PoolId = proplists:get_value(id, ProviderConfig),
     PoolOpts = proplists:get_value(opts, ProviderConfig, []),
-    Size = proplists:get_value(size, ProviderConfig, 10),
+    Size = proplists:get_value(size, PoolOpts, 5),
     MaxOverflow = proplists:get_value(max_overflow, ProviderConfig, 20),
     WorkerArgs = [proplists:get_value(host, PoolOpts),
                   proplists:get_value(port, PoolOpts)],

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix bug causing the `pool_size` option for databases to not be respected.
+
 ## VerneMQ 1.11.0
 
 - Improve Proxy protocol error logging (warn instead of crash process).


### PR DESCRIPTION
#### Disclaimer: This is my first time with erlang.

## Proposed Changes

This fixes the size option (`vmq_diversity.postgres.pool_size` or `DOCKER_VERNEMQ_VMQ_DIVERSITY__POSTGRES__POOL_SIZE`) of all database pools to not be applied.
Also changed the default to 5 like documented.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1656)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

I verified this works now by building a docker image from this branch and testing manually. I enabled postgres support, set the option to 1 and queried the database for connections with `SELECT * FROM pg_stat_activity` which showed 1 connection. Also ran tests with `./rebar3 eunit` and `./rebar3 ct`.
