### PR TITLE
Initial support for TLS-PSK

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1576,6 +1576,72 @@
                                                                                   hidden
                                                                                  ]}.
 
+%% @doc If listener.ssl.pskfile is enabled VerneMQ supports TLS connection based on
+%% pre-shared keys (PSK).
+%%
+%% The option can be specified either for all SSL listeners or for
+%% a specific listener.  
+%%
+%%     - listener.ssl.psk_support
+%%
+%% or on the listener level:
+%%
+%%     - listener.ssl.my_ssl_listener.psk_support
+{mapping, "listener.ssl.psk_support", "vmq_server.listeners", [
+                                                               {default, off},
+                                                               {datatype, flag},
+                                                               {commented, off}
+                                                              ]}.
+{mapping, "listener.ssl.$name.psk_support", "vmq_server.listeners", [
+                                                                     {datatype, flag},
+                                                                      hidden
+                                                                    ]}.
+%% @doc The PSK hint sent by the server to the client.
+%%
+%% The option can be specified either for all SSL listeners or for
+%% a specific listener.
+%%
+%%     - listener.ssl.psk_identity_hint
+%%
+%% or on the listener level:
+%%
+%%     - listener.ssl.my_ssl_listener.psk_identity_hint
+{mapping, "listener.ssl.psk_identity_hint", "vmq_server.listeners", [
+                                                               {default, "VMQ_PSK"},
+                                                               {datatype, string},
+                                                               {commented, "VMQ_PSK"}
+                                                              ]}.
+{mapping, "listener.ssl.$name.psk_identity_hint", "vmq_server.listeners", [
+                                                                     {datatype, string},
+                                                                      hidden
+                                                                    ]}.
+
+
+%% @doc If PSK support is enabled, the pre-shared keys must be provided as key value pairs 
+%% seperated by a seperator (by default ":"), e.g.
+%%
+%% mypskidentity:mypskkey
+%%
+%% The key is a string (not hex-encoded). The psk file is used for all listerners.   
+{mapping, "listener.ssl.pskfile", "vmq_server.listeners", [
+                                                           {default, "{{platform_etc_dir}}/vmq.psk"},
+                                                           {datatype, file}
+                                                          ]}.
+%% @doc The pre-shared keys and the psk identity are separated by a separator.
+%% By default, a colon is used.
+{mapping, "listener.ssl.pskfile_separator", "vmq_server.listeners", [
+                                                               {default, ":"},
+                                                               {datatype, string},
+                                                               {commented, ":"},
+                                                               {validators, ["separator_validator"]}
+                                                              ]}.
+
+{validator, "separator_validator", "separator must be  a 1 character string",
+ fun(String) ->
+         string:length(String) == 1
+ end}.
+
+
 {translation, "vmq_server.listeners",
  fun(Conf) ->
          vmq_schema:translate_listeners(Conf)

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -120,6 +120,18 @@ vmq_listener_start_cmd() ->
                 end
             end}
         ]},
