### PR TITLE
Allow ignore max online from offline queue to online queue

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -269,6 +269,13 @@
                                                                   {datatype, atom},
                                                                   hidden]}.
 
+%% @doc Allows a session that changes from offline to online to override the maximum
+%% online message count (max_online_messages). All offlines messages will be added 
+%% to the online queue. 
+{mapping, "override_max_online_messages", "vmq_server.override_max_online_messages", [{default, off},
+                                                  {datatype, flag}
+                                                  ]}.
+
 %% @doc specify how the queue should process the messages,
 %% either the 'fifo' or 'lifo' way.
 {mapping, "queue_type", "vmq_server.queue_type", [{default, fifo},

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -44,6 +44,7 @@ register_config_() ->
             "max_online_messages",
             "max_offline_messages",
             "queue_deliver_mode",
+            "override_max_online_messages",
             "queue_type",
             "max_message_rate",
             "max_message_size",

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Offline queues to online queue transition can (temporarily) override the max online queue size (#1663)
 - Fix processing of line endings in vmq_acl (#1897)
 - QoS0 messages for offline sessions now count towards the queue_unhandeled metric (#1528,#1536)
 - Allow overriding last will delay in plugins (#1998)


### PR DESCRIPTION
## Proposed Changes

Currently, when a session goes from offline to online and the actual offlines messages > max_online_messages those additional messages are immediately dropped. 

This PR introduces:
(a) a way to switch between different strategies for moving messages from the offline queue to the online queue
(b) a new strategy called "add_all" which does the following

* it moves all messages (or to be more correct their metadata/references) from offline queue to the online queue of the sessions immediately
* it ignores the size limit of the online queue
* it utilizes the already existing streaming/batching functionality, that means the messages will not be loaded from disk immediately but within the batching from disk. The additional memory needed therefore is limited to the metadata.
* the offline message into the shadow "backup" queue which is used for batching allowing online messages to arrive 
* the order in which the messages are sent to the subscribers is not changed (offline before online)

it does not change the state machine or anything else, as it just "simulates" a online queue with a higher capacity.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [X] New feature (non-breaking change which adds functionality) #1663 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
