### PR TITLE
Add a new delayed subscription strategy for topics with retained mess…

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -43,6 +43,23 @@
  [{default, on},
   {datatype, flag}]}.
 
+%% Retrain subscriber mode defines if subscribers on topics with retrained flag set should wait for 
+%% a retrain server sync or process immmediatly.
+{mapping, "subscriber_retain_mode", "vmq_server.subscriber_retain_mode", [
+                                                               {default, immediate},
+                                                               {datatype, atom},
+                                                               hidden
+                                                              ]}.
+
+{translation, "vmq_server.subscriber_retain_mode",
+ fun(Conf) ->
+         case cuttlefish:conf_get("subscriber_retain_mode", Conf) of
+             immediate -> immediate;
+             syncwait -> syncwait;
+             _ -> cuttlefish:invalid("subscriber_retain_mode must be either 'immediate' or 'syncwait'!")
+         end
+ end}.
+
 %% @doc queue_type enables to change the default queue delivery behaviour from
 %% 'fifo' to 'lifo'. In order to make this work the underlying message store
 %% must deliver the messages in proper order.

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -64,7 +64,8 @@ register_config_() ->
             "suppress_lwt_on_session_takeover",
             "coordinate_registrations",
             "mqtt_connect_timeout",
-            "disconnect_on_unauthorized_publish_v3"
+            "disconnect_on_unauthorized_publish_v3",
+            "subscriber_retain_mode"
         ],
     _ = [
         clique:register_config([Key], fun register_config_callback/2)

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -49,6 +49,8 @@
         {max_offline_messages, -1},
         % balance vs fanout
         {queue_deliver_mode, fanout},
+        % subscriber retain mode immediate
+        {subscriber_retain_mode, immediate},
         % fifo vs lifo
         {queue_type, fifo},
         % never

--- a/apps/vmq_server/test/vmq_retain_SUITE.erl
+++ b/apps/vmq_server/test/vmq_retain_SUITE.erl
@@ -28,8 +28,16 @@ end_per_suite(_Config) ->
     _Config.
 
 init_per_group(mqttv4, Config) ->
+    vmq_server_cmd:set_config(subscriber_retain_mode, immediate),
     [{protover, 4}|Config];
 init_per_group(mqttv5, Config) ->
+    vmq_server_cmd:set_config(subscriber_retain_mode, immediate),
+    [{protover, 5}|Config];
+init_per_group(mqttv4waitsync, Config) ->
+    vmq_server_cmd:set_config(subscriber_retain_mode, waitsync),
+    [{protover, 4}|Config];
+init_per_group(mqttv5waitsync, Config) ->
+    vmq_server_cmd:set_config(subscriber_retain_mode, waitsync),
     [{protover, 5}|Config].
 
 end_per_group(_Group, _Config) ->
@@ -44,7 +52,9 @@ end_per_testcase(_, Config) ->
 all() ->
     [
      {group, mqttv4},
-     {group, mqttv5}
+     {group, mqttv4waitsync},
+     {group, mqttv5},
+     {group, mqttv5waitsync}
     ].
 
 groups() ->

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- New feature: Synchronized wait for retrained message store
 - Add option for a default rule ("*") in database Lua scripts, so that Clients can fallback to default ACLs.
 
 ## VerneMQ 2.0 Release Candidate


### PR DESCRIPTION
Add a new delayed subscription strategy for topics with retained messages. Due to the fact that the retrain service and the message push are separate subsystems this is mitigate the unfortunate situation when a subscriber subscribes slightly after the messaging system has send the message, and slightly before the retrain sync has completed. This only affects clustered setups which use retrained messages.

## Proposed Changes
- Add a new strategy that let subscribers wait for the retrain subystem to sync
- New messages will still be accepted, just delayed until the subsystem has synced
- After the sync, the retrained message is added to the beginning of the queue

Implications:
- The new function QFun in vmq_queue might hurt performance slightly - did not measure yet. Could maybe rewritten in a way that it uses pattern matching... 
- It is possible to get the very same message twice (the retrained one, and the original one, based on some unfortunate timing)

This PR is just to see if there is interest in finalizing this, or if we want to stick with the original design. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1633 )
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
