### PR TITLE
Bugfix: Increase waiting time in hope some flaky integration tests

### DIFF
--- a/apps/vmq_server/test/vmq_queue_SUITE.erl
+++ b/apps/vmq_server/test/vmq_queue_SUITE.erl
@@ -75,14 +75,14 @@ queue_crash_test(_) ->
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId,
                                   [{[<<"test">>, <<"topic">>], 1}]),
     %% at this point we've a working subscription
-    timer:sleep(10),
+    timer:sleep(20),
     Msg = msg([<<"test">>, <<"topic">>], <<"test-message">>, 1),
     {ok, {1, 0}} = vmq_reg:publish(true, vmq_reg_trie, ClientId, Msg),
     receive_msg(QPid1, 1, Msg),
 
     %% teardown session
     SessionPid1 ! go_down,
-    timer:sleep(10),
+    timer:sleep(20),
     {offline, fanout, 0, 0, false} = vmq_queue:status(QPid1),
 
     %% fill the offline queue
@@ -92,7 +92,7 @@ queue_crash_test(_) ->
     %% crash the queue
     catch gen_fsm:sync_send_all_state_event(QPid1, byebye),
     false = is_process_alive(QPid1),
-    timer:sleep(10),
+    timer:sleep(20),
     NewQPid = vmq_reg:get_queue_pid(SubscriberId),
     {offline, fanout, 1, 0, false} = vmq_queue:status(NewQPid),
 
@@ -116,7 +116,7 @@ queue_fifo_test(_) ->
                            [{[<<"test">>, <<"fifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
-    timer:sleep(10),
+    timer:sleep(20),
 
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"fifo">>, <<"topic">>]),
 
@@ -138,7 +138,7 @@ queue_lifo_test(_) ->
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"lifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
-    timer:sleep(10),
+    timer:sleep(20),
 
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"lifo">>, <<"topic">>]),
 
@@ -161,7 +161,7 @@ queue_fifo_offline_drop_test(_) ->
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"fifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
-    timer:sleep(10),
+    timer:sleep(20),
 
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"fifo">>, <<"topic">>]), % publish 100, only the first 10 are kept
     {offline, fanout, 10, 0, false} = vmq_queue:status(QPid),
@@ -188,7 +188,7 @@ queue_lifo_offline_drop_test(_) ->
                            [{[<<"test">>, <<"lifo">>, <<"topic">>], 1}]),
     %% teardown session
     SessionPid1 ! go_down,
-    timer:sleep(10),
+    timer:sleep(20),
 
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"lifo">>, <<"topic">>]), % publish 100, only the first 10 are kept
     {offline, fanout, 10, 0, false} = vmq_queue:status(QPid),
@@ -211,7 +211,7 @@ queue_offline_transition_test(_) ->
     {ok, #{session_present := false,
            queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
-    timer:sleep(10), % give some time to plumtree
+    timer:sleep(20), % give some time to plumtree
 
     %% teardown session
     catch vmq_queue:set_last_waiting_acks(QPid, []), % simulate what real session does
@@ -236,7 +236,7 @@ queue_persistent_client_expiration_test(_) ->
     {ok, #{session_present := false,
            queue_pid := QPid}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"transition">>], 1}]),
-    timer:sleep(50), % give some time to plumtree
+    timer:sleep(200), % give some time to plumtree
 
     %% teardown session
     catch vmq_queue:set_last_waiting_acks(QPid, []), % simulate what real session does
@@ -244,7 +244,7 @@ queue_persistent_client_expiration_test(_) ->
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"transition">>]),
     NumPubbedMsgs = length(Msgs),
 
-    timer:sleep(50), % give some time to plumtree
+    timer:sleep(200), % give some time to plumtree
     {ok, FoundMsgs} = vmq_message_store:find(SubscriberId, other),
     NumPubbedMsgs = length(FoundMsgs),
 
@@ -264,7 +264,7 @@ queue_force_disconnect_test(_) ->
     {ok, #{session_present := false,
            queue_pid := QPid0}} = vmq_reg:register_subscriber_(SessionPid1, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"disconnect">>], 1}]),
-    timer:sleep(50), % give some time to plumtree
+    timer:sleep(200), % give some time to plumtree
 
     monitor(process, SessionPid1),
     vmq_queue:force_disconnect(QPid0, ?ADMINISTRATIVE_ACTION),
@@ -289,12 +289,12 @@ queue_force_disconnect_cleanup_test(_) ->
     {ok, #{session_present := SessionPresent,
            queue_pid := QPid0}} = vmq_reg:register_subscriber_(NonConsumingSessionPid, SubscriberId, false, QueueOpts, 10),
     {ok, [1]} = vmq_reg:subscribe(false, SubscriberId, [{[<<"test">>, <<"discleanup">>], 1}]),
-    timer:sleep(50), % give some time to plumtree
+    timer:sleep(200), % give some time to plumtree
 
     Msgs = publish_multi(SubscriberId, [<<"test">>, <<"discleanup">>]),
     NumPubbedMsgs = length(Msgs),
 
-    timer:sleep(50), % give some time to plumtree
+    timer:sleep(200), % give some time to plumtree
     {ok, FoundMsgs} = vmq_message_store:find(SubscriberId, other),
     NumPubbedMsgs = length(FoundMsgs),
 


### PR DESCRIPTION
Increase waiting time in hope some flaky integration tests will run through more smoothly. vmq_queue_SUITE fails for timing reasons in the automated tests. Increase the waiting times a little bit should make this test suite more reliable.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
