### PR TITLE
Centralize JSON encoding/decoding

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
         ports:
           - 11211:11211
       mongodb:
-        image: mongo
+        image: mongo:5.0
         ports:
           - 27017:27017
         env:

--- a/apps/vmq_commons/src/vmq_json.erl
+++ b/apps/vmq_commons/src/vmq_json.erl
@@ -1,0 +1,30 @@
+-module(vmq_json).
+
+-export([decode/1, decode/2, encode/1, encode/2, is_json/1]).
+
+-export_type([json_term/0]).
+
+-define(DEFAULT_ENCODE_OPTS, []).
+-define(DEFAULT_DECODE_OPTS, []).
+
+-type json_term() :: jsx:json_term().
+
+-spec decode(iodata()) -> json_term() | {incomplete, function()}.
+decode(Data) ->
+    decode(Data, ?DEFAULT_DECODE_OPTS).
+
+-spec decode(iodata(), list()) -> json_term() | {incomplete, function()}.
+decode(Data, Opts) ->
+    jsx:decode(Data, Opts).
+
+-spec encode(json_term()) -> iodata() | {incomplete, function()}.
+encode(Term) ->
+    jsx:encode(Term, ?DEFAULT_ENCODE_OPTS).
+
+-spec encode(json_term(), []) -> iodata() | {incomplete, function()}.
+encode(Term, Opts) ->
+    jsx:encode(Term, Opts).
+
+-spec is_json(iodata()) -> boolean().
+is_json(Data) ->
+    jsx:is_json(Data).

--- a/apps/vmq_diversity/test/json_test.lua
+++ b/apps/vmq_diversity/test/json_test.lua
@@ -21,9 +21,9 @@ function equals(o1, o2)
     return true
 end
 
-a1 = {awesome = true, 
-      library = "jsx"}
-a2 = "{\"awesome\":true,\"library\":\"jsx\"}"
+a1 = {awesome = true,
+      format = "json"}
+a2 = "{\"awesome\":true,\"format\":\"json\"}"
 assert(equals(a1, json.decode(a2)))
 assert(equals(json.encode(a1), a2))
 

--- a/apps/vmq_server/src/vmq_cli_json_writer.erl
+++ b/apps/vmq_server/src/vmq_cli_json_writer.erl
@@ -57,9 +57,9 @@
 write(Status) ->
     case lists:reverse(prepare(Status)) of
         [PreparedOutput] ->
-            {jsx:encode(PreparedOutput), []};
+            {vmq_json:encode(PreparedOutput), []};
         PreparedOutput ->
-            {[jsx:encode(PreparedOutput), "\n"], []}
+            {[vmq_json:encode(PreparedOutput), "\n"], []}
     end.
 
 %% @doc Returns status data that's been prepared for conversion to JSON.

--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -34,7 +34,7 @@ init(Req, Opts) ->
                 ]}
         end,
     Headers = #{<<"content-type">> => <<"application/json">>},
-    cowboy_req:reply(Code, Headers, jsx:encode(Payload), Req),
+    cowboy_req:reply(Code, Headers, vmq_json:encode(Payload), Req),
     {ok, Req, Opts}.
 
 -spec check_health_concerns() -> [] | [Concern :: string()].

--- a/apps/vmq_server/src/vmq_status_http.erl
+++ b/apps/vmq_server/src/vmq_status_http.erl
@@ -65,7 +65,7 @@ cluster_status() ->
         {atom_to_binary(Node, utf8), NodeResult}
      || {Node, NodeResult} <- lists:zip([node() | Nodes1], [MyStatus | Result2])
     ],
-    jsx:encode([Data]).
+    vmq_json:encode([Data]).
 
 node_status() ->
     % Total Connections

--- a/apps/vmq_server/test/vmq_http_SUITE.erl
+++ b/apps/vmq_server/test/vmq_http_SUITE.erl
@@ -38,5 +38,5 @@ simple_healthcheck_test(_) ->
                                          {config_fun, routes}]),
     application:ensure_all_started(inets),
     {ok, {_Status, _Headers, Body}} = httpc:request("http://localhost:8888/health"),
-    JsonResponse = jsx:decode(list_to_binary(Body), [return_maps, {labels, binary}]),
+    JsonResponse = vmq_json:decode(list_to_binary(Body), [return_maps, {labels, binary}]),
     <<"OK">> = maps:get(<<"status">>, JsonResponse).

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -866,12 +866,12 @@ call_endpoint(Endpoint, EOpts, Hook, Args0) ->
             {ok, 200, RespHeaders, CRef} ->
                 case hackney:body(CRef) of
                     {ok, Body} ->
