### PR TITLE
Introduces API Key for all exposed HTTP endpoints

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -233,7 +233,7 @@
 %% transmitted simultaneously. This includes messages currently going through handshakes
 %% and messages that are being retried. Defaults to 20. Set to 0 for no maximum. If set
 %% to 1, this will guarantee in-order delivery of messages.
-%% Note: for MQTT v5, use receive_max_client/receive_max_broker to implement 
+%% Note: for MQTT v5, use receive_max_client/receive_max_broker to implement
 %% similar behaviour.
 {mapping, "max_inflight_messages", "vmq_server.max_inflight_messages", [
                                                                         {default, 20},
@@ -348,6 +348,7 @@
                                                       {datatype, string},
                                                       hidden
                                                      ]}.
+
 {translation, "vmq_server.http_modules",
  fun(Conf) ->
          S = cuttlefish:conf_get("http_modules", Conf),
@@ -355,6 +356,62 @@
          {ok, Term} = erl_parse:parse_term(T),
          Term
  end}.
+
+%% @doc specifies the minimal length of an API key (default: 0)
+{mapping, "min_apikey_length", "vmq_server.min_apikey_length", [{datatype, integer}, {default, 0},
+                                                                               hidden
+                                                                                ]}.
+%% @doc specifies the max duration of an API key before it expires (default: undefined)
+{mapping, "max_apikey_expiry_days", "vmq_server.max_apikey_expiry_days", [{datatype, integer}, {default, undefined},
+                                                                               hidden
+                                                                                ]}.
+
+%% @doc http_module.$module.auth.mode lets you select the authentication method for accessing the http_module.
+%% You can set this option global, or an a listener level.
+%%
+%% - listener.http.$name.http_module.$module.auth.mode
+%% - listener.https.$name.http_module.$module.auth.mode
+%%
+%% The default for vmq_http_mgmt_api is "apikey", for all others it is noauth.
+{mapping, "http_module.$name.auth.mode", "vmq_server.http_modules_auth", [{datatype, string}, {default, "noauth"},
+                                                                               hidden
+                                                                                ]}.
+{mapping, "http_module.vmq_http_mgmt_api.auth.mode", "vmq_server.http_modules_auth", [{datatype, string}, {default, "apikey"},
+                                                                               hidden
+                                                                                ]}.
+{mapping, "listener.http.$name.http_module.$module.auth.mode", "vmq_server.http_listener_modules_auth", [{datatype, string},
+                                                                               hidden
+                                                                                ]}.
+{mapping, "listener.https.$name.http_module.$module.auth.mode", "vmq_server.http_listener_modules_auth", [{datatype, string},
+                                                                               hidden
+                                                                                ]}.
+{translation,
+  "vmq_server.http_modules_auth",
+  fun(Conf) ->
+     HTTPModules = cuttlefish_variable:filter_by_prefix("http_module",Conf),
+ 	 HTTPModulesAsAtom = lists:map(fun(Element) -> list_to_atom(lists:nth(2,element(1, Element))) end, HTTPModules),
+     KnownHttpModules = [vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http],%
+	 UniqueModules = lists:usort(HTTPModulesAsAtom ++ KnownHttpModules),
+     Map = lists:map(fun(Atom) -> String = "http_module."++atom_to_list(Atom)++".auth.mode", #{Atom => cuttlefish:conf_get(String, Conf, "noauth")} end, UniqueModules),
+     Ret = maps:from_list(lists:foldl(fun(Elem, Acc) -> maps:to_list(Elem) ++ Acc end, [], Map)),
+	 Ret
+	 end
+}.
+
+{translation,
+  "vmq_server.http_listener_modules_auth",
+  fun(Conf) ->
+     Candidates = cuttlefish_variable:filter_by_prefix("listener.http.",Conf) ++ cuttlefish_variable:filter_by_prefix("listener.https.",Conf),
+	 HTTPModuleListers = lists:filter(fun(Elem) -> case element(1,Elem) of X when length(X)>5 -> lists:nth(4,X) == "http_module"; _ -> false end end, Candidates),
+     MapListenerModule = lists:map(fun(Elem) -> Elem1 = element(1, Elem), {list_to_atom(lists:nth(2,Elem1)), list_to_atom(lists:nth(3,Elem1)), list_to_atom(lists:nth(5,Elem1))} end, HTTPModuleListers),
+     MapWithValue = lists:map(fun(AtomTuple) -> String = "listener."++atom_to_list(element(1,AtomTuple))++"."++atom_to_list(element(2,AtomTuple))++".http_module."++atom_to_list(element(3,AtomTuple))++".auth.mode", #{AtomTuple => cuttlefish:conf_get(String, Conf)} end, MapListenerModule),
+     Ret = maps:from_list(lists:foldl(fun(Elem, Acc) -> maps:to_list(Elem) ++ Acc end, [], MapWithValue)),
+     Ret
+	 end
+}.
+
+
+
 
 %% @doc listener.tcp.buffer_sizes is an list of three integers
 %% (sndbuf,recbuf,buffer) specifying respectively the kernel TCP send
@@ -971,7 +1028,6 @@
                                                           {datatype, ip},
                                                           {include_default, "default"}
                                                          ]}.
