### PR TITLE
Expose handshake_timeout option in listeners

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -661,6 +661,69 @@
                                                                                   hidden
                                                                           ]}.
 
+%% @doc Set the TLS handshake timeout. This represents the maximum time that can
+%% be spent completing the TLS handshake for the protocol.
+%%
+%% It can be useful to set this to a higher value when clients are running on
+%% constrained devices (e.g. microcontrollers) which can take more than 5 seconds
+%% (the default value) to complete the TLS handshake.
+%%
+%% This can be specified either on the protocol level:
+%%
+%%     - listener.ssl.tls_handshake_timeout
+%%     - listener.wss.tls_handshake_timeout
+%%     - listener.vmqs.tls_handshake_timeout
+%%     - listener.https.tls_handshake_timeout
+%%
+%% or on the listener level:
+%%
+%%     - listener.ssl.my_ssl_listener.tls_handshake_timeout
+%%     - listener.wss.my_wss_listener.tls_handshake_timeout
+%%     - listener.vmqs.my_vmqs_listener.tls_handshake_timeout
+%%     - listener.https.my_https_listener.tls_handshake_timeout
+{mapping, "listener.ssl.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                      {default, -1},
+                                                                      {datatype, [integer, {atom, infinity}]},
+                                                                      hidden
+                                                                     ]}.
+
+{mapping, "listener.ssl.$name.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                            {datatype, [integer, {atom, infinity}]},
+                                                                            hidden
+                                                                           ]}.
+
+{mapping, "listener.wss.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                            {default, -1},
+                                                                            {datatype, [integer, {atom, infinity}]},
+                                                                            hidden
+                                                                           ]}.
+
+{mapping, "listener.wss.$name.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                                  {datatype, [integer, {atom, infinity}]},
+                                                                                  hidden
+                                                                                 ]}.
+
+{mapping, "listener.vmqs.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                                  {default, -1},
+                                                                                  {datatype, [integer, {atom, infinity}]},
+                                                                                  hidden
+                                                                                 ]}.
+{mapping, "listener.vmqs.$name.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                                  {datatype, [integer, {atom, infinity}]},
+                                                                                  hidden
+                                                                                 ]}.
+
+{mapping, "listener.https.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                                  {default, -1},
+                                                                                  {datatype, [integer, {atom, infinity}]},
+                                                                                  hidden
+                                                                                 ]}.
+
+{mapping, "listener.https.$name.tls_handshake_timeout", "vmq_server.listeners", [
+                                                                                  {datatype, [integer, {atom, infinity}]},
+                                                                                  hidden
+                                                                          ]}.
+
 %% @doc listener.tcp.<name> is an IP address and TCP port that
 %% the broker will bind to. You can define multiple listeners e.g:
 %% - listener.tcp.default = 127.0.0.1:1883

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -45,6 +45,12 @@ vmq_listener_start_cmd() ->
                                           end}]},
                  {nr_of_acceptors, [{longname, "nr_of_acceptors"},
                                     {typecast, fun(N) -> list_to_integer(N) end}]},
+                 {tls_handshake_timeout, [{longname, "tls_handshake_timeout"},
+                                    {typecast, fun
+                                                   ("infinity") -> infinity;
+                                         (N) ->
+                                            list_to_integer(N)
+                                    end}]},
                  {websocket, [{shortname, "ws"},
                               {longname, "websocket"}]},
                  {proxy_protocol, [{longname, "proxy_protocol"}]},
@@ -307,6 +313,7 @@ vmq_listener_start_usage() ->
      "  -m, --mountpoint=Mountpoint\n",
      "  --nr_of_acceptors=NrOfAcceptors\n",
      "  --max_connections=[infinity | MaxConnections]\n",
