### PR TITLE
Make test case independent of predefined ECCS.

### DIFF
--- a/apps/vmq_server/test/vmq_schema_SUITE.erl
+++ b/apps/vmq_server/test/vmq_schema_SUITE.erl
@@ -250,12 +250,14 @@ allowed_protocol_versions_inheritance_test(_Config) ->
     [3,4,5] = expect(Conf, [vmq_server, listeners, mqttwss,{{127,0,0,1}, 900}, allowed_protocol_versions]).
 
 allowed_eccs_test(_Config) ->
+    [_ | Allowed_ECCS] = lists:usort(ssl:eccs()),
+    ECC_List = string:join([atom_to_list(A) || A <- Allowed_ECCS], ", "),
     Conf = [
-            {["listener","ssl","default", "eccs"], "sect163r1,sect163r2,secp160k1,secp160r1"},
+            {["listener","ssl","default", "eccs"], ECC_List},
             {["listener","ssl","default"],"127.0.0.1:8884"}
             | global_substitutions()
            ],
-    ExpectedECCs = lists:usort([sect163r1,sect163r2,secp160k1,secp160r1]),
+    ExpectedECCs = Allowed_ECCS,
     ExpectedECCs = expect(Conf, [vmq_server, listeners, mqtts, {{127,0,0,1}, 8884}, eccs]).
 
 default_eccs_test(_Config) ->
@@ -268,9 +270,11 @@ default_eccs_test(_Config) ->
     KnownECCs = expect(Conf, [vmq_server, listeners, mqtts, {{127,0,0,1}, 8884}, eccs]).
 
 invalid_eccs_test(_Config) ->
+    Allowed_ECCS_and_wrong = lists:usort(ssl:eccs() ++ [wrong]),
+    ECC_List = string:join([atom_to_list(A) || A <- Allowed_ECCS_and_wrong], ", "),
     Conf = [
             %% tcp/ssl/mqtt
-            {["listener","ssl","default","eccs"], "[sect163r1,sect163r2,wrong,secp160r1]"},
+            {["listener","ssl","default","eccs"], ECC_List},
             {["listener","ssl","default"],"127.0.0.1:8884"}
             | global_substitutions()
            ],


### PR DESCRIPTION
## Proposed Changes

The apps/vmq_server/test/vmq_schema_SUITE.erl always fails for me, because ssl:eccs() does not return any of the expected and thus always fails. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/master/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