-
 {mapping, "listener.http.$name.config_mod", "vmq_server.listeners", [
                                                                      {default, vmq_http_config},
                                                                      {datatype, atom},
@@ -984,19 +1040,19 @@
                                                                      hidden
                                                                     ]}.
 
-%% @doc specifies the modules to be enabled by the http(s) listener 
+%% @doc specifies the modules to be enabled by the http(s) listener
 {mapping, "listener.http.$name.http_modules", "vmq_server.listeners", [
                                                       {default, "[]"},
                                                       {datatype, string},
                                                       hidden
                                                      ]}.
 
+
 {mapping, "listener.https.$name", "vmq_server.listeners", [
                                                           {default, { "{{http_default_ip}}", {{http_default_port}} }},
                                                           {datatype, ip},
                                                           hidden
                                                          ]}.
-
 {mapping, "listener.https.$name.config_mod", "vmq_server.listeners", [
                                                                      {default, vmq_http_config},
                                                                      {datatype, atom},
@@ -1008,7 +1064,7 @@
                                                                      {datatype, atom},
                                                                      hidden
                                                                     ]}.
-%% @doc specifies the modules to be enabled by the http(s) listener 
+%% @doc specifies the modules to be enabled by the http(s) listener
 {mapping, "listener.https.$name.http_modules", "vmq_server.listeners", [
                                                       {default, "[]"},
                                                       {datatype, string},
@@ -1595,7 +1651,7 @@
 %% pre-shared keys (PSK).
 %%
 %% The option can be specified either for all SSL listeners or for
-%% a specific listener.  
+%% a specific listener.
 %%
 %%     - listener.ssl.psk_support
 %%
@@ -1632,12 +1688,12 @@
                                                                     ]}.
 
 
-%% @doc If PSK support is enabled, the pre-shared keys must be provided as key value pairs 
+%% @doc If PSK support is enabled, the pre-shared keys must be provided as key value pairs
 %% seperated by a seperator (by default ":"), e.g.
 %%
 %% mypskidentity:mypskkey
 %%
-%% The key is a string (not hex-encoded). The psk file is used for all listerners.   
+%% The key is a string (not hex-encoded). The psk file is used for all listerners.
 {mapping, "listener.ssl.pskfile", "vmq_server.listeners", [
                                                            {default, "{{platform_etc_dir}}/vmq.psk"},
                                                            {datatype, file}

--- a/apps/vmq_server/src/vmq_auth_apikey.erl
+++ b/apps/vmq_server/src/vmq_auth_apikey.erl
@@ -1,0 +1,207 @@
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_auth_apikey).
+
+-export([
+    create_api_key/2,
+    add_api_key/3,
+    delete_api_key/2,
+    list_api_keys/0,
+    list_api_keys/1,
+    is_authorized/3
+]).
+
+-define(ENV_API_KEYS, http_endpoint_api_keys).
+
+%%
+%% API KEY MANAGEMENT
+%%
+
+create_api_key(Scope, Expires) ->
+    Chars = list_to_tuple("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
+    Size = size(Chars),
+    F = fun() -> element(rand:uniform(Size), Chars) end,
+    MinKeyLength = vmq_config:get_env(vmq_server, min_apikey_length, 0),
+    ApiKey = list_to_binary([F() || _ <- lists:seq(1, max(32, MinKeyLength))]),
+    case add_api_key(ApiKey, Scope, Expires) of
+        ok -> ApiKey;
+        Else -> Else
+    end.
+
+add_api_key(ApiKey, Scope, Expires) when is_binary(ApiKey) ->
+    case {check_key_length(ApiKey), check_key_exists(ApiKey, Scope)} of
+        {true, false} ->
+            case {check_scope(Scope), check_date(Expires)} of
+                {true, true} ->
+                    Keys = vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []),
+                    Keys1 = lists:delete({ApiKey, Scope}, Keys),
+                    ExpiresUTC =
+                        case Expires of
+                            undefined -> undefined;
+                            _ -> parse_date_time_string(Expires)
+                        end,
+                    vmq_config:set_global_env(
+                        vmq_server, ?ENV_API_KEYS, [{ApiKey, Scope, ExpiresUTC} | Keys1], true
+                    ),
+                    ok;
+                {_, false} ->
+                    {error, invalid_expiry_date};
+                {false, true} ->
+                    {error, invalid_scope}
+            end;
+        {_, true} ->
+            {error, key_already_exists};
+        {_, _} ->
+            {error, invalid_key_length}
+    end.
+
+delete_api_key(ApiKey, Scope) ->
+    case check_scope(Scope) of
+        true ->
+            case vmq_config:get_env(?ENV_API_KEYS, []) of
+                undefined ->
+                    ok;
+                Keys when is_list(Keys) ->
+                    EntryForDeletion = lists:keyfind(
+                        ApiKey, 1, vmq_auth_apikey:list_api_keys(Scope)
+                    ),
+                    case EntryForDeletion of
+                        false ->
+                            {error, key_not_found};
+                        _ ->
+                            vmq_config:set_global_env(
+                                vmq_server, ?ENV_API_KEYS, Keys -- [EntryForDeletion], true
+                            ),
+                            ok
+                    end
+            end;
+        _ ->
+            {error, invalid_scope}
+    end.
+
+list_api_keys(Scope) ->
+    case check_scope(Scope) of
+        true ->
+            IsInScope = fun({_, KeyScope, _}) -> KeyScope == Scope end,
+            lists:filter(IsInScope, vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []));
+        _ ->
+            {error, invalid_scope}
+    end.
+
+list_api_keys() ->
+    vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []).
+
+check_api_key(ApiKey, Scope, Req, State) ->
+    Res = lists:keyfind(ApiKey, 1, vmq_auth_apikey:list_api_keys(Scope)),
+    case Res of
+        {Key, _, Expires} ->
+            case {Key == ApiKey, not_expired(Expires)} of
+                {true, true} -> {true, Req, State};
+                _ -> {{false, <<"Authorization realm=\"VerneMQ\"">>}, Req, State}
+            end;
+        false ->
+            {{false, <<"Authorization realm=\"VerneMQ\"">>}, Req, State}
+    end.
+
+is_authorized(basic, Req, State, Scope) ->
+    case cowboy_req:parse_header(<<"authorization">>, Req) of
+        {basic, ApiKey, _} ->
+            check_api_key(ApiKey, Scope, Req, State);
+        _ ->
+            {{false, <<"Authorization realm=\"VerneMQ\"">>}, Req, State}
+    end;
+is_authorized(xapikey, Req, State, Scope) ->
+    case cowboy_req:header(<<"x-api-key">>, Req) of
+        ApiKey when is_binary(ApiKey) ->
+            check_api_key(ApiKey, Scope, Req, State);
+        _ ->
+            {{false, <<"Authorization realm=\"VerneMQ\"">>}, Req, State}
+    end.
+is_authorized(Req, State, Scope) ->
+    case cowboy_req:parse_header(<<"authorization">>, Req, undefined) of
+        undefined -> is_authorized(xapikey, Req, State, Scope);
+        _ -> is_authorized(basic, Req, State, Scope)
+    end.
+
+%
+% internal
+%
+
+parse_date_time_string(DateTimeString) ->
+    [DateStr, TimeStr] = string:split(DateTimeString, "T"),
+    [Year, Month, Day] = [list_to_integer(X) || X <- string:tokens(DateStr, "-")],
+    [Hour, Minute, Second] = [list_to_integer(X) || X <- string:tokens(TimeStr, ":")],
+    case is_valid_date_time(Year, Month, Day, Hour, Minute, Second) of
+        true ->
+            DateTimeUTC = calendar:datetime_to_gregorian_seconds(
+                hd(
+                    calendar:local_time_to_universal_time_dst({
+                        {Year, Month, Day}, {Hour, Minute, Second}
+                    })
+                )
+            ),
+            DateTimeUTC;
+        _ ->
+            invalid_datetime_string
+    end.
+
+is_valid_date_time(Year, Month, Day, Hour, Minute, Second) ->
+    case calendar:datetime_to_gregorian_seconds({{Year, Month, Day}, {Hour, Minute, Second}}) of
+        0 -> false;
+        DateTimeUTC when is_integer(DateTimeUTC) -> true
+    end.
+
+scopes() ->
+    ["status", "mgmt", "metrics", "health"].
+
+time_diff_now_secs(ExpiresUTC) ->
+    CurrentTime = calendar:now_to_universal_time(erlang:timestamp()),
+    calendar:datetime_to_gregorian_seconds(CurrentTime) - ExpiresUTC.
+
+not_expired(undefined) ->
+    true;
+not_expired(ExpiresUTC) ->
+    TimeDiff = time_diff_now_secs(ExpiresUTC),
+    TimeDiff < 0.
+
+expired_within_max_range(_, undefined) ->
+    true;
+expired_within_max_range(ExpiresUTC, MaxRangeInDays) ->
+    CurrentTime = calendar:now_to_universal_time(erlang:timestamp()),
+    ExpiresUTC < (calendar:datetime_to_gregorian_seconds(CurrentTime) + (MaxRangeInDays * 86400)).
+
+check_date(undefined) ->
+    expired_within_max_range(
+        undefined, vmq_config:get_env(vmq_server, max_apikey_expiry_days, undefined)
+    );
+check_date(Expires) ->
+    ExpiresUTC = parse_date_time_string(Expires),
+    not_expired(ExpiresUTC) and
+        expired_within_max_range(
+            ExpiresUTC, vmq_config:get_env(vmq_server, max_apikey_expiry_days, undefined)
+        ).
+
+check_scope(Scope) ->
+    case lists:member(Scope, scopes()) of
+        true -> true;
+        _ -> false
+    end.
+
+check_key_length(ApiKey) ->
+    case byte_size(ApiKey) >= vmq_config:get_env(vmq_server, min_apikey_length, 0) of
+        true -> true;
+        _ -> {error, invalid_key_length}
+    end.
+
+check_key_exists(ApiKey, Scope) ->
+    is_tuple(lists:keyfind(ApiKey, 1, vmq_auth_apikey:list_api_keys(Scope))).

--- a/apps/vmq_server/src/vmq_health_http.erl
+++ b/apps/vmq_server/src/vmq_health_http.erl
@@ -16,7 +16,7 @@
 
 -behaviour(vmq_http_config).
 
--export([routes/0]).
+-export([routes/0, is_authorized/2]).
 -export([init/2]).
 
 routes() ->
@@ -36,6 +36,14 @@ init(Req, Opts) ->
     Headers = #{<<"content-type">> => <<"application/json">>},
     cowboy_req:reply(Code, Headers, vmq_json:encode(Payload), Req),
     {ok, Req, Opts}.
+
+is_authorized(Req, State) ->
+    AuthMode = vmq_http_config:auth_mode(Req, vmq_health_http),
+    case AuthMode of
+        "apikey" -> vmq_auth_apikey:is_authorized(Req, State, "health");
+        "noauth" -> {true, Req, State};
+        _ -> {error, invalid_authentication_scheme}
+    end.
 
 -spec check_health_concerns() -> [] | [Concern :: string()].
 check_health_concerns() ->

--- a/apps/vmq_server/src/vmq_http_mgmt_api.erl
+++ b/apps/vmq_server/src/vmq_http_mgmt_api.erl
@@ -27,14 +27,8 @@
 ]).
 
 -export([
-    routes/0,
-    create_api_key/0,
-    add_api_key/1,
-    delete_api_key/1,
-    list_api_keys/0
+    routes/0
 ]).
-
--define(ENV_API_KEYS, http_mgmt_api_keys).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Cowboy REST Handler
@@ -59,16 +53,11 @@ options(Req0, State) ->
     {ok, cowboy_req:set_resp_headers(CorsHeaders, Req0), State}.
 
 is_authorized(Req, State) ->
-    case cowboy_req:parse_header(<<"authorization">>, Req) of
-        {basic, ApiKey, _} ->
-            case lists:member(ApiKey, list_api_keys()) of
-                true ->
-                    {true, Req, State};
-                false ->
-                    {{false, <<"Basic realm=\"VerneMQ\"">>}, Req, State}
-            end;
-        _ ->
-            {{false, <<"Basic realm=\"VerneMQ\"">>}, Req, State}
+    AuthMode = vmq_http_config:auth_mode(Req, vmq_http_mgmt_api),
+    case AuthMode of
+        "apikey" -> vmq_auth_apikey:is_authorized(Req, State, "mgmt");
+        "noauth" -> {true, Req, State};
+        _ -> {error, invalid_authentication_scheme}
     end.
 
 malformed_request(Req, State) ->
@@ -137,28 +126,3 @@ parse_command(Command) -> ["vmq-admin" | [binary_to_list(C) || C <- Command]].
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 routes() ->
     [{"/api/v1/[...]", ?MODULE, []}].
-
-create_api_key() ->
-    Chars = list_to_tuple("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
-    Size = size(Chars),
-    F = fun() -> element(rand:uniform(Size), Chars) end,
-    ApiKey = list_to_binary([F() || _ <- lists:seq(1, 32)]),
-    add_api_key(ApiKey),
-    ApiKey.
-
-add_api_key(ApiKey) when is_binary(ApiKey) ->
-    Keys = vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []),
-    Keys1 = lists:delete(ApiKey, Keys),
-    vmq_config:set_global_env(vmq_server, ?ENV_API_KEYS, [ApiKey | Keys1], true).
-
-delete_api_key(ApiKey) ->
-    case vmq_config:get_env(?ENV_API_KEYS, []) of
-        undefined ->
-            ok;
-        Keys when is_list(Keys) ->
-            vmq_config:set_global_env(vmq_server, ?ENV_API_KEYS, Keys -- [ApiKey], true)
-    end,
-    ok.
-
-list_api_keys() ->
-    vmq_config:get_env(vmq_server, ?ENV_API_KEYS, []).

--- a/apps/vmq_server/src/vmq_metrics_http.erl
+++ b/apps/vmq_server/src/vmq_metrics_http.erl
@@ -17,7 +17,7 @@
 
 -include("vmq_metrics.hrl").
 
--export([routes/0]).
+-export([routes/0, is_authorized/2]).
 -export([
     init/2,
     content_types_provided/2,
@@ -26,6 +26,14 @@
 
 routes() ->
     [{"/metrics", ?MODULE, []}].
+
+is_authorized(Req, State) ->
+    AuthMode = vmq_http_config:auth_mode(Req, vmq_metrics_http),
+    case AuthMode of
+        "apikey" -> vmq_auth_apikey:is_authorized(Req, State, "metrics");
+        "noauth" -> {true, Req, State};
+        _ -> {error, invalid_authentication_scheme}
+    end.
 
 init(Req, Opts) ->
     {cowboy_rest, Req, Opts}.

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -132,6 +132,15 @@ delete_listener(ListenerRef) ->
     end.
 
 start_listener(Type, Addr, Port, Opts) when is_list(Opts) ->
+    try
+        case Opts of
+            [] -> [];
+            [_, B] -> [B]
+        end
+    catch
+        _:_:Stacktrace ->
+            erlang:display(Stacktrace)
+    end,
     TCPOpts = vmq_config:get_env(tcp_listen_options),
     SocketOpts = TCPOpts ++ socket_opts_for_type(Type, Opts),
     start_listener(Type, Addr, Port, {SocketOpts, Opts});
@@ -339,7 +348,7 @@ protocol_opts(cowboy_clear, _, Opts) ->
         end,
     CowboyRoutes = [{'_', Routes}],
     Dispatch = cowboy_router:compile(CowboyRoutes),
-    #{env => #{dispatch => Dispatch}};
+    #{env => #{dispatch => Dispatch}, opts => Opts};
 protocol_opts(vmq_cluster_com, _, Opts) ->
     Opts.
 

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -215,6 +215,11 @@ translate_listeners(Conf) ->
     {HTTPIPs, HTTPConfigMod} = lists:unzip(extract("listener.http", "config_mod", AtomVal, Conf)),
     {HTTPIPs, HTTPConfigFun} = lists:unzip(extract("listener.http", "config_fun", AtomVal, Conf)),
     {HTTPIPs, HTTPModules} = lists:unzip(extract("listener.http", "http_modules", StrVal, Conf)),
+    {HTTPIPs, HTTPListenerName} = lists:unzip(extract_var("listener.http", "listener_name", Conf)),
+
+    {HTTP_SSLIPs, HTTP_SSLListenerName} = lists:unzip(
+        extract_var("listener.https", "listener_name", Conf)
+    ),
     {HTTP_SSLIPs, HTTP_SSLConfigMod} = lists:unzip(
         extract("listener.https", "config_mod", AtomVal, Conf)
     ),
@@ -355,6 +360,7 @@ translate_listeners(Conf) ->
             HTTPConfigMod,
             HTTPConfigFun,
             HTTPModules,
+            HTTPListenerName,
             HTTPProxyProto
         ])
     ),
@@ -441,7 +447,8 @@ translate_listeners(Conf) ->
             HTTP_SSLVersions,
             HTTP_SSLConfigMod,
             HTTP_SSLConfigFun,
-            HTTP_SSLHTTPModules
+            HTTP_SSLHTTPModules,
+            HTTP_SSLListenerName
         ])
     ),
     DropUndef = fun(L) ->
@@ -456,6 +463,24 @@ translate_listeners(Conf) ->
         {vmqs, DropUndef(VMQS)},
         {http, DropUndef(HTTP)},
         {https, DropUndef(HTTPS)}
+    ].
+
+extract_var(Prefix, Suffix, Conf) ->
+    NameSubPrefix = lists:flatten([Prefix, ".$name"]),
+    [
+        begin
+            Addr = parse_addr(StrAddr),
+            _ = lists:flatten([Prefix, ".", Name, ".", Suffix]),
+            AddrPort = {Addr, Port},
+            {AddrPort, {list_to_atom(Suffix), Name}}
+        end
+     || {[_, _, Name], {StrAddr, Port}} <- lists:filter(
+            fun({K, _V}) ->
+                cuttlefish_variable:is_fuzzy_match(K, string:tokens(NameSubPrefix, "."))
+            end,
+            Conf
+        ),
+        not lists:member(Name, [])
     ].
 
 extract(Prefix, Suffix, Val, Conf) ->

--- a/apps/vmq_server/src/vmq_status_http.erl
+++ b/apps/vmq_server/src/vmq_status_http.erl
@@ -16,7 +16,7 @@
 -behaviour(vmq_http_config).
 -include("vmq_metrics.hrl").
 
--export([routes/0]).
+-export([routes/0, is_authorized/2]).
 -export([node_status/0]).
 -export([
     init/2,
@@ -47,6 +47,14 @@ content_types_provided(Req, State) ->
         Req,
         State
     }.
+
+is_authorized(Req, State) ->
+    AuthMode = vmq_http_config:auth_mode(Req, vmq_status_http),
+    case AuthMode of
+        "apikey" -> vmq_auth_apikey:is_authorized(Req, State, "status");
+        "noauth" -> {true, Req, State};
+        _ -> {error, invalid_authentication_scheme}
+    end.
 
 terminate(_Reason, _Req, _State) ->
     ok.

--- a/apps/vmq_server/test/vmq_metrics_SUITE.erl
+++ b/apps/vmq_server/test/vmq_metrics_SUITE.erl
@@ -32,6 +32,7 @@ init_per_testcase(_Case, Config) ->
     vmq_server_cmd:set_config(systree_interval, 100),
     vmq_server_cmd:set_config(retry_interval, 10),
     application:set_env(vmq_server, vmq_metrics_mfa, {?MODULE, plugin_metrics, []}),
+    application:set_env(vmq_server, http_modules_auth, #{vmq_metrics_http => "noauth"}),
     vmq_server_cmd:listener_start(1888, []),
     vmq_metrics:reset_counters(),
     Config.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Allow protection of all HTTP(s) endpoints with API keys (e.g. metrics)
 - Update bootstrap 4.6.2 in status page and add favicon
 - vmq_passwd -c no longer overwrites existing files by default.  
 - Allow per-purpose HTTP endpoints (status, metrics, api) by assigning http_modules


### PR DESCRIPTION
## Proposed Changes
- Extend the scope of API keys to all http endpoints (metrics, health...)
- Generalize the auth functionality a bit, which will allow jwt authentication later on
- Introduce a expiry date that will support key rotation
- Auth for each endpoint can be turned on/off via verne.conf

This pull request is for an initial review and not yet fully finalized.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/master/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