+        {pskfile, [
+            {longname, "pskfile"},
+            {typecast, fun(FileName) ->
+                case filelib:is_file(FileName) of
+                    true -> FileName;
+                    false -> {error, {invalid_flag_value, {pskfile, FileName}}}
+                end
+            end}
+        ]},
+        {psk_support, [
+            {longname, "psk_support"}
+        ]},
         {ciphers, [
             {longname, "ciphers"},
             {typecast, fun(C) -> C end}

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -143,6 +143,7 @@ start_listener(Type, Addr, Port, {SocketOpts, Opts}) ->
         Opts,
         vmq_config:get_env(max_connections)
     ),
+    vmq_ssl_psk:init(Opts),
     NrOfAcceptors = proplists:get_value(
         nr_of_acceptors,
         Opts,

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -236,6 +236,16 @@ translate_listeners(Conf) ->
     {SSLIPs, SSLUseIdents} = lists:unzip(
         extract("listener.ssl", "use_identity_as_username", BoolVal, Conf)
     ),
+    {SSLIPs, SSLPSKSupport} = lists:unzip(
+        extract("listener.ssl", "psk_support", BoolVal, Conf)
+    ),
+    {SSLIPs, SSLPSKFile} = lists:unzip(extract("listener.ssl", "pskfile", StrVal, Conf)),
+    {SSLIPs, SSLPSKFileSeparator} = lists:unzip(
+        extract("listener.ssl", "pskfile_separator", StrVal, Conf)
+    ),
+    {SSLIPs, SSLPSKIdentityHint} = lists:unzip(
+        extract("listener.ssl", "psk_identity_hint", StrVal, Conf)
+    ),
 
     % WSS
     {WS_SSLIPs, WS_SSLCAFiles} = lists:unzip(extract("listener.wss", "cafile", StrVal, Conf)),
@@ -361,6 +371,10 @@ translate_listeners(Conf) ->
             SSLRequireCerts,
             SSLVersions,
             SSLUseIdents,
+            SSLPSKSupport,
+            SSLPSKFile,
+            SSLPSKFileSeparator,
+            SSLPSKIdentityHint,
             SSLAllowedProto,
             SSLBufferSizes,
             SSLAllowAnonymousOverride
@@ -453,6 +467,10 @@ extract(Prefix, Suffix, Val, Conf) ->
             "require_certificate",
             "tls_version",
             "use_identity_as_username",
+            "psk_support",
+            "pskfile",
+            "pskfile_separator",
+            "psk_identity_hint",
             "buffer_sizes",
             "high_watermark",
             "low_watermark",

--- a/apps/vmq_server/src/vmq_ssl.erl
+++ b/apps/vmq_server/src/vmq_ssl.erl
@@ -72,46 +72,57 @@ extract_cn2([_ | Rest]) ->
 extract_cn2([]) ->
     undefined.
 
-opts(Opts) ->
+opts(certfiles, Opts) ->
     [
         {cacertfile, proplists:get_value(cafile, Opts)},
         {certfile, proplists:get_value(certfile, Opts)},
-        {keyfile, proplists:get_value(keyfile, Opts)},
-        {ciphers, ciphersuite_transform(proplists:get_value(ciphers, Opts, []))},
-        {eccs, proplists:get_value(eccs, Opts, ssl:eccs())},
-        {fail_if_no_peer_cert,
-            proplists:get_value(
-                require_certificate,
-                Opts,
-                false
-            )},
-        {verify,
-            case
-                proplists:get_value(require_certificate, Opts, false) or
-                    proplists:get_value(use_identity_as_username, Opts, false)
-            of
-                true -> verify_peer;
-                _ -> verify_none
-            end},
-        {verify_fun, {fun verify_ssl_peer/3, proplists:get_value(crlfile, Opts, no_crl)}},
-        {depth, proplists:get_value(depth, Opts, 1)},
-        {versions, [proplists:get_value(tls_version, Opts, 'tlsv1.2')]}
-        | []
-        %% TODO: support for flexible partial chain functions
-        % case support_partial_chain() of
-        %     true ->
-        %         [{partial_chain, fun([DerCert|_]) ->
-        %                                  {trusted_ca, DerCert}
-        %                          end}];
-        %     false ->
-        %         []
-        % end
-    ].
+        {keyfile, proplists:get_value(keyfile, Opts)}
+    ];
+opts(cert, Opts) ->
+    case {vmq_ssl_psk:psk_support_enabled(Opts), proplists:get_value(certfile, Opts)} of
+        {true, undefined} -> [];
+        {true, _} -> opts(certfiles, Opts);
+        {false, _} -> opts(certfiles, Opts)
+    end.
 
--spec ciphersuite_transform([string()]) -> [string()].
-ciphersuite_transform([]) ->
-    ciphers();
-ciphersuite_transform(CiphersString) when is_list(CiphersString) ->
+opts(Opts) ->
+    opts(cert, Opts) ++
+        vmq_ssl_psk:opts(Opts) ++
+        [
+            {ciphers, ciphersuite_transform(proplists:get_value(ciphers, Opts, []), Opts)},
+            {eccs, proplists:get_value(eccs, Opts, ssl:eccs())},
+            {fail_if_no_peer_cert,
+                proplists:get_value(
+                    require_certificate,
+                    Opts,
+                    false
+                )},
+            {verify,
+                case
+                    proplists:get_value(require_certificate, Opts, false) or
+                        proplists:get_value(use_identity_as_username, Opts, false)
+                of
+                    true -> verify_peer;
+                    _ -> verify_none
+                end},
+            {verify_fun, {fun verify_ssl_peer/3, proplists:get_value(crlfile, Opts, no_crl)}},
+            {depth, proplists:get_value(depth, Opts, 1)},
+            {versions, [proplists:get_value(tls_version, Opts, 'tlsv1.2')]}
+            | []
+            %% TODO: support for flexible partial chain functions
+            % case support_partial_chain() of
+            %     true ->
+            %         [{partial_chain, fun([DerCert|_]) ->
+            %                                  {trusted_ca, DerCert}
+            %                          end}];
+            %     false ->
+            %         []
+            % end
+        ].
+
+ciphersuite_transform([], Opts) ->
+    ciphers() ++ vmq_ssl_psk:ciphers(Opts);
+ciphersuite_transform(CiphersString, _) when is_list(CiphersString) ->
     CiphersString.
 
 -spec verify_ssl_peer(

--- a/apps/vmq_server/src/vmq_ssl_psk.erl
+++ b/apps/vmq_server/src/vmq_ssl_psk.erl
@@ -1,0 +1,129 @@
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_ssl_psk).
+-export([
+    init/1,
+    opts/1,
+    psk_lookup/3,
+    psk_support_enabled/1,
+    ciphers/1
+]).
+
+-define(TABLE, ?MODULE).
+
+%
+% API
+%
+
+psk_support_enabled(Opts) ->
+    proplists:get_value(psk_support, Opts, false).
+
+opts(Opts) ->
+    case psk_support_enabled(Opts) of
+        false ->
+            [];
+        _ ->
+            [
+                {psk_identity, proplists:get_value(psk_identity_hint, Opts)},
+                {user_lookup_fun, {fun psk_lookup/3, #{}}}
+            ]
+    end.
+
+psk_lookup(psk, PskIdentity, _) ->
+    case ets:lookup(?TABLE, PskIdentity) of
+        [{_, PSK, _}] -> {ok, PSK};
+        _ -> {error, no_psk_found_for_identity}
+    end.
+
+ciphers(Opts) ->
+    case psk_support_enabled(Opts) of
+        true ->
+            [
+                "PSK-AES256-GCM-SHA384",
+                "PSK-AES256-CBC-SHA",
+                "PSK-AES128-GCM-SHA256",
+                "PSK-AES128-CBC-SHA"
+            ];
+        _ ->
+            []
+    end.
+
+%%
+%% INTERNAL FILE HANDLING
+%%
+%% The Pre-Shared-Keys are read from a file
+%%
+
+init(Opts) ->
+    case psk_support_enabled(Opts) of
+        true ->
+            case lists:member(?TABLE, ets:all()) of
+                true ->
+                    ok;
+                false ->
+                    ets:new(?TABLE, [public, named_table, {read_concurrency, true}]),
+                    load_from_file(
+                        proplists:get_value(pskfile, Opts),
+                        proplists:get_value(pskfile_separator, Opts, ":")
+                    )
+            end,
+            ok;
+        _ ->
+            ok
+    end.
+
+load_from_file(File, Separator) ->
+    case file:open(File, [read, binary]) of
+        {ok, Fd} ->
+            age_entries(),
+            F = fun
+                (FF, read) -> {FF, rl(Fd)};
+                (_, close) -> file:close(Fd)
+            end,
+            parse_psk_line(F(F, read), Separator),
+            del_aged_entries();
+        {error, _Reason} ->
+            lager:error("Failed to open PSK file: ~p, reason: ~p", [File, _Reason]),
+            {error, _Reason}
+    end.
+
+parse_psk_line({F, eof}, _) ->
+    F(F, close),
+    ok;
+parse_psk_line({F, <<"\n">>}, Separator) ->
+    parse_psk_line(F(F, read), Separator);
+parse_psk_line({F, Line}, Separator) ->
+    [Ident, PSK] = binary:split(Line, list_to_binary(Separator)),
+    Item = {Ident, PSK, 1},
+    ets:insert(?TABLE, Item),
+    parse_psk_line(F(F, read), Separator).
+
+age_entries() ->
+    iterate(fun(K) -> ets:update_element(?TABLE, K, {3, 2}) end).
+
+del_aged_entries() ->
+    ets:match_delete(?TABLE, {'_', '_', 2}),
+    ok.
+
+iterate(Fun) ->
+    iterate(Fun, ets:first(?TABLE)).
+iterate(_, '$end_of_table') ->
+    ok;
+iterate(Fun, K) ->
+    Fun(K),
+    iterate(Fun, ets:next(?TABLE, K)).
+
+rl({ok, Data}) -> string:trim(Data, trailing, "\n");
+rl({error, Reason}) -> exit(Reason);
+rl(eof) -> eof;
+rl(Fd) -> rl(file:read_line(Fd)).

--- a/apps/vmq_server/test/ssl/test-psk.psk
+++ b/apps/vmq_server/test/ssl/test-psk.psk
@@ -1,0 +1,1 @@
+psk_identity_1:test123

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 
-
+- Add support for TLS-PSK (Pre-Shared Key) for MQTTS (TLS) listeners
 - Fix regression in handling of the Proxy protocol for WebSockets.
 ## VerneMQ 1.12.6.2
 


### PR DESCRIPTION
## Proposed Changes

Add support for TLS-PSK.

Usage:

Configure a TLS listener as follows:

```
listener.ssl.psk_support = on
listener.ssl.pskfile = /srv/vernemq/etc/vernemq.psk
listener.ssl.ciphers  = PSK-AES256-GCM-SHA384:PSK-AES256-CBC-SHA:PSK-AES128-GCM-SHA256

```

add a psk file that matches a psk identity to a psk:
`
test:abcdefg
`

You can now test, e.g. with mosquitto
`
mosquitto_pub --topic t/T1 -h myhost  -m "hello psk3" -u myuser -P mypw -i myident --port 8883 --psk-identity "test" --psk "61626364656667" --ciphers "PSK-AES256-GCM-SHA384" -d
`
Notes:
- Mosquitto expects the string as hex 6162... is the same as abcdefg (as shown in the verne config)
- You can use cert and psk on the same listener (but do not have to)
- The .psk file is loaded just once. Currently, a new PSK needs a restart.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [X ] New feature (non-breaking change which adds functionality #1675 )
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CODE_OF_CONDUCT.md` document
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

The feature for sure needs some cleanup, but I would like to be interested if Verne would accept PSK support, once it meets quality standards.
