### PR TITLE
catch the exception when trying to getopts for a non-exist socket

### DIFF
--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -70,8 +70,10 @@ init(Ref, Parent, Transport, Opts) ->
                         {ok, BufSizes} ->
                             BufSize = lists:max([Sz || {_, Sz} <- BufSizes]),
                             setopts(MaskedSocket, [{buffer, BufSize}]),
-                            start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent)
-                        end;
+                            start_accepting_messages(
+                                MaskedSocket, FsmState, FsmMod, Transport, Parent
+                            )
+                    end;
                 [SndBuf, RecBuf, Buffer] ->
                     setopts(MaskedSocket, [{sndbuf, SndBuf}, {recbuf, RecBuf}, {buffer, Buffer}]),
                     start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent)

--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -62,23 +62,20 @@ init(Ref, Parent, Transport, Opts) ->
             CfgBufSizes = proplists:get_value(buffer_sizes, Opts, undefined),
             case CfgBufSizes of
                 undefined ->
-                    {ok, BufSizes} = getopts(MaskedSocket, [sndbuf, recbuf, buffer]),
-                    BufSize = lists:max([Sz || {_, Sz} <- BufSizes]),
-                    setopts(MaskedSocket, [{buffer, BufSize}]);
+                    case getopts(MaskedSocket, [sndbuf, recbuf, buffer]) of
+                        {error, Reason} ->
+                            %% If the socket already closed we don't want to
+                            %% go through teardown, because no session was initialized
+                            lager:debug("getopts error, socket already closed: ~p", [Reason]);
+                        {ok, BufSizes} ->
+                            BufSize = lists:max([Sz || {_, Sz} <- BufSizes]),
+                            setopts(MaskedSocket, [{buffer, BufSize}]),
+                            start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent)
+                        end;
                 [SndBuf, RecBuf, Buffer] ->
-                    setopts(MaskedSocket, [{sndbuf, SndBuf}, {recbuf, RecBuf}, {buffer, Buffer}])
-            end,
-            %% start accepting messages
-            active_once(MaskedSocket),
-            process_flag(trap_exit, true),
-            _ = vmq_metrics:incr_socket_open(),
-            loop(#st{
-                socket = MaskedSocket,
-                fsm_state = FsmState,
-                fsm_mod = FsmMod,
-                proto_tag = Transport:messages(),
-                parent = Parent
-            });
+                    setopts(MaskedSocket, [{sndbuf, SndBuf}, {recbuf, RecBuf}, {buffer, Buffer}]),
+                    start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent)
+            end;
         {error, enotconn} ->
             %% If the client already disconnected we don't want to
             %% know about it - it's not an error.
@@ -142,6 +139,18 @@ peer_info_no_proxy(Peer, Socket, Transport, Opts) ->
         _ ->
             {ok, {Peer, Opts}}
     end.
+
+start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent) ->
+    active_once(MaskedSocket),
+    process_flag(trap_exit, true),
+    _ = vmq_metrics:incr_socket_open(),
+    loop(#st{
+        socket = MaskedSocket,
+        fsm_state = FsmState,
+        fsm_mod = FsmMod,
+        proto_tag = Transport:messages(),
+        parent = Parent
+    }).
 
 mask_socket(ranch_tcp, Socket) -> Socket;
 mask_socket(vmq_ranch_proxy_protocol, Socket) -> vmq_ranch_proxy_protocol:get_csocket(Socket);


### PR DESCRIPTION
## Proposed Changes

Trying to fix the [issue](https://github.com/vernemq/vernemq/issues/1609). It will catch the exception when trying to `getopts` for a non-exist/closed socket.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [ ] I have updated the changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

Based on our production experience, this exception will be thrown when there is an `accept queue` overflow.
