### PR TITLE
Allow configuration of buffer sizes for vmq_cluster_com, and autotune…

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -402,6 +402,29 @@
   {validators, ["buffer_size_validator"]}
  ]}.
 
+ %% @doc Set the watermark levels for the `vmq_cluster_mon` listener
+ %% That is, the listener receiving the MQTT messages from other nodes.
+{mapping, "listener.vmq.$name.high_watermark", "vmq_server.listeners", [
+                                                                  {default, 8192},
+                                                                  {datatype, integer},
+                                                                  hidden
+                                                                ]}.
+{mapping, "listener.vmq.$name.low_watermark", "vmq_server.listeners", [
+                                                                  {default, 4096},
+                                                                  {datatype, integer},
+                                                                  hidden
+                                                                ]}.
+{mapping, "listener.vmq.$name.high_msgq_watermark", "vmq_server.listeners", [
+                                                                  {default, 8192},
+                                                                  {datatype, integer},
+                                                                  hidden
+                                                                ]}.
+{mapping, "listener.vmq.$name.low_msgq_watermark", "vmq_server.listeners", [
+                                                                  {default, 4096},
+                                                                  {datatype, integer},
+                                                                  hidden
+                                                                ]}.
+
 {validator, "buffer_size_validator", "value must be three comma-separated, positive integers",
  fun(Val) when is_list(Val) ->
          case vmq_schema:parse_list_to_term(Val) of

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -396,6 +396,11 @@
   {validators, ["buffer_size_validator"]}
  ]}.
 
+{mapping, "listener.vmq.$name.buffer_sizes", "vmq_server.listeners",
+ [{datatype, string},
+  hidden,
+  {validators, ["buffer_size_validator"]}
+ ]}.
 
 {validator, "buffer_size_validator", "value must be three comma-separated, positive integers",
  fun(Val) when is_list(Val) ->

--- a/apps/vmq_server/src/vmq_cluster_com.erl
+++ b/apps/vmq_server/src/vmq_cluster_com.erl
@@ -48,6 +48,10 @@ init(Ref, Transport, Opts) ->
     MaskedSocket = mask_socket(Transport, Socket),
     %% tune buffer sizes
     CfgBufSizes = proplists:get_value(buffer_sizes, Opts, undefined),
+    HighWatermark = proplists:get_value(high_watermark, Opts, 8192),
+    LowWatermark = proplists:get_value(low_watermark, Opts, 4096),
+    HighMsgQWatermark = proplists:get_value(high_msgq_watermark, Opts, 8192),
+    LowMsgQWatermark = proplists:get_value(low_msgq_watermark, Opts, 4096),
     case CfgBufSizes of
         undefined ->
             {ok, BufSizes} = getopts(MaskedSocket, [sndbuf, recbuf, buffer]),
@@ -56,6 +60,10 @@ init(Ref, Transport, Opts) ->
         [SndBuf,RecBuf,Buffer] ->
             setopts(MaskedSocket, [{sndbuf, SndBuf}, {recbuf, RecBuf}, {buffer, Buffer}])
     end,
+    setopts(MaskedSocket, [{high_watermark, HighWatermark},
+                        {low_watermark, LowWatermark}, 
+                        {high_msgq_watermark, HighMsgQWatermark},
+                        {low_msgq_watermark, LowMsgQWatermark}]),
     case active_once(MaskedSocket) of
         ok ->
             loop(#st{socket=MaskedSocket, reg_view=RegView,

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -273,7 +273,7 @@ protocol_opts(cowboy_clear, _, Opts) ->
     CowboyRoutes = [{'_', Routes}],
     Dispatch = cowboy_router:compile(CowboyRoutes),
     #{env => #{dispatch => Dispatch}};
-protocol_opts(vmq_cluster_com, _, _) -> [].
+protocol_opts(vmq_cluster_com, _, Opts) -> Opts.
 
 default_session_opts(Opts) ->
     MaybeSSLDefaults =

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -109,6 +109,7 @@ translate_listeners(Conf) ->
 
     {TCPIPs, TCPBufferSizes} = lists:unzip(extract("listener.tcp", "buffer_sizes", StringIntegerListVal, Conf)),
     {SSLIPs, SSLBufferSizes} = lists:unzip(extract("listener.ssl", "buffer_sizes", StringIntegerListVal, Conf)),
+    {VMQIPs, VMQBufferSizes} = lists:unzip(extract("listener.vmq", "buffer_sizes", StringIntegerListVal, Conf)),
 
     {HTTPIPs, HTTPConfigMod} = lists:unzip(extract("listener.http", "config_mod", AtomVal, Conf)),
     {HTTPIPs, HTTPConfigFun} = lists:unzip(extract("listener.http", "config_fun", AtomVal, Conf)),
@@ -149,6 +150,7 @@ translate_listeners(Conf) ->
     {VMQ_SSLIPs, VMQ_SSLKeyFiles} = lists:unzip(extract("listener.vmqs", "keyfile", StrVal, Conf)),
     {VMQ_SSLIPs, VMQ_SSLRequireCerts} = lists:unzip(extract("listener.vmqs", "require_certificate", BoolVal, Conf)),
     {VMQ_SSLIPs, VMQ_SSLVersions} = lists:unzip(extract("listener.vmqs", "tls_version", AtomVal, Conf)),
+    {VMQ_SSLIPs, VMQ_SSLBufferSizes} = lists:unzip(extract("listener.vmqs", "buffer_sizes", StringIntegerListVal, Conf)),
 
                                                 % HTTPS
     {HTTP_SSLIPs, HTTP_SSLCAFiles} = lists:unzip(extract("listener.https", "cafile", StrVal, Conf)),
@@ -174,7 +176,8 @@ translate_listeners(Conf) ->
                                 WSAllowedProto])),
     VMQ = lists:zip(VMQIPs, MZip([VMQMaxConns,
                                   VMQNrOfAcceptors,
-                                  VMQMountPoint])),
+                                  VMQMountPoint,
+                                  VMQBufferSizes])),
     HTTP = lists:zip(HTTPIPs, MZip([HTTPMaxConns,
                                     HTTPNrOfAcceptors,
                                     HTTPConfigMod,
@@ -221,7 +224,8 @@ translate_listeners(Conf) ->
                                        VMQ_SSLCrlFiles,
                                        VMQ_SSLKeyFiles,
                                        VMQ_SSLRequireCerts,
-                                       VMQ_SSLVersions])),
+                                       VMQ_SSLVersions,
+                                       VMQ_SSLBufferSizes])),
     HTTPS = lists:zip(HTTP_SSLIPs, MZip([HTTP_SSLMaxConns,
                                          HTTP_SSLNrOfAcceptors,
                                          HTTP_SSLCAFiles,

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -110,6 +110,11 @@ translate_listeners(Conf) ->
     {TCPIPs, TCPBufferSizes} = lists:unzip(extract("listener.tcp", "buffer_sizes", StringIntegerListVal, Conf)),
     {SSLIPs, SSLBufferSizes} = lists:unzip(extract("listener.ssl", "buffer_sizes", StringIntegerListVal, Conf)),
     {VMQIPs, VMQBufferSizes} = lists:unzip(extract("listener.vmq", "buffer_sizes", StringIntegerListVal, Conf)),
+    {VMQIPs, VMQHighWatermarks} = lists:unzip(extract("listener.vmq", "high_watermark", IntVal, Conf)),
+    {VMQIPs, VMQHighMsgQWatermarks} = lists:unzip(extract("listener.vmq", "high_msgq_watermark", IntVal, Conf)),
+    {VMQIPs, VMQLowWatermarks} = lists:unzip(extract("listener.vmq", "low_watermark", IntVal, Conf)),
+    {VMQIPs, VMQLowMsgQWatermarks} = lists:unzip(extract("listener.vmq", "low_msgq_watermark", IntVal, Conf)),
+
 
     {HTTPIPs, HTTPConfigMod} = lists:unzip(extract("listener.http", "config_mod", AtomVal, Conf)),
     {HTTPIPs, HTTPConfigFun} = lists:unzip(extract("listener.http", "config_fun", AtomVal, Conf)),
@@ -177,7 +182,11 @@ translate_listeners(Conf) ->
     VMQ = lists:zip(VMQIPs, MZip([VMQMaxConns,
                                   VMQNrOfAcceptors,
                                   VMQMountPoint,
-                                  VMQBufferSizes])),
+                                  VMQBufferSizes,
+                                  VMQHighWatermarks,
+                                  VMQLowWatermarks,
+                                  VMQHighMsgQWatermarks,
+                                  VMQLowMsgQWatermarks])),
     HTTP = lists:zip(HTTPIPs, MZip([HTTPMaxConns,
                                     HTTPNrOfAcceptors,
                                     HTTPConfigMod,
@@ -259,7 +268,8 @@ extract(Prefix, Suffix, Val, Conf) ->
         = [%% ssl listener specific
            "cafile", "depth", "certfile", "ciphers", "eccs", "crlfile",
            "keyfile", "require_certificate", "tls_version",
-           "use_identity_as_username", "buffer_sizes",
+           "use_identity_as_username", "buffer_sizes", "high_watermark",
+           "low_watermark", "high_msgq_watermark", "low_msgq_watermark",
            %% http listener specific
            "config_mod", "config_fun",
            %% mqtt listener specific


### PR DESCRIPTION
… 'buffer' for vmq_cluster_node

In a VerneMQ cluster, `vmq_cluster_node` is the component that connects to the remote broker to forward MQTT messages.
`vmq_cluster_com` is the component (protocol) handling the listener and receiving MQTT messages.

With `listener.vmq.clustering.buffer_sizes = X,Y,Z` in the `vernemq.conf` file, we can now set `recbuf`, `sndbuf` and `buffer` directly for the 44053 `vmq_cluster_com` listener.
This PR also tunes the `buffer` of the connect coming from `vmq_cluster_node`, based on the OS settings for recbuf and sndbuf.

## Configuring outgoing TCP options for `vmq_cluster_node`
You can also add an `advanced.config` file at the side of the `vernemq.conf` file, with specific TCP options for the outgoing component of the data handling in the cluster (that is `vmq_cluster_node`), like this:

```
[{vmq_server, [
          {outgoing_connect_opts,
           [{high_watermark, 589824},
	   {high_msgq_watermark, 589824},
	   {low_watermark, 8192},
	   {low_msgq_watermark, 8192}]}]}].
```
You can add any additional TCP options, not just the watermarks, except the hardcoded `[binary, {active, true}, {keepalive, true},{send_timeout, 0}]`.

## Configuring incoming TCP options for `vmq_cluster_com`


With `listener.vmq.clustering.buffer_sizes = X,Y,Z` in the `vernemq.conf` file, we can now set `recbuf`, `sndbuf` and `buffer` directly for the 44053 `vmq_cluster_com` listener.

It is now also possible to set the watermarks (for the incoming side at `vmq_cluster_com` in the `vernemq.conf` file:

```
listener.vmq.clustering.high_watermark = 589824
listener.vmq.clustering.high_msgq_watermark = 589824
listener.vmq.clustering.low_watermark = 8192
listener.vmq.clustering.low_msgq_watermark = 8192
```


With that we already have the tools to run experiments for the cluster data communication, and effects on latency and throughput with changing buffer sizes and watermarks.