### PR TITLE
WIP: Initial v2 HTTP API

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -351,7 +351,8 @@
 
 %% @doc specifies the modules to be enabled by the http(s) listeners. Overriding this setting is possible for specific listeners.
 {mapping, "http_modules", "vmq_server.http_modules", [
-                                                      {default, "[vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http]"},
+                                                      {default, "[vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http,
+                                                                vmq_http_v2_api]"},
                                                       {datatype, string},
                                                       hidden
                                                      ]}.
@@ -397,7 +398,7 @@
   fun(Conf) ->
      HTTPModules = cuttlefish_variable:filter_by_prefix("http_module",Conf),
  	 HTTPModulesAsAtom = lists:map(fun(Element) -> list_to_atom(lists:nth(2,element(1, Element))) end, HTTPModules),
-     KnownHttpModules = [vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http],%
+     KnownHttpModules = [vmq_metrics_http,vmq_http_mgmt_api, vmq_status_http, vmq_health_http, vmq_http_v2_api],%
 	 UniqueModules = lists:usort(HTTPModulesAsAtom ++ KnownHttpModules),
      Map = lists:map(fun(Atom) -> String = "http_module."++atom_to_list(Atom)++".auth.mode", #{Atom => cuttlefish:conf_get(String, Conf, "noauth")} end, UniqueModules),
      Ret = maps:from_list(lists:foldl(fun(Elem, Acc) -> maps:to_list(Elem) ++ Acc end, [], Map)),

--- a/apps/vmq_server/src/vmq_auth_apikey.erl
+++ b/apps/vmq_server/src/vmq_auth_apikey.erl
@@ -162,7 +162,7 @@ is_valid_date_time(Year, Month, Day, Hour, Minute, Second) ->
     end.
 
 scopes() ->
-    ["status", "mgmt", "metrics", "health"].
+    ["status", "mgmt", "metrics", "health", "api2"].
 
 time_diff_now_secs(ExpiresUTC) ->
     CurrentTime = calendar:now_to_universal_time(erlang:timestamp()),

--- a/apps/vmq_server/src/vmq_http_v2_api.erl
+++ b/apps/vmq_server/src/vmq_http_v2_api.erl
@@ -1,0 +1,134 @@
+%% Copyright 2023- Octavo Labs AG, Switzerland
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(vmq_http_v2_api).
+-behaviour(vmq_http_config).
+-include("vmq_server.hrl").
+
+%% cowboy rest handler callbacks
+-export([
+    init/2,
+    allowed_methods/2,
+    content_types_provided/2,
+    options/2,
+    is_authorized/2,
+    to_json/2
+]).
+
+-export([
+    routes/0
+]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Cowboy REST Handler
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+init(Req, Opts) ->
+    {cowboy_rest, Req, Opts}.
+
+allowed_methods(Req, State) ->
+    {[<<"GET">>, <<"OPTIONS">>, <<"HEAD">>], Req, State}.
+
+content_types_provided(Req, State) ->
+    {[{{<<"application">>, <<"json">>, '*'}, to_json}], Req, State}.
+
+options(Req, State) ->
+    %% Set CORS Headers
+    CorsHeaders = #{
+        <<"access-control-max-age">> => <<"1728000">>,
+        <<"access-control-allow-methods">> => <<"HEAD, GET">>,
+        <<"access-control-allow-headers">> => <<"content-type, authorization">>,
+        <<"access-control-allow-origin">> => <<$*>>
+    },
+    {ok, cowboy_req:set_resp_headers(CorsHeaders, Req), State}.
+
+is_authorized(Req, State) ->
+    AuthMode = vmq_http_config:auth_mode(Req, ?MODULE),
+    case AuthMode of
+        "apikey" -> vmq_auth_apikey:is_authorized(Req, State, "api2");
+        "noauth" -> {true, Req, State};
+        _ -> {error, invalid_authentication_scheme}
+    end.
+
+to_json(Req, State) ->
+    Command = cowboy_req:binding(command, Req),
+    handle_command(Command, Req, State).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Cowboy Config
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+routes() ->
+    [{"/api/v2/:command", ?MODULE, []}].
+
+%% internal calls
+handle_command(<<"client">>, Req, State) ->
+    Qs = cowboy_req:parse_qs(Req),
+    SubscriberId = subscriber_from_qs(Qs),
+    TopicFlag = proplists:get_value(<<"topics">>, Qs, false),
+    OnlineStatus = get_online_status(SubscriberId),
+    Reply0 =
+        case TopicFlag of
+            true ->
+                Topics = get_topics(SubscriberId),
+                [{<<"status">>, OnlineStatus}, {<<"topics">>, Topics}];
+            _ ->
+                [{<<"status">>, OnlineStatus}]
+        end,
+    ReplyReq = cowboy_req:reply(200, #{}, vmq_json:encode(Reply0), Req),
+    {stop, ReplyReq, State};
+handle_command(<<"disconnect">>, Req, State) ->
+    Qs = cowboy_req:parse_qs(Req),
+    SubscriberId = subscriber_from_qs(Qs),
+    DoCleanup = proplists:get_value(<<"cleanup">>, Qs, false),
+    Reply0 = force_disconnect(SubscriberId, DoCleanup),
+    ReplyReq = cowboy_req:reply(200, #{}, vmq_json:encode(Reply0), Req),
+    {stop, ReplyReq, State};
+handle_command(_Command, Req, State) ->
+    Reply = cowboy_req:reply(400, #{}, <<"invalid_command">>, Req),
+    {stop, Reply, State}.
+
+subscriber_from_qs(Qs) ->
+    Mountpoint = proplists:get_value(<<"mountpoint">>, Qs, []),
+    ClientId = proplists:get_value(<<"client_id">>, Qs),
+    {Mountpoint, ClientId}.
+
+get_online_status(SubscriberId) ->
+    QueuePid = vmq_queue_sup_sup:get_queue_pid(SubscriberId),
+    case QueuePid of
+        not_found ->
+            <<"unknown">>;
+        _ ->
+            #{is_online := IsOnline} = vmq_queue:info(QueuePid),
+            case IsOnline of
+                true -> <<"online">>;
+                _ -> <<"offline">>
+            end
+    end.
+
+get_topics(SubscriberId) ->
+    Res = vmq_subscriber_db:read(SubscriberId),
+    case Res of
+        undefined ->
+            [];
+        [{_, _, []}] ->
+            [];
+        [{_, _, Topics}] ->
+            [{iolist_to_binary(vmq_topic:unword(Topic)), QoS} || {Topic, QoS} <- Topics]
+    end.
+
+force_disconnect(SubscriberId, DoCleanup) ->
+    QueuePid = vmq_queue_sup_sup:get_queue_pid(SubscriberId),
+    case QueuePid of
+        not_found -> not_found;
+        _ -> vmq_queue:force_disconnect(QueuePid, ?ADMINISTRATIVE_ACTION, DoCleanup)
+    end.

--- a/apps/vmq_server/src/vmq_http_v2_api.erl
+++ b/apps/vmq_server/src/vmq_http_v2_api.erl
@@ -30,7 +30,7 @@
     routes/0
 ]).
 
--define(RPC_TIMEOUT, 5000).
+-define(RPC_TIMEOUT, 60000).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Cowboy REST Handler

--- a/apps/vmq_server/src/vmq_http_v2_api.erl
+++ b/apps/vmq_server/src/vmq_http_v2_api.erl
@@ -115,7 +115,7 @@ force_disconnect(SubscriberId, DoCleanup) ->
                 QPid when is_pid(QPid) ->
                     vmq_queue:force_disconnect(QPid, ?ADMINISTRATIVE_ACTION, DoCleanup)
             catch
-                E:R -> 
+                E:R ->
                     lager:debug("API v2 disconnect RPC failed with ~p:~p", [E, R]),
                     {error, rpc_fail}
             end
@@ -143,7 +143,7 @@ get_status_and_topics(SubscriberId) ->
                         _ -> {<<"offline">>, FlatTopics}
                     end
             catch
-                E:R -> 
+                E:R ->
                     lager:debug("API v2 client status RPC failed with ~p:~p", [E, R]),
                     {error, rpc_fail}
             end


### PR DESCRIPTION
Beginning of a v2 HTTP API, without the full management capabilities of v1 but with better performance for specific scriptable tasks. (avoiding `VMQL`).

### To use:

1. Create a specific API key for the v2 endpoint:
`vmq-admin api-key create scope=api2`
You can also use the general management API key, without the `api2` scope. When you create an API key on a cluster node, it will be replicated to other cluster nodes and can be used for calls on all cluster nodes.

2. Add a specific API2 listener to `vernemq.conf`, and restrict it to handle API2 only:
```
listener.http.api2 = 127.0.0.1:8885
listener.http.api2.http_modules = vmq_http_v2_api
http_module.vmq_http_v2_api.auth.mode = apikey
```

`api2` is the name of the listener (you can choose another one). `vmq_http_v2_api` is the module of code we want that endpoint to use. Auth mode `apikey` tells that module to require an API key. (to allow calls without key, set to `noauth`)

3. Use the API key for calls against the v2 API:
```
curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/client?client_id=tester&topics'
{"status":"online","topics":{"bla":0,"bla/tu/#":0,"test":0}}%
```

Check whether a Client is known, online or offline:
`curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/client?client_id=tester'`

Check the same with a specific given mountpoint (you don't have to give the default mountpoint):
`curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/client?client_id=tester&mountpoint=other'`

Check as above, but also get the list of topics the client is subscribed to:
`curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/client?client_id=tester&topics'`

Disconnect a client:
`curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/disconnect?client_id=tester'`

Disconnect and cleanup (=delete) state:
`curl 'http://DkvQif8cWiWax43iJS8Vq6NyUk6lOMjs@127.0.0.1:8885/api/v2/disconnect?client_id=tester&cleanup'`.
