### PR TITLE
Bugfix: HTTP2 not correctly working with TLS connections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Improvew HTTP/2 support for HTTPS listeners (#2117)
 - Make Redis username configurable in vmq_diversity.
 - Enable v5 protocol for WS and SSL listeners as a default.
 - Fix dev_n builds (make dev0 dev1...).


### PR DESCRIPTION
Bugfix: HTTP2 not correctly working with TLS connections, defaulting to HTTP1.1 (#2117)

## Proposed Changes

Use officially documented start_clear and start_tls. I am not sure if this has any undesired side-effects so review carefully :-)


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #2117 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
