### PR TITLE
Cluster ha improvements

### DIFF
--- a/apps/vmq_server/src/vmq_cluster_com.erl
+++ b/apps/vmq_server/src/vmq_cluster_com.erl
@@ -158,6 +158,10 @@ process_bytes(Bytes, Buffer, St) ->
         <<"vmq-send", L:32, BFrames:L/binary, Rest/binary>> ->
             process(BFrames, St),
             process_bytes(Rest, <<>>, St);
+        <<"vmq-tail", L:32, BinPid:L/binary, Rest/binary>> ->
+            Pid = binary_to_term(BinPid),
+            Pid ! block_ack,
+            process_bytes(Rest, <<>>, St);
         _ ->
             %% if we have received something else than "vmq-send" we
             %% will buffer everything unbounded forever and ever!

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -453,25 +453,24 @@ connected({mail, QPid, Msgs, _, Dropped},
     {NewState2, Out} =
     case handle_messages(Msgs, [], 0, NewState, Waiting) of
         {NewState1, HandledMsgs, []} ->
+            %% messages aren't delivered (yet) but are queued in this process
+            %% we notify the queue that we're ready for new messages.
             vmq_queue:notify(QPid),
             {NewState1, HandledMsgs};
         {NewState1, HandledMsgs, NewWaiting} ->
             %% messages aren't delivered (yet) but are queued in this process
-            %% we tell the queue to get rid of them
-            vmq_queue:notify_recv(QPid),
-            %% we call vmq_queue:notify as soon as
-            %% the check_in_flight returns true again
-            %% SEE: Comment in handle_waiting_msgs function.
+            %% we still have waiting messages
             {NewState1#state{waiting_msgs=NewWaiting}, HandledMsgs}
     end,
     {NewState2, Out};
 connected(#mqtt5_puback{message_id=MessageId, reason_code=RC}, #state{waiting_acks=WAcks} = State) ->
     %% qos1 flow
     _ = vmq_metrics:incr({?MQTT5_PUBACK_RECEIVED, rc2rcn(RC)}),
-    case maps:get(MessageId, WAcks, not_found) of
+    case Msg = maps:get(MessageId, WAcks, not_found) of
         #vmq_msg{} ->
             Cnt = fc_decr_cnt(State#state.fc_send_cnt, puback),
-            handle_waiting_msgs(State#state{fc_send_cnt=Cnt, waiting_acks=maps:remove(MessageId, WAcks)});
+            {NewState, Out} = handle_waiting_msgs(State#state{fc_send_cnt=Cnt, waiting_acks=maps:remove(MessageId, WAcks)}),
+            {release_message(Msg, NewState), Out};
         not_found ->
             _ = vmq_metrics:incr(?MQTT5_PUBACK_INVALID_ERROR),
             {State, []}
@@ -481,12 +480,13 @@ connected(#mqtt5_pubrec{message_id=MessageId, reason_code=RC}, State) when RC < 
     #state{waiting_acks=WAcks} = State,
     %% qos2 flow
     _ = vmq_metrics:incr({?MQTT5_PUBREC_RECEIVED,rc2rcn(RC)}),
-    case maps:get(MessageId, WAcks, not_found) of
+    case Msg = maps:get(MessageId, WAcks, not_found) of
         #vmq_msg{} ->
             PubRelFrame = #mqtt5_pubrel{message_id=MessageId, reason_code=?M5_SUCCESS, properties=#{}},
             _ = vmq_metrics:incr({?MQTT5_PUBREL_SENT, ?SUCCESS}),
-            {State#state{waiting_acks=maps:update(MessageId, PubRelFrame, WAcks)},
-             [serialise_frame(PubRelFrame)]};
+            NewState = State#state{waiting_acks=maps:update(MessageId, PubRelFrame, WAcks)},
+            {release_message(Msg, NewState), [serialise_frame(PubRelFrame)]};
+
         #mqtt5_pubrel{message_id=MessageId} = PubRelFrame ->
             %% handle PUBREC retries from the client.
             _ = vmq_metrics:incr({?MQTT5_PUBREL_SENT, ?SUCCESS}),
@@ -1381,6 +1381,7 @@ prepare_frame(#deliver{qos=QoS, msg_id=MsgId, msg=Msg}, State0) ->
              properties=Props0,
              expiry_ts=ExpiryTS} = Msg,
     NewQoS = maybe_upgrade_qos(QoS, MsgQoS, State0),
+    maybe_release_message(NewQoS, Msg, State0),
     {Topic1, Payload1, Props2} =
     case on_deliver_hook(User, SubscriberId, QoS, Topic0, Payload0, IsRetained, Props0) of
         {error, _} ->
@@ -1419,6 +1420,22 @@ prepare_frame(#deliver{qos=QoS, msg_id=MsgId, msg=Msg}, State0) ->
                waiting_acks=maps:put(OutgoingMsgId,
                                      Msg#vmq_msg{qos=NewQoS}, WAcks)}}
     end.
+
+
+%% non-upgraded qos0 message is released immediately
+-spec maybe_release_message(qos(), msg(), state()) -> state().
+maybe_release_message(0, Msg, State) -> 
+     release_message(Msg,State);
+maybe_release_message(_,_,State) -> State.
+
+-spec release_message(msg(), state()) -> state().
+release_message(Msg, #state{queue_pid=QPid} = State) -> 
+     vmq_queue:release_message(QPid, Msg),
+     State.
+
+
+
+
 
 on_deliver_hook(User, SubscriberId, QoS, Topic, Payload, IsRetain, Props) ->
     HookArgs0 = [User, SubscriberId, Topic, Payload, Props],

--- a/apps/vmq_server/src/vmq_queue_sup.erl
+++ b/apps/vmq_server/src/vmq_queue_sup.erl
@@ -59,7 +59,11 @@ start_queue(SupPid, SubscriberId, Clean) ->
     end.
 
 get_queue_pid(QueueTabId, SubscriberId) ->
-    case ets:lookup(QueueTabId, SubscriberId) of
+    case catch ets:lookup(QueueTabId, SubscriberId) of
+        {'EXIT', {badarg,Reason}} ->
+            %% handle exception to avoid crash !
+            lager:warning("queue_sup:get_queue_pid intercepted {badarg, ~p} for qtabid ~p subscriberid ~p", [Reason, QueueTabId, SubscriberId]),
+            not_found;
         [] ->
             not_found;
         [{_, Pid}] ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -194,6 +194,9 @@ register_subscriber_(SessionPid, SubscriberId, StartClean, QueueOpts, N, Reason)
                     false ->
                         Fun = fun(Sid, OldNode) ->
                                       case rpc:call(OldNode, ?MODULE, get_queue_pid, [Sid]) of
+                                          {badrpc, nodedown} ->
+                                              lager:warning("get_queue_pid on old node ~p failed : intercepted {badrpc, nodedown}", [OldNode]),
+                                              done;
                                           not_found ->
                                               case get_queue_pid(Sid) of
                                                   not_found ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -358,9 +358,10 @@ route_remote_msg(RegView, MP, Topic, Msg) ->
     ok.
 route_remote_msg_fold_fun({_, _} = SubscriberIdAndSubInfo, From, Acc) ->
     publish_fold_fun(SubscriberIdAndSubInfo, From, Acc);
-route_remote_msg_fold_fun(_Node, _, Acc) ->
-    %% we ignore remote subscriptions, they are already covered
-    %% by original publisher
+route_remote_msg_fold_fun(Node, From, Acc) ->
+    %% When this node restarted after e.g a crash, messages buffered in remote node
+    %% will arrive here and need to be handled.
+    publish_fold_fun(Node, From, Acc),
     Acc.
 
 -spec publish_fold_wrapper(module(), client_id(), topic(), msg()) -> {ok, {integer(), integer()}}.

--- a/apps/vmq_server/test/vmq_cluster_com_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_com_SUITE.erl
@@ -36,9 +36,12 @@ end_per_testcase(_Case, Config) ->
     ok.
 
 all() ->
-    [connect_success_test,
-     connect_success_send_error,
-     connect_success_send_error_timeout
+    [
+     connect_success_and_send_message,
+     reconnect_resends_backup_on_ack_timeout,
+     msgs_buffered_while_unreachable,
+     reconnect_resends_backup_and_next_buffered_messages,
+     msgs_dropped_when_exceeding_configured_buffer_size
     ].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -47,7 +50,10 @@ all() ->
 connect_params(_RemoteNode) ->
     {gen_tcp, {127,0,0,1}, 12345}.
 
-connect_success_test(Config) ->
+
+
+
+connect_success_and_send_message(Config) ->
     ClusterNodePid = cluster_node_pid(Config),
     {ok, ListenSocket} = gen_tcp:listen(12345, [binary, {reuseaddr, true}, {active, false}]),
     {ok, Socket} = gen_tcp:accept(ListenSocket, 30000),
@@ -55,11 +61,38 @@ connect_success_test(Config) ->
 
     % send test message
     ok = send_message(ClusterNodePid, hello_world),
-    % recv this message
-    recv_message(Socket, hello_world).
+    % recv and ack this message
+    ok = recv_and_ack_message_block(Socket, ClusterNodePid, hello_world).
 
-connect_success_send_error(Config) ->
+reconnect_resends_backup_on_ack_timeout(Config) ->
+    % check that message in transit is not lost.
+    % After e.g. a receiver crash, the sender reconnects and retransmits the last unacked block
+    % We simulate the crash by consuming the message but not acknowledging it to the sender.
+    ClusterNodePid = cluster_node_pid(Config),
+    {ok, ListenSocket} = gen_tcp:listen(12345, [binary, {reuseaddr, true}, {active, false}]),
+    {ok, Socket1} = gen_tcp:accept(ListenSocket, 30000),
+    recv_connect(Socket1, Config),
+
+    % send test message
+    ok = send_message(ClusterNodePid, hello_world),
+    % recv this message without acknowledging to sender (=simulating receiver crash)
+    ok = recv_message_block(Socket1, ClusterNodePid, hello_world),
+
+    % sender closed connection after ack_timeout
+    {error, closed} = gen_tcp:recv(Socket1, 0),
+    % sender reconnects
+    {ok, Socket2} = gen_tcp:accept(ListenSocket, 30000),
+    recv_connect(Socket2, Config),
+
+    % sender retransmits the previously unacked message
+    % This time we recv and ack the original message
+    ok = recv_and_ack_message_block(Socket2, ClusterNodePid, hello_world).
+
+
+msgs_buffered_while_unreachable(Config) ->
     % check that message isn't lost
+    % In case the receiver is unreachable incoming messages are buffered
+    % and delivered upon reconnect.
     ClusterNodePid = cluster_node_pid(Config),
     {ok, ListenSocket} = gen_tcp:listen(12345, [binary, {reuseaddr, true}, {active, false}]),
     {ok, Socket1} = gen_tcp:accept(ListenSocket, 30000),
@@ -68,34 +101,82 @@ connect_success_send_error(Config) ->
     gen_tcp:close(Socket1),
     % send test message, will be buffered and delivered on next successful reconnect
     ok = send_message(ClusterNodePid, hello_world),
-
+    
     {ok, Socket2} = gen_tcp:accept(ListenSocket, 30000),
     recv_connect(Socket2, Config),
-    % recv this message
-    recv_message(Socket2, hello_world).
 
-connect_success_send_error_timeout(Config) ->
-    ct:timetrap({minutes, 10}),
-    % check that message isn't lost
+    % recv and ack the buffered message
+    ok = recv_and_ack_message_block(Socket2, ClusterNodePid, hello_world).
+
+reconnect_resends_backup_and_next_buffered_messages(Config) ->
+    % check that after reconnect (e.g. after receiver crash as simulated here),
+    % the sender retransmits the backup + next buffered messages.
     ClusterNodePid = cluster_node_pid(Config),
     {ok, ListenSocket} = gen_tcp:listen(12345, [binary, {reuseaddr, true}, {active, false}]),
     {ok, Socket1} = gen_tcp:accept(ListenSocket, 30000),
     recv_connect(Socket1, Config),
 
-    N = send_until_tcp_buffer_full(ClusterNodePid),
-    % once the tcp buffer is full, we get disconnected
-    recv_until_tcp_buffer_empty(Socket1, N),
-    % we should have a TCP_CLOSE now
-    {error, closed} = gen_tcp:recv(Socket1, 0),
+    % send 2 messages
+    ok = send_message(ClusterNodePid, hello_world_1),
+    ok = send_message(ClusterNodePid, hello_world_2),
 
-    % the cluster node should do the reconnect
+    % recv first message without acknowledging to sender (=simulating receiver crash)
+    ok = recv_message_block(Socket1, ClusterNodePid, hello_world_1),
+
+    % send 2 more messages
+    ok = send_message(ClusterNodePid, hello_world_3),
+    ok = send_message(ClusterNodePid, hello_world_4),
+
+    % sender closed connection
+    {error, closed} = gen_tcp:recv(Socket1, 0),
+    % sender reconnects
     {ok, Socket2} = gen_tcp:accept(ListenSocket, 30000),
     recv_connect(Socket2, Config),
 
-    % the last buffered message is repeated as the cluster node doesn't
-    % actually know if we have received it or not.
-    recv_message(Socket2, <<1:10000, N:32>>),
-    {error, timeout} = gen_tcp:recv(Socket2, 0, 1000).
+    % sender retransmits the first message and the next buffered messages in one block
+    % This time we recv and ack all 4 messages (in correct order)
+    ok = recv_and_ack_message_block(Socket2, ClusterNodePid, [hello_world_1, hello_world_2, hello_world_3, hello_world_4]).
+
+msgs_dropped_when_exceeding_configured_buffer_size(Config) ->
+    % check that the max_queue_size limit is respected.
+    ClusterNodePid = cluster_node_pid(Config),
+    {ok, ListenSocket} = gen_tcp:listen(12345, [binary, {reuseaddr, true}, {active, false}]),
+    {ok, Socket1} = gen_tcp:accept(ListenSocket, 30000),
+    recv_connect(Socket1, Config),
+    % close this socket
+    gen_tcp:close(Socket1),
+
+    % each of those messages results in a binary size of 250 bytes to be buffered :
+    Msg1 = <<1:237/unit:8>>,
+    Msg2 = <<2:237/unit:8>>,
+    Msg3 = <<3:237/unit:8>>,
+    Msg4 = <<4:237/unit:8>>,
+
+    Msg5 = <<5:1/unit:8>>,
+
+    % send test messages, will be buffered until configured buffer size reached
+    ok = send_message(ClusterNodePid, Msg1),
+    ok = send_message(ClusterNodePid, Msg2),
+    ok = send_message(ClusterNodePid, Msg3),
+    ok = send_message(ClusterNodePid, Msg4),
+  
+    % outgoing_clustering_buffer_size was configured to 1000 bytes
+    % at this point this size is exactly reached hence the next small message will be dropped:
+    Msg5 = <<5:1/unit:8>>,
+    {error, msg_dropped} = send_message(ClusterNodePid, Msg5),
+
+    % reconnect
+    {ok, Socket2} = gen_tcp:accept(ListenSocket, 30000),
+    recv_connect(Socket2, Config),
+
+    % recv and ack the 4 buffered messages
+    ok = recv_and_ack_message_block(Socket2, ClusterNodePid, [Msg1,Msg2,Msg3,Msg4]).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Internal helper functions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 
 
 send_until_tcp_buffer_full(ClusterNodePid) ->
@@ -163,3 +244,44 @@ recv_message(Socket, Term) ->
             io:format(user, "got ~p instead of ~p~n", [E, {ok, BatchMsg}]),
             E
     end.
+
+recv_and_ack_message_block(Socket, ClusterNodePid, Msgs) ->
+    ok = recv_message_block(Socket, ClusterNodePid, Msgs),
+    ack_message_block(ClusterNodePid).
+
+recv_message_block(Socket, ClusterNodePid, Msgs) when is_list(Msgs) ->
+    %%Block = iolist_to_binary(wrap_msgs(Msgs)),
+    Block = wrap_msgs(Msgs),
+    Tail = tail(ClusterNodePid),
+     L = iolist_size(Block),
+    BatchMsg = iolist_to_binary([<<"vmq-send", L:32>>, Block, Tail]),
+    %%BatchMsg = <<"vmq-send", L:32, Block/binary, Tail/binary>>,
+    case gen_tcp:recv(Socket, byte_size(BatchMsg)) of
+        {ok, BatchMsg} -> ok;
+        E ->
+            io:format(user, "got ~p instead of ~p~n", [E, {ok, BatchMsg}]),
+            E
+    end;
+recv_message_block(Socket, ClusterNodePid, Msg) ->
+    recv_message_block(Socket, ClusterNodePid, [Msg]).
+
+ack_message_block(ClusterNodePid) ->
+    ClusterNodePid ! block_ack,
+    ok.
+
+
+wrap_msgs(Msgs) ->
+    wrap_msgs_(Msgs, []).
+
+wrap_msgs_([], Acc) ->
+    lists:reverse(Acc);
+wrap_msgs_([Msg | Rest], Acc) ->
+    Bin = term_to_binary(Msg),
+    L = byte_size(Bin),
+    Wrap = <<"msg", L:32, Bin/binary>>,
+    wrap_msgs_(Rest, [Wrap | Acc]).
+
+tail(Pid) ->
+   Bin = term_to_binary(Pid),
+   L = byte_size(Bin),
+   [<<"vmq-tail", L:32>>, Bin].

--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -345,6 +345,7 @@ mock_session(Parent) ->
             mock_session(Parent);
         {to_session_fsm, {mail, QPid, Msgs, _, _}} ->
             vmq_queue:notify(QPid),
+            release_msgs(QPid, Msgs),
             timer:sleep(100),
             Parent ! {received, QPid, Msgs},
             mock_session(Parent);
@@ -353,6 +354,12 @@ mock_session(Parent) ->
         _ -> % go down
             ok
     end.
+
+release_msgs(_, []) -> ok;
+release_msgs(QPid, [Msg | Rest]) ->
+    vmq_queue:release_message(QPid, Msg),
+    release_msgs(QPid, Rest).
+
 
 msg(Topic, Payload, QoS) ->
     #vmq_msg{msg_ref=vmq_mqtt_fsm_util:msg_ref(),


### PR DESCRIPTION
## Proposed Changes

These changes fix missing messages in QoS1 in a HA VerneMQ cluster
as reported in this issue:
Message loss on node fault with QoS1(#1700)

Following problems were discovered/addressed:

1. Make enqueue a synhronous call :
When the broker receives a message from a publisher it was written into the subscriber(s) queue(s)
using an asynchronous function call. This causes the ack to be sent before the message was written to persistent storage
hence leaving a small time-window in which a crash of the broker causes the acknowledged message to be lost.

Solved by using a synchronous call.

2. Add handshake on inter-node TCP connection :
When the broker receives messages for a subscriber connected to another node, the messages are sent via the dedicated inter-node TCP connection.  A crash of the receiving node while a message is present in the tcp receive buffer
and acknowledged to the sender but not yet processed by the broker will cause that message to be lost.
The publisher received an ack when the message was delivered to the senders tcp stack.

Solved by introducing an application-level handshake on the inter-node tcp connection:
 - The message block "in transit" is buffered until acknowledged by the receiving node.
 - In case the receiving node crashed and hence no ack was received, the buffer is resent when the connection is re-established.
 - In case the subscriber reconnected to another node, the resent messages are forwarded to that new node.

3. Catch crashes during queue migration :
During HA testing some some crashes were observed when queue migration was triggered
i.,e. rpc call to get queue pid from the crashed node and ets:lookup.

Solved by handling the exceptions.

4. Only release messages when acknowledged :
When the broker delivers messages to a connected subscriber, the messages from the queue are saved in a
backup queue and "mailed" to the fsm process that performs the interaction with the client. (retries, acks, ...).
But the backup messages were released (=deleted from persistent storage) before they were actually acknowledged
by the subscriber.
Again, when the broker crashes those messages are lost.

Solved by : 
- releasing each message individually when the fsm receives the ack.
- QoS0 messages are released immediately (unless potentially being upgraded by "maybe_upgrade_qos")
- next message batch is now added to the backup queue instead of replacing it.


## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1700)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

These fixes do not yet cover all cases of message loss but already drastically reduced their ocurrence:

Without the fixes about 1 in 3 HA testruns showed message loss.
Above fixes reduced this to about 1 lost message in 1000 testruns.
