### PR TITLE
Allow plugin to post in net split situations (follows global config)

### DIFF
--- a/apps/vmq_http_pub/src/vmq_http_pub.erl
+++ b/apps/vmq_http_pub/src/vmq_http_pub.erl
@@ -773,5 +773,10 @@ map_to_response_code(unknown_payload_encoding) -> 400.
 %%% Cowboy Config
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 routes() ->
-    {_, Publish, _} = vmq_reg:direct_plugin_exports(httpmqtt),
-    [{"/restmqtt/api/v1/publish", ?MODULE, [{publish_fun, Publish}]}].
+    {ok, #{
+        publish_fun := PubFun
+    }} = vmq_reg:direct_plugin_exports(vmq_http_pub, #{
+        wait_till_ready => not vmq_config:get_env(allow_publish_during_netsplit, false),
+        cap_publish => vmq_config:get_env(allow_publish_during_netsplit, false)
+    }),
+    [{"/restmqtt/api/v1/publish", ?MODULE, [{publish_fun, PubFun}]}].

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- 'vmq_http_pub': Allows post in netsplit situations (follows allow_publish_during_netsplit global config)
 - 'vmq_admin': Add new command tls invalide-pem-cache to support easier certificate replacement
 - Add compatibility with [Erlang/OTP 26]
 - Add new command to vmq-admin to clear webhook cache (webhooks cache clear)


### PR DESCRIPTION
## Proposed Changes

The http publisher plugin did not follow the global net split configuration and thus was not able to publish during netsplit situations.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
