### PR TITLE
Fix typo in vmq_listener_cli help text

### DIFF
--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -315,7 +315,7 @@ vmq_listener_start_usage() ->
      "PROXYv2 Options\n\n",
      "  --proxy_protocol\n",
      "      Enable PROXY v2 protocol for this listener\n",
-     "  --use_cn_as_username\n",
+     "  --proxy_protocol_use_cn_as_username\n",
      "      If PROXY v2 is enabled for this listener use this flag\n",
      "      to decide if the common name should replace the MQTT username\n",
      "      Enabled by default (use `=false`) to disable\n\n",


### PR DESCRIPTION
## Proposed Changes
Fix cli output of help-text for the `proxy_protocol_use_cn_as_username` listener property
(`vmq-admin listener start -h`)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
