### PR TITLE
Fix mountpoint filtering for vmq-admin retain show. Add delete command.

### DIFF
--- a/apps/vmq_server/src/vmq_info_cli.erl
+++ b/apps/vmq_server/src/vmq_info_cli.erl
@@ -23,13 +23,15 @@ register_cli() ->
     vmq_session_disconnect_cmd(),
     vmq_session_reauthorize_cmd(),
     vmq_retain_show_cmd(),
+    vmq_retain_delete_cmd(),
 
     clique:register_usage(["vmq-admin", "session"], session_usage()),
     clique:register_usage(["vmq-admin", "session", "show"], vmq_session_show_usage()),
     clique:register_usage(["vmq-admin", "session", "disconnect"], vmq_session_disconnect_usage()),
     clique:register_usage(["vmq-admin", "session", "reauthorize"], vmq_session_reauthorize_usage()),
     clique:register_usage(["vmq-admin", "retain"], retain_usage()),
-    clique:register_usage(["vmq-admin", "retain"], retain_show_usage()).
+    clique:register_usage(["vmq-admin", "retain", "show"], retain_show_usage()),
+    clique:register_usage(["vmq-admin", "retain", "delete"], retain_delete_usage()).
 
 vmq_retain_show_cmd() ->
     Cmd = ["vmq-admin", "retain", "show"],
@@ -41,6 +43,44 @@ vmq_retain_show_cmd() ->
         ],
     DefaultFields = ["topic", "payload"],
     Callback = vmq_ql_callback("retain_srv", DefaultFields, [{nodes, [node()]}]),
+    clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
+
+vmq_retain_delete_cmd() ->
+    Cmd = ["vmq-admin", "retain", "delete"],
+    KeySpecs = [],
+    FlagSpecs = [
+        {mountpoint, [
+            {shortname, "m"},
+            {longname, "mountpoint"},
+            {typecast, fun(Mountpoint) -> Mountpoint end}
+        ]},
+
+        {topic, [
+            {shortname, "t"},
+            {longname, "topic"},
+            {typecast, fun(Topic) -> vmq_topic:word(Topic) end}
+        ]}
+    ],
+    Callback = fun
+        (_, [], Flags) ->
+            Mountpoint =
+                case proplists:get_value(mountpoint, Flags) of
+                    % no --mountpoint flag given, we take the default mountpoint
+                    undefined -> "";
+                    MP -> MP
+                end,
+            case proplists:get_value(topic, Flags) of
+                undefined ->
+                    Text = clique_status:text("No valid topic given."),
+                    [clique_status:alert([Text])];
+                Topic ->
+                    vmq_retain_srv:delete(Mountpoint, Topic),
+                    [clique_status:text("Done")]
+            end;
+        (_, _, _) ->
+            Text = clique_status:text(retain_delete_usage()),
+            [clique_status:alert([Text])]
+    end,
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
 vmq_session_list_cmd() ->
@@ -270,6 +310,7 @@ retain_usage() ->
         "  Inspect MQTT retained messages.\n\n",
         "  Sub-commands:\n",
         "    show        Show and filter running sessions\n",
+        "    delete      Delete retained message\n",
         "  Use --help after a sub-command for more details.\n"
     ].
 
@@ -286,5 +327,24 @@ retain_show_usage() ->
         "Options\n\n"
         "  --limit=<NumberOfResults>\n"
         "      Limit the number of results returned. Defaults is 100.\n"
+        "  --mountpoint\n"
+        "      Show retained messages for mountpoint.\n"
+        "      If no mountpoint is given, the default (empty) mountpoint\n"
+        "      is assumed."
+        | Options
+    ].
+
+retain_delete_usage() ->
+    Options = [
+        io_lib:format("  --~p\n", [Item])
+     || Item <- [topic, mountpoint]
+    ],
+    [
+        "vmq-admin retain delete\n\n",
+        "  Delete retained MQTT messages for some or all topics.\n\n",
+        "Default options:\n"
+        "  --mountpoint --topic\n\n"
+        "If --mountpoint is not set, the default empty mountpoint\n"
+        "is assumed.\n\n"
         | Options
     ].

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -587,7 +587,7 @@ deliver_retained({MP, _} = SubscriberId, Topic, QoS, SubOpts, _) ->
     vmq_retain_srv:match_fold(
         fun
             (
-                {T, #retain_msg{
+                {{_M, T}, #retain_msg{
                     payload = Payload,
                     properties = Properties,
                     expiry_ts = ExpiryTs
@@ -608,7 +608,7 @@ deliver_retained({MP, _} = SubscriberId, Topic, QoS, SubOpts, _) ->
                 Msg1 = maybe_add_sub_id({QoS, SubOpts}, Msg),
                 maybe_delete_expired(ExpiryTs, MP, Topic),
                 vmq_queue:enqueue(QPid, {deliver, QoS, Msg1});
-            ({T, Payload}, _) when is_binary(Payload) ->
+            ({{_M, T}, Payload}, _) when is_binary(Payload) ->
                 %% compatibility with old style retained messages.
                 Msg = #vmq_msg{
                     routing_key = T,

--- a/apps/vmq_server/src/vmq_retain_srv.erl
+++ b/apps/vmq_server/src/vmq_retain_srv.erl
@@ -97,7 +97,7 @@ match_fold(FoldFun, Acc, MP, Topic) ->
                     ({{_M, T}, Payload}, AccAcc) ->
                         case vmq_topic:match(T, Topic) of
                             true ->
-                                FoldFun({T, Payload}, AccAcc);
+                                FoldFun({{MP, T}, Payload}, AccAcc);
                             false ->
                                 AccAcc
                         end;
@@ -110,7 +110,7 @@ match_fold(FoldFun, Acc, MP, Topic) ->
         false ->
             case ets:lookup(?RETAIN_CACHE, {MP, Topic}) of
                 [] -> Acc;
-                [{_, Payload}] -> FoldFun({Topic, Payload}, Acc)
+                [{_, Payload}] -> FoldFun({{MP, Topic}, Payload}, Acc)
             end
     end.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+
+- Add `vmq-admin retain delete` command to CLI (single topic delete only).
+- Fix per mountpoint filtering of `vmq-admin retain show`.
 - Add 'keypasswd': Allows setting password for pem keyfile (#1676)
 - Bugfix:w Improve warning messages for unexpected frame type error to track origin (#1671)
 - Bugfix: Remove special chars in auto-generated client id (#1673)


### PR DESCRIPTION
Fixes the filtering for retained messages by `--mountpoint=my_mp` flag. This was broken for any other mountpoint than the default empty mountpoint.
Note that `vmq-admin retain show` assumes the default empty mountpoint (which cannot be expressed directly on the CLI)

`vmq-admin retain show` always displays retained messages for 1 mountpoint.

This PR also adds a simple new command: `vmq-admin retain delete --topic=my_topic --mountpoint=my_mp`.
Again, to delete a topic under the default empty mountpoint, just leave out the `--mountpoint` flag:
`vmq-admin retain delete --topic=my_topic`

We might consider an option `--all` to delete all retained messages. (maybe triggering a lot of distributed deletes)