+     "  --tls_handshake_timeout=[infinity | TLSHandshakeTimeout]\n",
      "  --allowed_protocol_versions=[3|4|5]\n",
      "      Defaults to 3,4\n\n",
      "WebSocket Options\n\n",

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -91,6 +91,11 @@ translate_listeners(Conf) ->
     {HTTPIPs, HTTPNrOfAcceptors} = lists:unzip(extract("listener.http", "nr_of_acceptors", InfIntVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLNrOfAcceptors} = lists:unzip(extract("listener.https", "nr_of_acceptors", InfIntVal, Conf)),
 
+    {SSLIPs, SSLTLSHandshakeTimeout} = lists:unzip(extract("listener.ssl", "tls_handshake_timeout", InfIntVal, Conf)),
+    {WS_SSLIPs, WS_SSLTLSHandshakeTimeout} = lists:unzip(extract("listener.wss", "tls_handshake_timeout", InfIntVal, Conf)),
+    {VMQ_SSLIPs, VMQ_SSLTLSHandshakeTimeout} = lists:unzip(extract("listener.vmqs", "tls_handshake_timeout", InfIntVal, Conf)),
+    {HTTP_SSLIPs, HTTP_SSLTLSHandshakeTimeout} = lists:unzip(extract("listener.https", "tls_handshake_timeout", InfIntVal, Conf)),
+
     {TCPIPs, TCPMountPoint} = lists:unzip(extract("listener.tcp", "mountpoint", MPVal, Conf)),
     {SSLIPs, SSLMountPoint} = lists:unzip(extract("listener.ssl", "mountpoint", MPVal, Conf)),
     {WSIPs, WSMountPoint} = lists:unzip(extract("listener.ws", "mountpoint", MPVal, Conf)),
@@ -199,6 +204,7 @@ translate_listeners(Conf) ->
 
     SSL = lists:zip(SSLIPs, MZip([SSLMaxConns,
                                   SSLNrOfAcceptors,
+                                  SSLTLSHandshakeTimeout,
                                   SSLMountPoint,
                                   SSLCAFiles,
                                   SSLDepths,
@@ -215,6 +221,7 @@ translate_listeners(Conf) ->
                                   SSLAllowAnonymousOverride])),
     WSS = lists:zip(WS_SSLIPs, MZip([WS_SSLMaxConns,
                                      WS_SSLNrOfAcceptors,
+                                     WS_SSLTLSHandshakeTimeout,
                                      WS_SSLMountPoint,
                                      WS_SSLCAFiles,
                                      WS_SSLDepths,
@@ -229,6 +236,7 @@ translate_listeners(Conf) ->
                                      WS_SSLAllowedProto])),
     VMQS = lists:zip(VMQ_SSLIPs, MZip([VMQ_SSLMaxConns,
                                        VMQ_SSLNrOfAcceptors,
+                                       VMQ_SSLTLSHandshakeTimeout,
                                        VMQ_SSLMountPoint,
                                        VMQ_SSLCAFiles,
                                        VMQ_SSLDepths,
@@ -242,6 +250,7 @@ translate_listeners(Conf) ->
                                        VMQ_SSLBufferSizes])),
     HTTPS = lists:zip(HTTP_SSLIPs, MZip([HTTP_SSLMaxConns,
                                          HTTP_SSLNrOfAcceptors,
+                                         HTTP_SSLTLSHandshakeTimeout,
                                          HTTP_SSLCAFiles,
                                          HTTP_SSLDepths,
                                          HTTP_SSLCertFiles,
@@ -274,6 +283,7 @@ extract(Prefix, Suffix, Val, Conf) ->
            "keyfile", "require_certificate", "tls_version",
            "use_identity_as_username", "buffer_sizes", "high_watermark",
            "low_watermark", "high_msgq_watermark", "low_msgq_watermark",
+           "tls_handshake_timeout",
            %% http listener specific
            "config_mod", "config_fun",
            %% mqtt listener specific

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -55,6 +55,7 @@
       % default listener / clustering /system opts
       {max_connections, infinity},
       {nr_of_acceptors, 10},
+      {tls_handshake_timeout, 5000},
       {listeners, [{mqtt, [
                            {{{127,0,0,1}, 1889}, [{max_connections, infinity}, 
                                               {mountpoint, ""},

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Fix PostGres (`epgsql` 4.6.0) response format in `vmq_diversity`.
 - Fix Prometheus exposition format, related to MQTT v4 and v5 labels.
 - Add Unix domain listeners (to be configured as "listener.tcp.unix_socket = local:/tmp/my.sock:0")
+- Expose `tls_handshake_timeout` option to listeners.
 
 
 ## VerneMQ 1.12.5

--- a/vars.config
+++ b/vars.config
@@ -33,6 +33,7 @@
 %% vmq_server
 {max_connections, 10000}.
 {max_nr_of_acceptors, 10}.
+{tls_handshake_timeout, 5000}.
 {mqtt_default_ip, "127.0.0.1"}.
 {mqtt_default_port, 1883}.
 {mqtt_default_ws_ip, "127.0.0.1"}.

--- a/vars/dev_vars.config.src
+++ b/vars/dev_vars.config.src
@@ -34,6 +34,7 @@
 %% vmq_server
 {max_connections, 10000}.
 {max_nr_of_acceptors, 10}.
+{tls_handshake_timeout, 5000}.
 {mqtt_default_ip, "127.0.0.1"}.
 {mqtt_default_port, @MQTTPORT@}.
 {mqtt_default_ws_ip, "127.0.0.1"}.


### PR DESCRIPTION
## Proposed Changes

Ranch had a default value of 5 seconds for the handshake timeout. This sometimes caused constrained devices to fail the connection since they couldn't complete the SSL handshake in that amount of time.

This commit allows configuring the handshake timeout to arbitrary values to support such use cases.

This also includes a small internal refactoring, renaming the old `transport_opts` to `socket_opts`, since that's what they actually are, and introducing new base `transport_opts` that depend on the ranch transport.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1670)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging
