### PR TITLE
Allow more fine-grained control of which modules are loaded per listener

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -339,7 +339,8 @@
                                                             hidden
                                                            ]}.
 
-%% @doc specifies the modules that should be evaluated when setting up the cowboy routes
+
+%% @doc specifies the modules to be enabled by the http(s) listeners. Overriding this setting is possible for specific listeners.
 {mapping, "http_modules", "vmq_server.http_modules", [
                                                       {default, "[vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http]"},
                                                       {datatype, string},
@@ -981,6 +982,13 @@
                                                                      hidden
                                                                     ]}.
 
+%% @doc specifies the modules to be enabled by the http(s) listener 
+{mapping, "listener.http.$name.http_modules", "vmq_server.listeners", [
+                                                      {default, "[]"},
+                                                      {datatype, string},
+                                                      hidden
+                                                     ]}.
+
 {mapping, "listener.https.$name", "vmq_server.listeners", [
                                                           {default, { "{{http_default_ip}}", {{http_default_port}} }},
                                                           {datatype, ip},
@@ -998,7 +1006,12 @@
                                                                      {datatype, atom},
                                                                      hidden
                                                                     ]}.
-
+%% @doc specifies the modules to be enabled by the http(s) listener 
+{mapping, "listener.https.$name.http_modules", "vmq_server.listeners", [
+                                                      {default, "[]"},
+                                                      {datatype, string},
+                                                      hidden
+                                                     ]}.
 
 %% @doc Set the mountpoint on the protocol level or on the listener level
 %%

--- a/apps/vmq_server/src/vmq_http_config.erl
+++ b/apps/vmq_server/src/vmq_http_config.erl
@@ -13,12 +13,21 @@
 %% limitations under the License.
 
 -module(vmq_http_config).
--export([config/0]).
+-export([config/1]).
 
 -callback routes() -> [{string(), atom(), any()}].
+config(Opts) ->
+    HttpLocal = element(2, lists:keyfind(http_modules, 1, Opts)),
+    HttpLocalList = [
+        list_to_atom(string:strip(Token))
+     || Token <- string:tokens(string:trim(HttpLocal, both, "[]"), ",")
+    ],
 
-config() ->
-    HttpModules = vmq_config:get_env(http_modules),
+    HttpModules =
+        case {HttpLocalList, vmq_config:get_env(http_modules)} of
+            {[], _} -> vmq_config:get_env(http_modules);
+            {LocalModules, _} -> LocalModules
+        end,
     config(HttpModules, []).
 
 config([HttpModule | Rest], Routes) when is_atom(HttpModule) ->

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -168,6 +168,10 @@ vmq_listener_start_cmd() ->
         {config_fun, [
             {longname, "config_fun"},
             {typecast, fun(F) -> list_to_existing_atom(F) end}
+        ]},
+        {http_modules, [
+            {longname, "http_modules"},
+            {typecast, fun(C) -> C end}
         ]}
     ],
     Callback =

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -214,11 +214,15 @@ translate_listeners(Conf) ->
 
     {HTTPIPs, HTTPConfigMod} = lists:unzip(extract("listener.http", "config_mod", AtomVal, Conf)),
     {HTTPIPs, HTTPConfigFun} = lists:unzip(extract("listener.http", "config_fun", AtomVal, Conf)),
+    {HTTPIPs, HTTPModules} = lists:unzip(extract("listener.http", "http_modules", StrVal, Conf)),
     {HTTP_SSLIPs, HTTP_SSLConfigMod} = lists:unzip(
         extract("listener.https", "config_mod", AtomVal, Conf)
     ),
     {HTTP_SSLIPs, HTTP_SSLConfigFun} = lists:unzip(
         extract("listener.https", "config_fun", AtomVal, Conf)
+    ),
+    {HTTP_SSLIPs, HTTP_SSLHTTPModules} = lists:unzip(
+        extract("listener.https", "http_modules", StrVal, Conf)
     ),
 
     % SSL
@@ -350,6 +354,7 @@ translate_listeners(Conf) ->
             HTTPNrOfAcceptors,
             HTTPConfigMod,
             HTTPConfigFun,
+            HTTPModules,
             HTTPProxyProto
         ])
     ),
@@ -435,7 +440,8 @@ translate_listeners(Conf) ->
             HTTP_SSLRequireCerts,
             HTTP_SSLVersions,
             HTTP_SSLConfigMod,
-            HTTP_SSLConfigFun
+            HTTP_SSLConfigFun,
+            HTTP_SSLHTTPModules
         ])
     ),
     DropUndef = fun(L) ->
@@ -480,6 +486,7 @@ extract(Prefix, Suffix, Val, Conf) ->
             %% http listener specific
             "config_mod",
             "config_fun",
+            "http_modules",
             %% mqtt listener specific
             "allowed_protocol_versions",
             %% other

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-
+- Allow per-purpose HTTP endpoints (status, metrics, api) by assigning http_modules
 - Add support for TLS-PSK (Pre-Shared Key) for MQTTS (TLS) listeners
 - Fix regression in handling of the Proxy protocol for WebSockets.
 - Refactor metrics count of active connections, using 3 new gauges:


### PR DESCRIPTION
## Proposed Changes

This change will allow to set http_modules as a per-listener setting. This allows to seperate, for example, the management API from the status and health pages and enables e.g. more fine-granular firewall settings. In case there are no per-listener settings, the default values are used.

For example, the default listener could be limited to the health and status modules by setting listeners.https.default.http_modules = vmq_status_http, vmq_health_http

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/master/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
