### PR TITLE
[WIP] Revert MongoDB pool init change

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_sup.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_sup.erl
@@ -115,7 +115,7 @@ start_all_pools([{mongodb, ProviderConfig}|Rest], Acc) ->
                        SslOpts = proplists:get_value(ssl_opts, WorkerArgs0),
                        WorkerArgs1 = proplists:delete(ssl, WorkerArgs0),
                        WorkerArgs2 = proplists:delete(ssl_opts, WorkerArgs1),
-                       mc_worker_api:connect([{ssl,Ssl}, {ssl_opts, SslOpts}|WorkerArgs2])
+                       mc_worker:start_link([{ssl,Ssl}, {ssl_opts, SslOpts}|WorkerArgs2])
                end,
     TerminateFun = fun(Pid) -> mc_worker:disconnect(Pid) end,
     WrapperArgs = [{reconnect_timeout, 1000},

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Revert binary_to_term safe calls to bare version
+- Revert mc_worker_api:connect/1 to mc_worker:start_link/1 for MongoDB pool
 
 ## VerneMQ 1.12.0
 


### PR DESCRIPTION
Revert move from mc_worker:start_link/1 to mc_worker_api:connect/1.
Calling start_link/1 sets the MongoDB r_mode and w_mode.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1821)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
