### PR TITLE
Fix webhook cache to not allow multiple entries per key

### DIFF
--- a/apps/vmq_webhooks/src/vmq_webhooks_cache.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_cache.erl
@@ -35,7 +35,7 @@
 %% API
 -spec new() -> 'ok'.
 new() ->
-    ets:new(?CACHE, [public, bag, named_table, {read_concurrency, true}]),
+    ets:new(?CACHE, [public, set, named_table, {read_concurrency, true}]),
     ets:new(?STATS, [public, ordered_set, named_table, {write_concurrency, true}]),
     ok.
 


### PR DESCRIPTION
When many client requests with identical client ids are arriving almost in
parallel, it could happen that multiple requests are processed in parallel.
Nevertheless, those requests must not lead to multiple cache entries per
key, as this would crash the lookup function with the below error message.
Changing the ets storage table type from a `bag` to a `set` is apparently
already sufficient to achieve this.

This is the error message occurring before this change, which did no
longer occur after this change. Notice how the crash is caused by a
non-matching case in vmq_webhooks_cache:lookup_/3 line 88:

13:02:18.953 [error] CRASH REPORT Process <0.2338.0> with 0 neighbours crashed
with reason: no case clause matching [
{{<<"https://someserver:443/api/broker/auth/register">>,auth_on_register,[
{addr,<<"172.21.0.7">>},{mountpoint,<<"password">>},{client_id,<<"client11">>},
{username,<<"someuser">>},{password,<<"somepassword">>},{clean_session,true}]},
{<<"password">>,<<"client11">>},1652447234,[{mountpoint,<<>>},{client_id,<<"client11">>}]},
{{<<"https://someserver:443/api/broker/auth/register">>,auth_on_register,[
{addr,<<"172.21.0.7">>},{mountpoint,<<"password">>},{client_id,<<"client11">>},
{username,<<"someuser">>},{password,...},...]},...}]
in vmq_webhooks_cache:lookup_/3 line 88

## Proposed Changes

Fix crash in webhook_cache upon many parallel client requests

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [-] I have added necessary documentation (if needed)
- [-] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

I know only very little Erlang so far. Hence I don't (yet) have the skills to write tests for this, but rather did end-to-end tests in our deployment of the broker. There, I was able to reliably reproduce the crash before the change, and the non-occurrence of the crash after the change. So the change in table type as described here https://www.erlang.org/doc/man/ets.html#new-2 seems like the matching bugfix.