### PR TITLE
Initial support for X-Forward-For 

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -921,6 +921,30 @@
                                                                         {datatype, flag},
                                                                         hidden
                                                                        ]}.
+%% @doc listener.ws.xff_support specifies if the listener accepts
+%% connections opened by a proxy server that supports the  X-Forwarded-For header.
+%% This enables to retrieve peer information such as source IP/Port.
+{mapping, "listener.ws.$name.proxy_xff_support", "vmq_server.listeners", [
+                                                                        {datatype, flag},
+                                                                        hidden
+                                                                       ]}.
+{mapping, "listener.ws.proxy_xff_support", "vmq_server.listeners", [
+                                                                  {default, off},
+                                                                  {datatype, flag},
+                                                                  hidden
+                                                                 ]}.
+%% @doc listener.ws.proxy_xff_trusted_intermediate specifies the
+%% list of proxies accepted within the X-Forwarded-For list as last proxy. The other
+%% proxies in the chain are not checked.
+{mapping, "listener.ws.$name.proxy_xff_trusted_intermediate", "vmq_server.listeners", [
+                                                                        {datatype, string},
+                                                                        hidden
+                                                                       ]}.
+{mapping, "listener.ws.proxy_xff_trusted_intermediate", "vmq_server.listeners", [
+                                                                  {default, ""},
+                                                                  {datatype, string},
+                                                                  hidden
+                                                                 ]}.
 
 %% @doc If 'listener.tcp.proxy_protocol' is enabled, you may enable
 %% 'listener.tcp.proxy_protocol_use_cn_as_username' to use the CN

--- a/apps/vmq_server/src/vmq_proxy_xff.erl
+++ b/apps/vmq_server/src/vmq_proxy_xff.erl
@@ -1,0 +1,63 @@
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% This module implements X-Forwarded-For support. Currently, only the X-Forwared-For header is supported.
+%% X-Forwarded-For expects a list, as in X-Forwarded-For: <client>, <proxy1>, <proxy2>.
+%% proxy2 is checked against the configured list of trusted proxies. The trust relationship between proxy2
+%% and proxy1 has to be ensured by proxy2.
+%%
+%% Not supported at the moment (maybe later):
+%% - x-forwarded-client-cert, for CNAME support
+%% - Forwarded (RFC 7239)
+
+-module(vmq_proxy_xff).
+
+%% API
+-export([new_peer/2]).
+
+new_peer(Req, TrustedList) ->
+    XFF = header(Req),
+    {IP, Port} = cowboy_req:peer(Req),
+    {ok} = check_xff_proxy(XFF, IP, TrustedList),
+    {ok, IP0} = inet:parse_address(extract_xff_origin(XFF)),
+    {ok, {IP0, Port}}.
+
+header(Req) ->
+    XFFHeader = cowboy_req:header(<<"x-forwarded-for">>, Req, undefined),
+    XFFEntries = xff_header_to_list(XFFHeader),
+    XFFEntries.
+
+% XFF is a list of IPs. First one, the origin, last one the last proxy
+xff_header_to_list(XFFHeader) when is_binary(XFFHeader) ->
+    binary:split(XFFHeader, [<<",">>], [global]).
+
+% Check if the last proxy is a known one, and that it is the same as (current) peer.
+check_xff_proxy(XFFEntries, IP, TrustedList) when is_list(XFFEntries) ->
+    LastProxy = binary_to_list(lists:last(XFFEntries)),
+    {ok, IPLastProxy} = inet:parse_address(LastProxy),
+    case IPLastProxy == IP andalso check_trusted_list(LastProxy, TrustedList) of
+        true -> {ok};
+        _ -> {error, xff_proxy_addr_not_accepted}
+    end.
+
+check_trusted_list(LastProxy, TrustedList) ->
+    List = string:tokens(TrustedList, ";"),
+    case lists:member(LastProxy, List) of
+        true ->
+            true;
+        _ ->
+            lager:error("XFF proxy not in trused list!"),
+            false
+    end.
+
+extract_xff_origin(XFFEntries) when is_list(XFFEntries) ->
+    binary_to_list(lists:nth(1, XFFEntries)).

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -345,6 +345,17 @@ default_session_opts(Opts) ->
             false -> MaybeSSLDefaults;
             {_, V1} -> [{proxy_protocol_use_cn_as_username, V1} | MaybeSSLDefaults]
         end,
