### PR TITLE
Add support for Redis user

### DIFF
--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -364,6 +364,11 @@
   {default, ""},
   {commented, ""}]}.
 
+{mapping, "vmq_diversity.redis.user", "vmq_diversity.db_config.redis.user",
+ [{datatype, string},
+  {default, ""},
+  {commented, ""}]}.
+
 {mapping, "vmq_diversity.redis.database", "vmq_diversity.db_config.redis.database",
  [{datatype, integer},
   {default, 0},

--- a/apps/vmq_diversity/src/vmq_diversity_redis.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_redis.erl
@@ -258,7 +258,7 @@ ensure_pool(As, St) ->
                         [
                             {size, Size},
                             {password, Password},
-                            {user, User},
+                            {username, User},
                             {host, Host},
                             {port, Port},
                             {database, Database}

--- a/apps/vmq_diversity/src/vmq_diversity_redis.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_redis.erl
@@ -226,6 +226,13 @@ ensure_pool(As, St) ->
                             proplists:get_value(password, DefaultConf)
                         )
                     ),
+                    User = vmq_diversity_utils:str(
+                        maps:get(
+                            <<"user">>,
+                            Options,
+                            proplists:get_value(user, DefaultConf)
+                        )
+                    ),
                     Host = vmq_diversity_utils:str(
                         maps:get(
                             <<"host">>,
@@ -251,6 +258,7 @@ ensure_pool(As, St) ->
                         [
                             {size, Size},
                             {password, Password},
+                            {user, User},
                             {host, Host},
                             {port, Port},
                             {database, Database}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Make Redis username configurable in vmq_diversity.
 - Fix issue [#2078](https://github.com/vernemq/vernemq/issues/2008) where the default MQTT listener fails to create in `vernemq.conf`.
 - Fix configuration problems when using Unix Domain Sockets.
 - Add support for compilation in ARM architectures (Tested on M1 Mac and Raspberry PI). Now we can use the `make rel` target to build a VerneMQ release for RaspberryPI.


### PR DESCRIPTION
## Proposed Changes

_PR is related to issue https://github.com/vernemq/vernemq/issues/2110_

Adding support for Redis "user" allows the use of Redis with ACL to
leverage some security feature such as:

  - Different user than "default"
  - Different password
  - Level of permissions
  - Key patterns

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #2110)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

