### PR TITLE
Use default_reg_view instead of vmq_reg_trie directly.

### DIFF
--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1631,7 +1631,8 @@ fetch_external_metric(Mod, Fun, Default) ->
 
 -spec misc_statistics() -> [{metric_id(), any()}].
 misc_statistics() ->
-    {NrOfSubs, SMemory} = fetch_external_metric(vmq_reg_trie, stats, {0, 0}),
+    RegView = vmq_config:get_env(default_reg_view, vmq_reg_trie),
+    {NrOfSubs, SMemory} = fetch_external_metric(RegView, stats, {0, 0}),
     {NrOfRetain, RMemory} = fetch_external_metric(vmq_retain_srv, stats, {0, 0}),
     {NrOfMQTTConnections, NrOfMQTTWSConnections} = fetch_external_metric(
         vmq_ranch_sup, active_mqtt_connections, {0, 0}

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -948,7 +948,7 @@ direct_plugin_exports(LogName, Opts) ->
     CAPUnsubscribe = maps:get(cap_unsubscribe, Opts, false),
     SGPolicy = maps:get(sg_policy, Opts, prefer_local),
     Mountpoint = maps:get(mountpoint, Opts, ""),
-    RegView = maps:get(reg_view, Opts, vmq_reg_trie),
+    RegView = maps:get(reg_view, Opts, vmq_config:get_env(default_reg_view, vmq_reg_trie)),
 
     CallingPid = self(),
     ClientIdDef = list_to_binary(


### PR DESCRIPTION
## Proposed Changes

Some small bugfix: vmq_reg_trie shouldn't be referenced directly, instead the default_reg_view should be used.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
