### PR TITLE
Add CLI cmd tls invalide-pem-cache 

### DIFF
--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -69,6 +69,8 @@ register_cli() ->
     vmq_mgmt_delete_api_key_cmd(),
     vmq_mgmt_list_api_keys_cmd(),
 
+    vmq_mgmt_tls_clear_pem_cache_cmd(),
+
     vmq_listener_cli:register_server_cli(),
     vmq_info_cli:register_cli(),
 
@@ -92,6 +94,10 @@ register_cli_usage() ->
     clique:register_usage(["vmq-admin", "api-key"], api_usage()),
     clique:register_usage(["vmq-admin", "api-key", "delete"], api_delete_key_usage()),
     clique:register_usage(["vmq-admin", "api-key", "add"], api_add_key_usage()),
+
+    clique:register_usage(["vmq-admin", "tls"], tls_usage()),
+    clique:register_usage(["vmq-admin", "tls", "clear-pem-cache"], tls_clear_pem_cache_usage()),
+
     ok.
 
 vmq_server_stop_cmd() ->
@@ -642,6 +648,15 @@ vmq_mgmt_list_api_keys_cmd() ->
     end,
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
 
+vmq_mgmt_tls_clear_pem_cache_cmd() ->
+    Cmd = ["vmq-admin", "tls", "clear-pem-cache"],
+    KeySpecs = [],
+    FlagSpecs = [],
+    Callback = fun(_, _, _) ->
+        ok = ssl:clear_pem_cache()
+    end,
+    clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).
+
 start_usage() ->
     [
         "vmq-admin node start\n\n",
@@ -718,6 +733,7 @@ usage() ->
         "    metrics     Retrieve System Metrics\n",
         "    api-key     Manage API keys for the HTTP management interface\n",
         "    trace       Trace various aspects of VerneMQ\n",
+        "    tls         Manage TLS/SSL\n",
         remove_ok(vmq_plugin_mgr:get_usage_lead_lines()),
         "  Use --help after a sub-command for more details.\n"
     ].
@@ -801,6 +817,20 @@ api_add_key_usage() ->
         "  expires allows to set an expiery date, the expected format is \"yyyy-mm-ddThh:mm:ss\" \n\n",
         "  Example: \n",
         "  vmq-admin api-key add key=abcd scope=mgmt expires=2023-02-15T08:00:00 \n\n"
+    ].
+
+tls_usage() ->
+    [
+        "vmq-admin tls <sub-command>\n\n",
+        "  Interact with the TLS subsystem.\n\n",
+        "  Sub-commands:\n",
+        "    clear-pem-cache      Cleares cached certifactes and forces reload.\n"
+    ].
+
+tls_clear_pem_cache_usage() ->
+    [
+        "vmq-admin tls clear-pem-cache\n\n",
+        "  Cleares cached certifactes and forces reload.\n\n"
     ].
 
 ensure_all_stopped(App) ->

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- 'vmq_admin': Add new command tls invalide-pem-cache to support easier certificate replacement
 - Add compatibility with [Erlang/OTP 26]
 - Add new command to vmq-admin to clear webhook cache (webhooks cache clear)
 - 'vmq_admin': Add commands allowing batch disconnects (vmq-admin session disconnect batch and vmq-admin session disconnect clients)


### PR DESCRIPTION
## Proposed Changes

Adds a cli command vmq-admin tls invalidate-pem-cache, which invalidates PEM certificates. Supports immediate replace of TLS certificates without listener restart. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
