### PR TITLE
Fix [regression]: proxy protocol (and CN as username) for WebSockets.…

### DIFF
--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -83,7 +83,7 @@ init(Req, Opts) ->
                         end;
                     %mqttws
                     _ ->
-                        case proplists:get_value(proxy_protocol_use_cn_as_username, Opts, true) of
+                        case proplists:get_value(proxy_protocol_use_cn_as_username, Opts, false) of
                             false ->
                                 FsmMod:init(Peer, Opts);
                             true ->
@@ -95,9 +95,10 @@ init(Req, Opts) ->
                                     % back to the provided MQTT username.
                                     % We expected SSL information from the Proxy protocol but did not get
                                     % any.
+                                    #{ssl := #{cn := CN}} ->
+                                        FsmMod:init(Peer, [{preauth, CN} | Opts]);
                                     #{command := _} ->
-                                        #{ssl := #{cn := CN}} = ProxyInfo0,
-                                        FsmMod:init(Peer, [{preauth, CN} | Opts])
+                                        FsmMod:init(Peer, Opts)
                                 end
                         end
                 end,

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 
+
+- Fix regression in handling of the Proxy protocol for WebSockets.
 ## VerneMQ 1.12.6.2
 
 - Add `max_ws_frame_size` setting to limit incoming WebSocket stream.


### PR DESCRIPTION
… Silently fall back to MQTT username, if no CN is given in proxy protocol.

Fixes https://github.com/vernemq/vernemq/issues/2061