+    MaybeProxyDefaults2 =
+        case lists:keyfind(proxy_xff_trusted_intermediate, 1, Opts) of
+            false ->
+                MaybeProxyDefaults;
+            {_, V2} ->
+                [
+                    {xff_proxy, proplists:get_value(proxy_xff_support, Opts, false)},
+                    {proxy_xff_trusted_intermediate, V2}
+                    | MaybeProxyDefaults
+                ]
+        end,
     AllowedProtocolVersions = proplists:get_value(allowed_protocol_versions, Opts, [3, 4]),
     MaxConnectionLifeTime = proplists:get_value(max_connection_lifetime, Opts, 0),
     AllowAnonymousOverride = proplists:get_value(allow_anonymous_override, Opts, false),
@@ -355,7 +366,7 @@ default_session_opts(Opts) ->
         {max_connection_lifetime, MaxConnectionLifeTime},
         {allow_anonymous_override, AllowAnonymousOverride},
         {buffer_sizes, BufferSizes}
-        | MaybeProxyDefaults
+        | MaybeProxyDefaults2
     ].
 
 %%%===================================================================

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -178,6 +178,10 @@ translate_listeners(Conf) ->
 
     {TCPIPs, TCPProxyProto} = lists:unzip(extract("listener.tcp", "proxy_protocol", BoolVal, Conf)),
     {WSIPs, WSProxyProto} = lists:unzip(extract("listener.ws", "proxy_protocol", BoolVal, Conf)),
+    {WSIPs, WSProxyXFF} = lists:unzip(extract("listener.ws", "proxy_xff_support", BoolVal, Conf)),
+    {WSIPs, WSProxyXFFTrusted} = lists:unzip(
+        extract("listener.ws", "proxy_xff_trusted_intermediate", StrVal, Conf)
+    ),
     {HTTPIPs, HTTPProxyProto} = lists:unzip(
         extract("listener.http", "proxy_protocol", BoolVal, Conf)
     ),
@@ -358,6 +362,8 @@ translate_listeners(Conf) ->
             WSNrOfAcceptors,
             WSMountPoint,
             WSProxyProto,
+            WSProxyXFF,
+            WSProxyXFFTrusted,
             WSAllowedProto
         ])
     ),
@@ -545,6 +551,8 @@ extract(Prefix, Suffix, Val, Conf) ->
             "allowed_protocol_versions",
             %% other
             "proxy_protocol",
+            "proxy_xff_support",
+            "proxy_xff_trusted_intermediate",
             "allow_anonymous_override"
         ],
 

--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -64,9 +64,19 @@ init(Req, Opts) ->
                         src_port := SrcPort
                     } ->
                         {SrcAddr, SrcPort};
-                    % WS request without proxy_protocol
+                    % WS request without proxy_protocol (might have XFF)
                     error ->
-                        cowboy_req:peer(Req0)
+                        XFF_On = proplists:get_value(proxy_xff_support, Opts, false),
+                        case XFF_On of
+                            true ->
+                                {ok, NewPeer} = vmq_proxy_xff:new_peer(
+                                    Req0,
+                                    proplists:get_value(proxy_xff_trusted_intermediate, Opts, "")
+                                ),
+                                NewPeer;
+                            _ ->
+                                cowboy_req:peer(Req0)
+                        end
                 end,
             FsmMod = proplists:get_value(fsm_mod, Opts, vmq_mqtt_pre_init),
             FsmState =

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Add support for x-forward-for (XFF) header (Websockets) (#1783)
 - Bugfix: QoS0 message shall ignore receive maximum setting (#2150)
 - Offline queues to online queue transition can (temporarily) override the max online queue size (#1663)
 - Fix processing of line endings in vmq_acl (#1897)


### PR DESCRIPTION
Initial support for X-Forward-For  header. Currently, only works for Websockets (MQTTWS). To turn on support for X-Forward-Header you need to set

- listener.ws.$name.proxy_xff_support on
- istener.ws.$name.proxy_xff_trusted_intermediate IP1;IP2;...

where IP1... are acceptable proxy IPs. Support for vmq_http_pub plugin will follow (amazing how many changes this small plugin triggers lately) :-)

Related Issues:
#1754 
#1783 
(among others)

This is WiP, as I do not have a test lab for all kinds of proxies any help (testers) is appreciated. The code will print some debug information that will help in case something breaks. 

## Proposed Changes

Adds support for X-Forward-For header.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
