### PR TITLE
Fix a timing issue in cross_node_publish_subscribe test.

### DIFF
--- a/apps/vmq_server/test/vmq_cluster_SUITE.erl
+++ b/apps/vmq_server/test/vmq_cluster_SUITE.erl
@@ -821,18 +821,9 @@ cross_node_publish_subscribe() ->
     [{doc, "Make sure all subscribers on a cross-node publish receive the published messages."}].
 
 cross_node_publish_subscribe(Config) ->
-    %% Skip on CI:
-    %% https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    case os:getenv("CI") of
-        false ->
-            cross_node_publish_subscribe_(Config);
-        _Ci ->
-            {skip, "Flaky test in CI"}
-    end.
-
-cross_node_publish_subscribe_(Config) ->
     ok = ensure_cluster(Config),
     {_, Nodes} = lists:keyfind(nodes, 1, Config),
+    ct:sleep(15000),
 
     Topic = <<"cross-node-topic">>,
 


### PR DESCRIPTION
Fix a timing issue in cross_node_publish_subscribe test. Previously, failed all the time and was disabled on integration. It now reliably runs local and thus should also work well in the integration pipeline.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
