### PR TITLE
Introduce new metric "active_mqtt_connections"#760

### DIFF
--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -71,7 +71,7 @@ cluster_status() ->
 -spec listeners_status() -> ok | {error, Reason :: string()}.
 listeners_status() ->
     NotRunningListeners = lists:filtermap(
-        fun({Type, _, _, Status, _, _}) ->
+        fun({Type, _, _, Status, _, _, _, _}) ->
             case Status of
                 running ->
                     false;

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -332,7 +332,7 @@ vmq_listener_show_cmd() ->
         fun(_, [], []) ->
             Table =
                 lists:foldl(
-                    fun({Type, Ip, Port, Status, MP, MaxConns}, Acc) ->
+                    fun({Type, Ip, Port, Status, MP, MaxConns, ActiveConns, AllConns}, Acc) ->
                         [
                             [
                                 {type, Type},
@@ -340,7 +340,9 @@ vmq_listener_show_cmd() ->
                                 {ip, Ip},
                                 {port, Port},
                                 {mountpoint, MP},
-                                {max_conns, MaxConns}
+                                {max_conns, MaxConns},
+                                {active_conns, ActiveConns},
+                                {all_conns, AllConns}
                             ]
                             | Acc
                         ]

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1633,7 +1633,9 @@ fetch_external_metric(Mod, Fun, Default) ->
 misc_statistics() ->
     {NrOfSubs, SMemory} = fetch_external_metric(vmq_reg_trie, stats, {0, 0}),
     {NrOfRetain, RMemory} = fetch_external_metric(vmq_retain_srv, stats, {0, 0}),
-    {NrOfMQTTConnections, NrOfMQTTWSConnections} = fetch_external_metric(vmq_ranch_sup, nr_of_active_mqtt_connections, {0, 0}),
+    {NrOfMQTTConnections, NrOfMQTTWSConnections} = fetch_external_metric(
+        vmq_ranch_sup, active_mqtt_connections, {0, 0}
+    ),
     {NetsplitDetectedCount, NetsplitResolvedCount} =
         fetch_external_metric(vmq_cluster, netsplit_statistics, {0, 0}),
     [
@@ -1695,9 +1697,27 @@ misc_stats_def() ->
             <<"The number of bytes used for storing retained messages.">>
         ),
         m(gauge, [], queue_processes, queue_processes, <<"The number of MQTT queue processes.">>),
-        m(gauge, [], active_mqtt_connections, active_mqtt_connections, <<"The number of active MQTT(S) connections.">>),
-        m(gauge, [], active_mqttws_connections, active_mqttws_connections, <<"The number of active MQTT WS(S) connections.">>),
-        m(gauge, [], total_active_connections, total_active_connections, <<"The total number of active MQTT and MQTTWS connections.">>)
+        m(
+            gauge,
+            [],
+            active_mqtt_connections,
+            active_mqtt_connections,
+            <<"The number of active MQTT(S) connections.">>
+        ),
+        m(
+            gauge,
+            [],
+            active_mqttws_connections,
+            active_mqttws_connections,
+            <<"The number of active MQTT WS(S) connections.">>
+        ),
+        m(
+            gauge,
+            [],
+            total_active_connections,
+            total_active_connections,
+            <<"The total number of active MQTT and MQTTWS connections.">>
+        )
     ].
 
 -spec system_statistics() -> [{metric_id(), any()}].

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1633,6 +1633,7 @@ fetch_external_metric(Mod, Fun, Default) ->
 misc_statistics() ->
     {NrOfSubs, SMemory} = fetch_external_metric(vmq_reg_trie, stats, {0, 0}),
     {NrOfRetain, RMemory} = fetch_external_metric(vmq_retain_srv, stats, {0, 0}),
+    {NrOfMQTTConnections, NrOfMQTTWSConnections} = fetch_external_metric(vmq_ranch_sup, nr_of_active_mqtt_connections, {0, 0}),
     {NetsplitDetectedCount, NetsplitResolvedCount} =
         fetch_external_metric(vmq_cluster, netsplit_statistics, {0, 0}),
     [
@@ -1642,7 +1643,10 @@ misc_statistics() ->
         {router_memory, SMemory},
         {retain_messages, NrOfRetain},
         {retain_memory, RMemory},
-        {queue_processes, fetch_external_metric(vmq_queue_sup_sup, nr_of_queues, 0)}
+        {queue_processes, fetch_external_metric(vmq_queue_sup_sup, nr_of_queues, 0)},
+        {active_mqttws_connections, NrOfMQTTWSConnections},
+        {active_mqtt_connections, NrOfMQTTConnections},
+        {total_active_connections, NrOfMQTTWSConnections + NrOfMQTTConnections}
     ].
 
 -spec misc_stats_def() -> [metric_def()].
@@ -1690,7 +1694,10 @@ misc_stats_def() ->
             retain_memory,
             <<"The number of bytes used for storing retained messages.">>
         ),
