### PR TITLE
Loosen MongoDB reads

### DIFF
--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -294,15 +294,16 @@
   {default, 5},
   hidden]}.
 
-{mapping, "vmq_diversity.mongodb.r_mode", "vmq_diversity.db_config.mongodb.r_mode",
- [{datatype, atom},
-  {default, master},
-  hidden]}.
-
 {mapping, "vmq_diversity.mongodb.w_mode", "vmq_diversity.db_config.mongodb.w_mode",
  [{datatype, atom},
   {default, safe},
   hidden]}.
+
+{mapping, "vmq_diversity.mongodb.read_preference", "vmq_diversity.db_config.mongodb.read_preference",
+ [{datatype, {enum, [primary, primaryPreferred, secondary, secondaryPreferred, nearest]}},
+  {default, primaryPreferred},
+  hidden
+ ]}.
 
 %% @doc Specify if the mongodb driver should use TLS or not.
 {mapping, "vmq_diversity.mongodb.ssl", "vmq_diversity.db_config.mongodb.ssl",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+  -  Move from `r_mode` to read preference in VMQ Diversity MongoDB
+
 ## VerneMQ 1.12.2
 
   -  Fix username for allow_anonymous case in MQTT v5 (keep the given username in session)


### PR DESCRIPTION
This fixes the issue with r_mode not working in the latest version
of MongoDB. The r_mode option is deprecated in the underlying
MongoDB driver. We must now set a read preference instead.

This PR uses the primaryPreferred read preference by default.
However, the value isn't really meaningful, since VerneMQ
Diversity's pooling mechanism does not monitor a topology
of primary and secondary nodes in a MongoDB replica set.
This default read preference is a reasonable choice for
folks using VMQ Diversity to auth against MongoDB.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging


