### PR TITLE
Support the MongoDB auth_source connect option

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dialyzer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.0.0
       - name: Cache PLTs
@@ -24,7 +24,7 @@ jobs:
           otp-version: 23.2.1
       - run: ./rebar3 dialyzer
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       postgres:
         image: postgres
@@ -66,7 +66,7 @@ jobs:
           --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5    
+          --health-retries 5
     steps:
       - uses: actions/checkout@v2.0.0
       - run: sudo apt-get -y install libsnappy-dev
@@ -85,6 +85,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ct-test-report
+          if: always()
           path: _build/ci_tests+test/logs/
           retention-days: 5
   release-smoke-test:
@@ -92,7 +93,7 @@ jobs:
     container:
       image: erlang:23-slim
     steps:
-      - run: apt-get update && apt-get -y install make libsnappy-dev git netcat gcc g++ curl libssl-dev 
+      - run: apt-get update && apt-get -y install make libsnappy-dev git netcat gcc g++ curl libssl-dev
       - uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 0
@@ -109,7 +110,7 @@ jobs:
       - name: Stop the server
         run: ./_build/default/rel/vernemq/bin/vernemq stop
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         erlang: ["22.0", "22.3.4.9", "23.0.1"]

--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -2,9 +2,9 @@
 %% ex: ft=erlang
 
 %% @doc Enable to keep the Lua state between calls. This would allow to
-%% to set global variables and reuse them in a later callback call or 
+%% to set global variables and reuse them in a later callback call or
 %% even in a different callback. Default is 'off' enabling that no Lua