-        m(gauge, [], queue_processes, queue_processes, <<"The number of MQTT queue processes.">>)
+        m(gauge, [], queue_processes, queue_processes, <<"The number of MQTT queue processes.">>),
+        m(gauge, [], active_mqtt_connections, active_mqtt_connections, <<"The number of active MQTT(S) connections.">>),
+        m(gauge, [], active_mqttws_connections, active_mqttws_connections, <<"The number of active MQTT WS(S) connections.">>),
+        m(gauge, [], total_active_connections, total_active_connections, <<"The total number of active MQTT and MQTTWS connections.">>)
     ].
 
 -spec system_statistics() -> [{metric_id(), any()}].

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -173,50 +173,33 @@ start_listener(Type, Addr, Port, {SocketOpts, Opts}) ->
     end.
 
 listeners() ->
-    lists:foldl(
-        fun
-            ({ranch_server, _, _, _}, Acc) ->
-                Acc;
-            ({{ranch_listener_sup, {Ip, Port}}, Status, supervisor, _}, Acc) ->
-                {ok, {Type, Opts}} = get_listener_config(Ip, Port),
-                MountPoint = proplists:get_value(mountpoint, Opts, ""),
-                MaxConnections = proplists:get_value(
-                    max_connections,
-                    Opts,
-                    vmq_config:get_env(max_connections)
-                ),
-                Status1 =
-                    case Status of
-                        restarting ->
-                            restarting;
-                        undefined ->
-                            stopped;
-                        Pid when is_pid(Pid) ->
-                            case
-                                lists:keyfind(
-                                    ranch_acceptors_sup, 1, supervisor:which_children(Pid)
-                                )
-                            of
-                                false ->
-                                    not_found;
-                                {_, restarting, supervisor, _} ->
-                                    restarting;
-                                {_, undefined, supervisor, _} ->
-                                    stopped;
-                                {_, AcceptorPid, supervisor, _} when is_pid(AcceptorPid) ->
-                                    running
-                            end
-                    end,
-                StrIp =
-                    case Ip of
-                        {local, FS} -> FS;
-                        _ -> inet:ntoa(Ip)
-                    end,
-                StrPort = integer_to_list(Port),
-                [{Type, StrIp, StrPort, Status1, MountPoint, MaxConnections} | Acc]
+    maps:fold(
+        fun({Ip, Port}, ConfigMap, Acc) ->
+            {ok, {Type, Opts}} = get_listener_config(Ip, Port),
+            MountPoint = proplists:get_value(mountpoint, Opts, ""),
+            MaxConnections = proplists:get_value(
+                max_connections,
+                Opts,
+                vmq_config:get_env(max_connections)
+            ),
+            ActiveConnections = maps:get(active_connections, ConfigMap),
+            % the highest number of connections seen
+            AllConnections = maps:get(all_connections, ConfigMap),
+            Status = maps:get(status, ConfigMap),
+            StrIp =
+                case Ip of
+                    {local, FS} -> {local, FS};
+                    _ -> inet:ntoa(Ip)
+                end,
+            StrPort = integer_to_list(Port),
+            [
+                {Type, StrIp, StrPort, Status, MountPoint, MaxConnections, ActiveConnections,
+                    AllConnections}
+                | Acc
+            ]
         end,
         [],
-        supervisor:which_children(ranch_sup)
+        ranch:info()
     ).
 
 get_listener_config(Addr, Port) ->

--- a/apps/vmq_server/src/vmq_ranch_sup.erl
+++ b/apps/vmq_server/src/vmq_ranch_sup.erl
@@ -16,7 +16,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0, nr_of_active_mqtt_connections/0]).
+-export([start_link/0, active_mqtt_connections/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -27,19 +27,20 @@
 %%% API functions
 %%%===================================================================
 
-active_connections(Ip, Port) ->
-    {ok, IpAddr} = inet:parse_address(Ip),
-    Listener_name = {IpAddr, list_to_integer(Port)},
-    maps:get(active_connections, ranch:info(Listener_name)).
-
-nr_of_active_mqtt_connections() ->
+active_mqtt_connections() ->
     lists:foldl(
         fun
-            ({mqtt, Ip, Port, _, _, _}, Sum)    ->  {element(1,Sum) +  active_connections(Ip, Port), element(2, Sum)};  
-            ({mqtts, Ip, Port, _, _, _}, Sum)   ->  {element(1,Sum) +  active_connections(Ip, Port), element(2, Sum)}; 
-            ({mqttws, Ip, Port, _, _, _}, Sum)  ->  {element(1,Sum), element(2, Sum) + active_connections(Ip, Port)};
-            ({mqttwss, Ip, Port, _, _, _}, Sum) ->  {element(1,Sum), element(2, Sum) + active_connections(Ip, Port)};
-            (_, Sum) -> Sum
+            % Unix sockets will also be counted under "mqtt"
+            ({mqtt, _, _, _, _, _, Active, _}, {MQTT, WS}) ->
+                {MQTT + Active, WS};
+            ({mqtts, _, _, _, _, _, Active, _}, {MQTT, WS}) ->
+                {MQTT + Active, WS};
+            ({mqttws, _, _, _, _, _, Active, _}, {MQTT, WS}) ->
+                {MQTT, WS + Active};
+            ({mqttwss, _, _, _, _, _, Active, _}, {MQTT, WS}) ->
+                {MQTT, WS + Active};
+            (_, Sum) ->
+                Sum
         end,
         {0, 0},
         vmq_ranch_config:listeners()
@@ -59,7 +60,6 @@ nr_of_active_mqtt_connections() ->
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
-	
 %%%===================================================================
 %%% Supervisor callbacks
 %%%===================================================================

--- a/apps/vmq_server/src/vmq_status_http.erl
+++ b/apps/vmq_server/src/vmq_status_http.erl
@@ -69,12 +69,10 @@ cluster_status() ->
 
 node_status() ->
     % Total Connections
-    SocketOpen = counter_val(?METRIC_SOCKET_OPEN),
-    SocketClose = counter_val(?METRIC_SOCKET_CLOSE),
-    TotalConnections = SocketOpen - SocketClose,
+    TotalActiveMqttConnections = lists:sum(tuple_to_list(vmq_ranch_sup:nr_of_active_mqtt_connections())), 
     % Total Online Queues
     TotalQueues = vmq_queue_sup_sup:nr_of_queues(),
-    TotalOfflineQueues = TotalQueues - TotalConnections,
+    TotalOfflineQueues = TotalQueues - TotalActiveMqttConnections,
     TotalPublishIn =
         counter_val(?MQTT4_PUBLISH_RECEIVED) +
             counter_val(?MQTT5_PUBLISH_RECEIVED),
@@ -90,7 +88,7 @@ node_status() ->
     {NrOfSubs, _SMemory} = vmq_reg_trie:stats(),
     {NrOfRetain, _RMemory} = vmq_retain_srv:stats(),
     {ok, [
-        {<<"num_online">>, TotalConnections},
+        {<<"num_online">>, TotalActiveMqttConnections},
         {<<"num_offline">>, TotalOfflineQueues},
         {<<"msg_in">>, TotalPublishIn},
         {<<"msg_out">>, TotalPublishOut},

--- a/apps/vmq_server/src/vmq_status_http.erl
+++ b/apps/vmq_server/src/vmq_status_http.erl
@@ -69,7 +69,9 @@ cluster_status() ->
 
 node_status() ->
     % Total Connections
-    TotalActiveMqttConnections = lists:sum(tuple_to_list(vmq_ranch_sup:nr_of_active_mqtt_connections())), 
+    TotalActiveMqttConnections = lists:sum(
+        tuple_to_list(vmq_ranch_sup:active_mqtt_connections())
+    ),
     % Total Online Queues
     TotalQueues = vmq_queue_sup_sup:nr_of_queues(),
     TotalOfflineQueues = TotalQueues - TotalActiveMqttConnections,
@@ -116,12 +118,17 @@ counter_val(C) ->
 
 listeners() ->
     lists:foldl(
-        fun({Type, Ip, Port, Status, MP, MaxConns}, Acc) ->
+        fun({Type, Ip, Port, Status, MP, MaxConns, _, _}, Acc) ->
+            Ip1 =
+                case Ip of
+                    {local, FS} -> list_to_binary(FS);
+                    Any -> list_to_binary(Any)
+                end,
             [
                 [
                     {type, Type},
                     {status, Status},
-                    {ip, list_to_binary(Ip)},
+                    {ip, Ip1},
                     {port, list_to_integer(Port)},
                     {mountpoint, MP},
                     {max_conns, MaxConns}

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 
 - Add support for TLS-PSK (Pre-Shared Key) for MQTTS (TLS) listeners
 - Fix regression in handling of the Proxy protocol for WebSockets.
+- Refactor metrics count of active connections, using 3 new gauges:
+  `active_mqtt_connections`, `active_mqttws_connections` (WebSocket) and
+  `total_active_connections`. Adapt Status page. This also fixes an error,
+  where the status page would show a false connection count.
+- Add `active_conns` and `all_conns` info to `vmq-admin listener show`.
 ## VerneMQ 1.12.6.2
 
 - Add `max_ws_frame_size` setting to limit incoming WebSocket stream.


### PR DESCRIPTION
Adds a new metric active_mqtt_connections that replaces the old logic of counting open and closed sockets. The metric is then used for the status page which should not show negative offline clients anymore.


## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes issue #760)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CODE_OF_CONDUCT.md` document
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