-                        case jsx:is_json(Body) of
+                        case vmq_json:is_json(Body) of
                             true ->
                                 handle_response(
                                     Hook,
                                     parse_headers(RespHeaders),
-                                    jsx:decode(Body, [{labels, binary}, {return_maps, false}]),
+                                    vmq_json:decode(Body, [{labels, binary}, {return_maps, false}]),
                                     EOpts
                                 );
                             false ->
@@ -1183,7 +1183,7 @@ encode_payload(Hook, Args, Opts) when
             end,
             Args
         ),
-    jsx:encode(RemappedKeys);
+    vmq_json:encode(RemappedKeys);
 encode_payload(Hook, Args, Opts) when
     Hook =:= auth_on_subscribe; Hook =:= on_subscribe
 ->
@@ -1210,7 +1210,7 @@ encode_payload(Hook, Args, Opts) when
             end,
             Args
         ),
-    jsx:encode(RemappedKeys);
+    vmq_json:encode(RemappedKeys);
 encode_payload(_, Args, Opts) ->
     RemappedKeys =
         lists:map(
@@ -1224,7 +1224,7 @@ encode_payload(_, Args, Opts) ->
             end,
             Args
         ),
-    jsx:encode(RemappedKeys).
+    vmq_json:encode(RemappedKeys).
 
 -spec encode_props(properties(), map()) -> any().
 encode_props(Props, Opts) when is_map(Props) ->

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -38,17 +38,17 @@ stop_endpoint_clear() ->
 init(Req, State) ->
     Hook = cowboy_req:header(<<"vernemq-hook">>, Req),
     {ok, Body, Req1} = cowboy_req:read_body(Req),
-    ?DEBUG andalso io:format(user, ">>> ~s~n", [jsx:prettify(Body)]),
+    ?DEBUG andalso io:format(user, ">>> ~s~n", [Body]),
     case cowboy_req:path(Req) of
         <<"/">> ->
-            {Code, Resp} = process_hook(Hook, jsx:decode(Body, [{labels, atom}, return_maps])),
+            {Code, Resp} = process_hook(Hook, vmq_json:decode(Body, [{labels, atom}, return_maps])),
             Req2 =
                 cowboy_req:reply(Code,
                                  #{<<"content-type">> => <<"text/json">>},
                                  encode(Resp), Req1),
             {ok, Req2, State};
         <<"/cache">> ->
-            {Code, Resp} = process_cache_hook(Hook, jsx:decode(Body, [{labels, atom}, return_maps])),
+            {Code, Resp} = process_cache_hook(Hook, vmq_json:decode(Body, [{labels, atom}, return_maps])),
             Req2 =
                 cowboy_req:reply(Code,
                                  #{<<"content-type">> => <<"text/json">>,
@@ -56,7 +56,7 @@ init(Req, State) ->
                                  encode(Resp), Req1),
             {ok, Req2, State};
         <<"/cache1s">> ->
-            {Code, Resp} = process_cache_hook(Hook, jsx:decode(Body, [{labels, atom}, return_maps])),
+            {Code, Resp} = process_cache_hook(Hook, vmq_json:decode(Body, [{labels, atom}, return_maps])),
             Req2 =
                 cowboy_req:reply(Code,
                                  #{<<"content-type">> => <<"text/json">>,
@@ -66,8 +66,8 @@ init(Req, State) ->
     end.
 
 encode(Term) ->
-    Encoded = jsx:encode(Term),
-    ?DEBUG andalso io:format(user, "<<< ~s~n", [jsx:prettify(Encoded)]),
+    Encoded = vmq_json:encode(Term),
+    ?DEBUG andalso io:format(user, "<<< ~s~n", [Encoded]),
     Encoded.
 
 


### PR DESCRIPTION
## Proposed Changes

This PR abstracts JSON encoding/decoding in a common module, despite of
what library is used behind the scenes. This allows for easier refactoring
as well as switching the JSON library to a faster one with minimal effort.

With upcoming JSON logging that I'm working on it would probably make a difference
to have a library like jsone or thoas that are faster and more memory efficient than JSX.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CODE_OF_CONDUCT.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

@ioolkos - I was thinking if we should add the shared JSON library to `vernemq_dev` to have a common JSON library for plugin writers? 
