### PR TITLE
Add status command to vmq-admin node

### DIFF
--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -56,6 +56,7 @@ register_cli() ->
     vmq_config_cli:register_config(),
     register_cli_usage(),
     vmq_server_start_cmd(),
+    vmq_server_status_cmd(),
     vmq_server_stop_cmd(),
     vmq_server_show_cmd(),
     vmq_server_metrics_cmd(),
@@ -81,6 +82,7 @@ register_cli_usage() ->
     clique:register_usage(["vmq-admin"], fun usage/0),
     clique:register_usage(["vmq-admin", "node"], node_usage()),
     clique:register_usage(["vmq-admin", "node", "start"], start_usage()),
+    clique:register_usage(["vmq-admin", "node", "status"], status_usage()),
     clique:register_usage(["vmq-admin", "node", "stop"], stop_usage()),
     clique:register_usage(["vmq-admin", "node", "upgrade"], upgrade_usage()),
 
@@ -114,6 +116,16 @@ vmq_server_start_cmd() ->
         _ = application:ensure_all_started(vmq_server),
         [clique_status:text("Done")]
     end,
+    clique:register_command(Cmd, [], [], Callback).
+
+vmq_server_status_cmd() ->
+    Cmd = ["vmq-admin", "node", "status"],
+    Callback = fun(_, _, _) ->
+        {ok, Status} = vmq_info:node_status(),
+        Table = [[{'Status', Key}, {'Value', Value}] || {Key, Value} <- Status],
+        [clique_status:table(Table)]
+    end,
+
     clique:register_command(Cmd, [], [], Callback).
 
 vmq_server_show_cmd() ->
@@ -665,6 +677,12 @@ start_usage() ->
         "  when starting the service.\n"
     ].
 
+status_usage() ->
+    [
+        "vmq-admin node status\n\n",
+        "  Prints status information about the node\n"
+    ].
+
 stop_usage() ->
     [
         "vmq-admin node stop\n\n",
@@ -743,6 +761,7 @@ node_usage() ->
         "vmq-admin node <sub-command>\n\n",
         "  Administrate this VerneMQ node.\n\n",
         "  Sub-commands:\n",
+        "    status      Prints status information\n",
         "    start       Start the server application\n",
         "    stop        Stop the server application\n\n",
         "  Use --help after a sub-command for more details.\n"


### PR DESCRIPTION
## Proposed Changes

Adds a status command to vmq-admin that shows the same information as the status page. This makes it available as vmq-admin command, as well as via the v1 api.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
