### PR TITLE
Fix dev_n builds and listener overlays.

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -799,10 +799,9 @@
 %% - listener.ws.default = 127.0.0.1:800
 %% - listener.wss.default = 127.0.0.1:880
 {mapping, "listener.tcp.$name", "vmq_server.listeners", [
-                                                           {default, { "{{mqtt_default_ip}}", {{mqtt_default_port}} }},
-                                                           {datatype, [ip, domain_socket]},
-                                                           {include_default, "default"}
-                                                           ]}.
+                                                                {default, { "{{mqtt_default_ip}}", {{mqtt_default_port}} }},
+                                                                {datatype, [ip, domain_socket]}
+                                                                ]}.
 
 {mapping, "listener.ws.$name", "vmq_server.listeners", [
                                                                   {default, { "{{mqtt_default_ws_ip}}", {{mqtt_default_ws_port}} }},
@@ -817,9 +816,8 @@
                                                                  ]}.
 
 {mapping, "listener.ssl.$name", "vmq_server.listeners", [
-                                                            {default, { "{{mqtts_default_ip}}", {{mqtts_default_port}} }},
-                                                            {datatype, ip},
-                                                            hidden
+                                                            {commented, { "{{mqtts_default_ip}}", {{mqtts_default_port}} }},
+                                                            {datatype, ip}
                                                            ]}.
 
 %% @doc listener.tcp.proxy_protocol specifies if the listener accepts
@@ -964,7 +962,7 @@
 
 {mapping, "listener.ws.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -977,7 +975,7 @@
 
 {mapping, "listener.wss.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -990,7 +988,7 @@
 
 {mapping, "listener.ssl.allowed_protocol_versions", "vmq_server.listeners",
  [
-  {default, "3,4,131"},
+  {default, "3,4,5,131"},
   {datatype, string},
   hidden
  ]}.
@@ -1010,10 +1008,10 @@
 {mapping, "listener.vmq.$name", "vmq_server.listeners", [
                                                            {default, { "{{cluster_default_ip}}", {{cluster_default_port}} }},
                                                            {datatype, ip},
-                                                            {include_default, "clustering"}
+                                                           {include_default, "clustering"}
                                                           ]}.
 {mapping, "listener.vmqs.$name", "vmq_server.listeners", [
-                                                           {default, { "{{cluster_default_ip}}", {{cluster_default_port}} }},
+                                                           {default, { "{{cluster_ssl_default_ip}}", {{cluster_ssl_default_port}} }},
                                                            {datatype, ip},
                                                            hidden
                                                           ]}.
@@ -1049,7 +1047,7 @@
 
 
 {mapping, "listener.https.$name", "vmq_server.listeners", [
-                                                          {default, { "{{http_default_ip}}", {{http_default_port}} }},
+                                                          {default, { "{{https_default_ip}}", {{https_default_port}} }},
                                                           {datatype, ip},
                                                           hidden
                                                          ]}.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+
+- Enable v5 protocol for WS and SSL listeners as a default.
+- Fix dev_n builds (make dev0 dev1...).
 - Fix issue [#2078](https://github.com/vernemq/vernemq/issues/2008) where the default MQTT listener fails to create in `vernemq.conf`.
 - Fix configuration problems when using Unix Domain Sockets.
 - Add support for compilation in ARM architectures (Tested on M1 Mac and Raspberry PI). Now we can use the `make rel` target to build a VerneMQ release for RaspberryPI.

--- a/files/vmq.schema
+++ b/files/vmq.schema
@@ -21,7 +21,7 @@
 %% Acceptable values:
 %%   - text
 {mapping, "nodename" , "vm_args.-name", [
-                {default, "VerneMQ@127.0.0.1"}
+                 {default, "{{nodename}}" }
                 ]}.
 
 %% @doc Where to emit the default log messages (typically at 'info'

--- a/gen_dev
+++ b/gen_dev
@@ -14,13 +14,17 @@ NUMBER=${NAME##dev}
 BASE=$((10000 + 50 * $NUMBER))
 MQTTPORT=$(($BASE + 3))
 MQTTWSPORT=$(($BASE + 4))
+MQTTSPORT=$(($BASE + 5))
 CLUSTERPORT=$(($BASE + 10))
 METRICSPORT=$(($BASE + 20))
+HTTPSPORT=$(($BASE + 21))
 
 
 echo "Generating $NAME - node='$NODE' mqttport=$MQTTPORT mqttwsport=$MQTTWSPORT"
 sed -e "s/@NODE@/$NODE/" \
     -e "s/@MQTTPORT@/$MQTTPORT/" \
     -e "s/@MQTTWSPORT@/$MQTTWSPORT/" \
+    -e "s/@MQTTSPORT@/$MQTTSPORT/" \
     -e "s/@CLUSTERPORT@/$CLUSTERPORT/" \
+    -e "s/@HTTPSPORT@/$HTTPSPORT/" \
     -e "s/@METRICSPORT@/$METRICSPORT/" < $TEMPLATE > $VARFILE

--- a/vars.config
+++ b/vars.config
@@ -51,6 +51,7 @@
 {runner_ulimit_warn, 65536}.
 
 %% vmq_server
+{nodename, "VerneMQ@127.0.0.1"}.
 {max_connections, 10000}.
 
 {max_nr_of_acceptors, 10}.
@@ -69,11 +70,19 @@
 
 {cluster_default_ip, "0.0.0.0"}.
 
+{cluster_ssl_default_ip, "0.0.0.0"}.
+
+{cluster_ssl_default_port, 44054}.
+
 {cluster_default_port, 44053}.
 
 {http_default_ip, "127.0.0.1"}.
 
 {http_default_port, 8888}.
+
+{https_default_ip, "127.0.0.1"}.
+
+{https_default_port, "8889"}.
 
 {metadata_plugin, vmq_swc}.
 

--- a/vars/dev_vars.config.src
+++ b/vars/dev_vars.config.src
@@ -32,6 +32,7 @@
 {runner_ulimit_warn,    65536}.
 
 %% vmq_server
+{nodename, "@NODE@"}.
 {max_connections, 10000}.
 {max_nr_of_acceptors, 10}.
 {tls_handshake_timeout, 5000}.
@@ -39,10 +40,16 @@
 {mqtt_default_port, @MQTTPORT@}.
 {mqtt_default_ws_ip, "127.0.0.1"}.
 {mqtt_default_ws_port, @MQTTWSPORT@}.
+{mqtts_default_ip, "127.0.0.1"}.
+{mqtts_default_port, @MQTTSPORT@}.
 {cluster_default_ip, "0.0.0.0"}.
 {cluster_default_port, @CLUSTERPORT@}.
-{http_default_ip, "0.0.0.0"}.
+{cluster_ssl_default_ip, "0.0.0.0"}.
+{cluster_ssl_default_port, 44054}.
+{http_default_ip, "127.0.0.1"}.
 {http_default_port, @METRICSPORT@}.
+{https_default_ip, "127.0.0.1"}.
+{https_default_port, @HTTPSPORT@}.
 {metadata_plugin, vmq_swc}.
 
 %% lager


### PR DESCRIPTION
This tries to fix an issue, where listeners would be added to the generate app. files while not visible in `vernemq.conf`.
This also fixes the `make dev0 dev1` quick generation of local dev nodes. (creating correct nodenames, ports and listeners).

In addition, I enable v5 protocol as a default for WS and TLS listeners too (MQTT TCP had this for a while).

@codeadict I have the impression that {include_default, "default"} directive in schema files somehow creates issues, and we end up with 2 identical listeners in the generated app. files.