### PR TITLE
vmq_tracer: Do not crash when formatting topics without QoS on Unsubs…

### DIFF
--- a/apps/vmq_server/src/vmq_tracer.erl
+++ b/apps/vmq_server/src/vmq_tracer.erl
@@ -927,6 +927,8 @@ jtopic(T) when is_list(T) ->
 ftopics(Topics) ->
     lists:foldl(
         fun
+            (Topic, Acc) when is_list(Topic) ->
+                [{"    t: \"~s\"~n", [jtopic(Topic)]} | Acc];
             ({Topic, QoS}, Acc) when is_integer(QoS), is_list(Topic) ->
                 [{"    q:~p, t: \"~s\"~n", [QoS, jtopic(Topic)]} | Acc];
             ({Topic, {QoS, SubOpts}}, Acc) ->


### PR DESCRIPTION
The Tracer crashes when formatting the list of topics for a Unsubscribe packet.
When handling a Unsubscribe packet, the topics will not have a QoS, but the formatting
function, which is shared with Subscribe, expects a QoS for every topic.

## Proposed Changes

This bugfix simply adds a function clause to handle cases where we only have a topic,
with no QoS and no subscription options. The formatting is kept similar to other cases
for consistency.

## Types of Changes

- [ x] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging
