### PR TITLE
Add force option and change overwrite default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- vmq_passwd -c no longer overwrites existing files by default.  
 - Allow per-purpose HTTP endpoints (status, metrics, api) by assigning http_modules
 - Add support for TLS-PSK (Pre-Shared Key) for MQTTS (TLS) listeners
 - Fix regression in handling of the Proxy protocol for WebSockets.


### PR DESCRIPTION
Add force option and change default functionality of -c to not overwrite the passwd file

- Check parameters and return an error in case an unknown parameter is used
- Do not overwrite files by default. Overwrite not needs a new (f)orce flag.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/master/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
