### PR TITLE
Update internal Luerl interface (luerl:do/1 is no more), update Luerl…

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_script_state.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_script_state.erl
@@ -237,7 +237,7 @@ load_script(Id, Script) ->
     {ok, ScriptsDir} = application:get_env(vmq_diversity, script_dir),
     AbsScriptDir = filename:absname(ScriptsDir),
     Do1 = "package.path = package.path .. \";" ++ AbsScriptDir ++ "/?.lua\"",
-    {_, InitState1} = luerl:do(Do1),
+    {_, InitState1} = luerl:do(Do1, luerl:init()),
     Do2 = "__SCRIPT_INSTANCE_ID__ = " ++ integer_to_list(Id),
     {_, InitState2} = luerl:do(Do2, InitState1),
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -56,7 +56,7 @@
   0},
  {<<"luerl">>,
   {git,"git://github.com/rvirding/luerl.git",
-       {ref,"8654ba0d8f519352ec4611dfe9f19f54f74ba253"}},
+       {ref,"fc668ef337b04ca2aee83c648cf6853dab8babe6"}},
   0},
  {<<"mcd">>,
   {git,"git://github.com/EchoTeam/mcd.git",


### PR DESCRIPTION
… dependency

## Proposed Changes

The `luerl:do/1` call was removed in Luerl. This PR updates the internal call, and allows updating to the newest Luerl `develop` commit.