-%% garbage collection is triggered. 
+%% garbage collection is triggered.
 %% Scripts can override this configuration by setting `keep_state = true`
 %% global variable in Lua script
 {mapping, "vmq_diversity.keep_state", "vmq_diversity.keep_state", [
@@ -34,38 +34,38 @@
 {mapping, "vmq_diversity.auth_postgres.enabled", "vmq_diversity.auth_cache.postgres.enabled",
  [{datatype, flag},
   {default, off}]}.
-{mapping, "vmq_diversity.auth_postgres.script", "vmq_diversity.auth_cache.postgres.file", 
+{mapping, "vmq_diversity.auth_postgres.script", "vmq_diversity.auth_cache.postgres.file",
  [{datatype, file},
   {default, "{{platform_share_dir}}/lua/auth/postgres.lua"},
   hidden
  ]}.
 
-{mapping, "vmq_diversity.postgres.host", "vmq_diversity.db_config.postgres.host", 
+{mapping, "vmq_diversity.postgres.host", "vmq_diversity.db_config.postgres.host",
  [{datatype, string},
   {default, "localhost"},
   {commented, "localhost"}]}.
 
-{mapping, "vmq_diversity.postgres.port", "vmq_diversity.db_config.postgres.port", 
+{mapping, "vmq_diversity.postgres.port", "vmq_diversity.db_config.postgres.port",
  [{datatype, integer},
   {default, 5432},
   {commented, 5432}]}.
 
-{mapping, "vmq_diversity.postgres.user", "vmq_diversity.db_config.postgres.user", 
+{mapping, "vmq_diversity.postgres.user", "vmq_diversity.db_config.postgres.user",
  [{datatype, string},
   {default, "root"},
   {commented, "root"}]}.
 
-{mapping, "vmq_diversity.postgres.password", "vmq_diversity.db_config.postgres.password", 
+{mapping, "vmq_diversity.postgres.password", "vmq_diversity.db_config.postgres.password",
  [{datatype, string},
   {default, "password"},
   {commented, "password"}]}.
 
-{mapping, "vmq_diversity.postgres.database", "vmq_diversity.db_config.postgres.database", 
+{mapping, "vmq_diversity.postgres.database", "vmq_diversity.db_config.postgres.database",
  [{datatype, string},
   {default, "vernemq_db"},
   {commented, "vernemq_db"}]}.
 
-{mapping, "vmq_diversity.postgres.pool_size", "vmq_diversity.db_config.postgres.pool_size", 
+{mapping, "vmq_diversity.postgres.pool_size", "vmq_diversity.db_config.postgres.pool_size",
  [{datatype, integer},
   {default, 5},
   hidden]}.
@@ -193,23 +193,23 @@
 {mapping, "vmq_diversity.auth_mysql.enabled", "vmq_diversity.auth_cache.mysql.enabled",
  [{datatype, flag},
   {default, off}]}.
-{mapping, "vmq_diversity.auth_mysql.script", "vmq_diversity.auth_cache.mysql.file", 
+{mapping, "vmq_diversity.auth_mysql.script", "vmq_diversity.auth_cache.mysql.file",
  [{datatype, file},
   {default, "{{platform_share_dir}}/lua/auth/mysql.lua"},
   hidden
  ]}.
 
-{mapping, "vmq_diversity.mysql.host", "vmq_diversity.db_config.mysql.host", 
+{mapping, "vmq_diversity.mysql.host", "vmq_diversity.db_config.mysql.host",
  [{datatype, string},
   {default, "localhost"},
   {commented, "localhost"}]}.
 
-{mapping, "vmq_diversity.mysql.port", "vmq_diversity.db_config.mysql.port", 
+{mapping, "vmq_diversity.mysql.port", "vmq_diversity.db_config.mysql.port",
  [{datatype, integer},
   {default, 3306},
   {commented, 3306}]}.
 
-{mapping, "vmq_diversity.mysql.user", "vmq_diversity.db_config.mysql.user", 
+{mapping, "vmq_diversity.mysql.user", "vmq_diversity.db_config.mysql.user",
  [{datatype, string},
   {default, "root"},
   {commented, "root"}]}.
@@ -219,12 +219,12 @@
   {default, "password"},
   {commented, "password"}]}.
 
-{mapping, "vmq_diversity.mysql.database", "vmq_diversity.db_config.mysql.database", 
+{mapping, "vmq_diversity.mysql.database", "vmq_diversity.db_config.mysql.database",
  [{datatype, string},
   {default, "vernemq_db"},
   {commented, "vernemq_db"}]}.
 
-{mapping, "vmq_diversity.mysql.pool_size", "vmq_diversity.db_config.mysql.pool_size", 
+{mapping, "vmq_diversity.mysql.pool_size", "vmq_diversity.db_config.mysql.pool_size",
  [{datatype, integer},
   {default, 5},
   hidden]}.
@@ -237,7 +237,7 @@
 %%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_md5
 %%     sha1: Calculates the SHA-1 160-bit checksum for the password.
 %%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha1
-%%   sha256: Calculates the SHA-2 hash of the password, using 256 bits. 
+%%   sha256: Calculates the SHA-2 hash of the password, using 256 bits.
 %%           Works only if MySQL has been configured with SSL support.
 %%           Docs: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#function_sha2
 {mapping, "vmq_diversity.mysql.password_hash_method", "vmq_diversity.db_config.mysql.password_hash_method",
@@ -248,48 +248,53 @@
 {mapping, "vmq_diversity.auth_mongodb.enabled", "vmq_diversity.auth_cache.mongodb.enabled",
  [{datatype, flag},
   {default, off}]}.
-{mapping, "vmq_diversity.auth_mongodb.script", "vmq_diversity.auth_cache.mongodb.file", 
+{mapping, "vmq_diversity.auth_mongodb.script", "vmq_diversity.auth_cache.mongodb.file",
  [{datatype, file},
   {default, "{{platform_share_dir}}/lua/auth/mongodb.lua"},
   hidden
  ]}.
 
-{mapping, "vmq_diversity.mongodb.host", "vmq_diversity.db_config.mongodb.host", 
+{mapping, "vmq_diversity.mongodb.host", "vmq_diversity.db_config.mongodb.host",
  [{datatype, string},
   {default, "localhost"},
   {commented, "localhost"}]}.
 
-{mapping, "vmq_diversity.mongodb.port", "vmq_diversity.db_config.mongodb.port", 
+{mapping, "vmq_diversity.mongodb.port", "vmq_diversity.db_config.mongodb.port",
  [{datatype, integer},
   {default, 27017},
   {commented, 27017}]}.
 
-{mapping, "vmq_diversity.mongodb.login", "vmq_diversity.db_config.mongodb.login", 
+{mapping, "vmq_diversity.mongodb.login", "vmq_diversity.db_config.mongodb.login",
  [{datatype, string},
   {default, undefined},
   {commented, ""}]}.
 
-{mapping, "vmq_diversity.mongodb.password", "vmq_diversity.db_config.mongodb.password", 
+{mapping, "vmq_diversity.mongodb.password", "vmq_diversity.db_config.mongodb.password",
  [{datatype, string},
   {default, undefined},
   {commented, ""}]}.
 
-{mapping, "vmq_diversity.mongodb.database", "vmq_diversity.db_config.mongodb.database", 
+{mapping, "vmq_diversity.mongodb.auth_source", "vmq_diversity.db_config.mongodb.auth_source",
+[{datatype, string},
+ {default, "admin"},
+ {commented, ""}]}.
+
+{mapping, "vmq_diversity.mongodb.database", "vmq_diversity.db_config.mongodb.database",
  [{datatype, string},
   {default, undefined},
   {commented, ""}]}.
 
-{mapping, "vmq_diversity.mongodb.pool_size", "vmq_diversity.db_config.mongodb.pool_size", 
+{mapping, "vmq_diversity.mongodb.pool_size", "vmq_diversity.db_config.mongodb.pool_size",
  [{datatype, integer},
   {default, 5},
   hidden]}.
 
-{mapping, "vmq_diversity.mongodb.r_mode", "vmq_diversity.db_config.mongodb.r_mode", 
+{mapping, "vmq_diversity.mongodb.r_mode", "vmq_diversity.db_config.mongodb.r_mode",
  [{datatype, atom},
   {default, master},
   hidden]}.
 
-{mapping, "vmq_diversity.mongodb.w_mode", "vmq_diversity.db_config.mongodb.w_mode", 
+{mapping, "vmq_diversity.mongodb.w_mode", "vmq_diversity.db_config.mongodb.w_mode",
  [{datatype, atom},
   {default, safe},
   hidden]}.
@@ -332,44 +337,44 @@
 {mapping, "vmq_diversity.auth_redis.enabled", "vmq_diversity.auth_cache.redis.enabled",
  [{datatype, flag},
   {default, off}]}.
-{mapping, "vmq_diversity.auth_redis.script", "vmq_diversity.auth_cache.redis.file", 
+{mapping, "vmq_diversity.auth_redis.script", "vmq_diversity.auth_cache.redis.file",
  [{datatype, file},
   {default, "{{platform_share_dir}}/lua/auth/redis.lua"},
   hidden
  ]}.
 
-{mapping, "vmq_diversity.redis.host", "vmq_diversity.db_config.redis.host", 
+{mapping, "vmq_diversity.redis.host", "vmq_diversity.db_config.redis.host",
  [{datatype, string},
   {default, "localhost"},
   {commented, "localhost"}]}.
 
-{mapping, "vmq_diversity.redis.port", "vmq_diversity.db_config.redis.port", 
+{mapping, "vmq_diversity.redis.port", "vmq_diversity.db_config.redis.port",
  [{datatype, integer},
   {default, 6379},
   {commented, 6379}]}.
 
-{mapping, "vmq_diversity.redis.password", "vmq_diversity.db_config.redis.password", 
+{mapping, "vmq_diversity.redis.password", "vmq_diversity.db_config.redis.password",
  [{datatype, string},
   {default, ""},
   {commented, ""}]}.
 
-{mapping, "vmq_diversity.redis.database", "vmq_diversity.db_config.redis.database", 
+{mapping, "vmq_diversity.redis.database", "vmq_diversity.db_config.redis.database",
  [{datatype, integer},
   {default, 0},
   {commented, 0}]}.
 
-{mapping, "vmq_diversity.redis.pool_size", "vmq_diversity.db_config.redis.pool_size", 
+{mapping, "vmq_diversity.redis.pool_size", "vmq_diversity.db_config.redis.pool_size",
  [{datatype, integer},
   {default, 5},
   hidden]}.
 
 
-{mapping, "vmq_diversity.memcache.host", "vmq_diversity.db_config.memcache.host", 
+{mapping, "vmq_diversity.memcache.host", "vmq_diversity.db_config.memcache.host",
  [{datatype, string},
   {default, "localhost"},
   {commented, "localhost"}]}.
 
-{mapping, "vmq_diversity.memcache.port", "vmq_diversity.db_config.memcache.port", 
+{mapping, "vmq_diversity.memcache.port", "vmq_diversity.db_config.memcache.port",
  [{datatype, integer},
   {default, 11211},
   {commented, 11211}]}.
@@ -382,7 +387,7 @@
 %%
 %% Scripts loaded like this are loaded after the scripts in the
 %% default script dir.
-%% 
+%%
 {mapping, "vmq_diversity.$script.file", "vmq_diversity.user_scripts", [
                                                                        {datatype, file},
                                                                        {commented, "path/to/my/script.lua"},

--- a/apps/vmq_diversity/src/vmq_diversity_mongo.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_mongo.erl
@@ -90,6 +90,10 @@ ensure_pool(As, St) ->
                                  maps:get(<<"password">>,
                                           Options,
                                           proplists:get_value(password, DefaultConf))),
+                    AuthSource = vmq_diversity_utils:ustr(
+                                   maps:get(<<"auth_source">>,
+                                            Options,
+                                            proplists:get_value(auth_source, DefaultConf))),
                     Host = vmq_diversity_utils:str(
                              maps:get(<<"host">>,
                                       Options,
@@ -144,7 +148,8 @@ ensure_pool(As, St) ->
                     end,
                     NewOptions = HostPortOrSrv ++
                     [{login, mbin(Login)}, {password, mbin(Password)}, {database, mbin(Database)},
-                     {w_mode, WMode}, {r_mode, RMode}, {ssl, Ssl}, {ssl_opts, SslOpts}],
+                     {auth_source, mbin(AuthSource)}, {w_mode, WMode}, {r_mode, RMode}, {ssl, Ssl},
+                     {ssl_opts, SslOpts}],
                     vmq_diversity_sup:start_pool(mongodb,
                                                  [{id, PoolId},
                                                   {size, Size},

--- a/apps/vmq_diversity/test/mongodb_auth_source_test.lua
+++ b/apps/vmq_diversity/test/mongodb_auth_source_test.lua
@@ -1,0 +1,23 @@
+config = {
+    pool_id = "mongodb_test",
+    size = 1,
+    database="admin",
+    auth_source="core",
+    login="vmq_auth_source_test_user",
+    password="vmq_auth_source_test_password",
+    w_mode = "safe"
+}
+
+assert(mongodb.ensure_pool(config))
+
+assert(mongodb.delete("mongodb_test", "users", {}))
+
+doc1 = {_id = 'test-id',
+       first_name = 'Jules',
+       last_name = 'Verne',
+       protocol = 'MQTT',
+       broker = 'VerneMQ'}
+
+-- insert one document
+ret = mongodb.insert("mongodb_test", "users", doc1)
+assert(ret._id ==  'test-id')

--- a/apps/vmq_diversity/test/vmq_diversity_mongo_SUITE_data/create_auth_source_user.js
+++ b/apps/vmq_diversity/test/vmq_diversity_mongo_SUITE_data/create_auth_source_user.js
@@ -1,0 +1,5 @@
+use core
+db.createUser( { user: "vmq_auth_source_test_user",
+                 pwd: "vmq_auth_source_test_password",
+                 roles: ["readWrite"] },
+               { w: "majority" , wtimeout: 5000 } )

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - Update `vmq_diversity` to newest Luerl version
 - Bumps `rebar3` executable
 - Upgrade Cowboy dependency to 2.8.0
+- Adds support for `auth_source` in MongoDB connections in `vmq_diversity`
 
 ## VerneMQ 1.11.0
 


### PR DESCRIPTION
## Proposed Changes

Allow a different auth source in MongoDB connections. This allows MongoDB users (versus MQTT users) to reside in a database other than "admin".

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [x] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

The setup-gleam action started failing in my local GitHub Actions instance. This is likely because of a dependency issues between Ubuntu 18.04 and 20.04. I pinned CI runners to 18.04 until the issue gets fixed upstream.