### PR TITLE
Re-enable Redis 5 support in vmq_diversity

### DIFF
--- a/apps/vmq_diversity/src/vmq_diversity_redis.erl
+++ b/apps/vmq_diversity/src/vmq_diversity_redis.erl
@@ -255,14 +255,25 @@ ensure_pool(As, St) ->
                         )
                     ),
                     NewOptions =
-                        [
-                            {size, Size},
-                            {password, Password},
-                            {username, User},
-                            {host, Host},
-                            {port, Port},
-                            {database, Database}
-                        ],
+                        case User of
+                            [] ->
+                                [
+                                    {size, Size},
+                                    {password, Password},
+                                    {host, Host},
+                                    {port, Port},
+                                    {database, Database}
+                                ];
+                            _ ->
+                                [
+                                    {size, Size},
+                                    {password, Password},
+                                    {username, User},
+                                    {host, Host},
+                                    {port, Port},
+                                    {database, Database}
+                                ]
+                        end,
                     vmq_diversity_sup:start_all_pools(
                         [{redis, [{id, PoolId}, {opts, NewOptions}]}], []
                     ),


### PR DESCRIPTION
In relation to: 
https://github.com/vernemq/vernemq/pull/2112

PR enables Redis 5 compatibility (when we do not have a given Redis Username).

cc @goldyfruit @mths1 