### PR TITLE
Strengthen default config of vmq_http_v2_api

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -380,7 +380,7 @@
 %% - listener.http.$name.http_module.$module.auth.mode
 %% - listener.https.$name.http_module.$module.auth.mode
 %%
-%% The default for vmq_http_mgmt_api is "apikey", for all others it is noauth.
+%% The default for vmq_http_mgmt_api, vmq_http_v2 and vmq_http_pub is "apikey", for all others it is noauth.
 {mapping, "http_module.$name.auth.mode", "vmq_server.http_modules_auth", [{datatype, string}, {default, "noauth"},
                                                                                hidden
                                                                                 ]}.
@@ -388,6 +388,9 @@
                                                                                hidden
                                                                                 ]}.
 {mapping, "http_module.vmq_http_pub.auth.mode", "vmq_server.http_modules_auth", [{datatype, string}, {default, "apikey"},
+                                                                               hidden
+                                                                                ]}.
+{mapping, "http_module.vmq_http_v2_api.auth.mode", "vmq_server.http_modules_auth", [{datatype, string}, {default, "apikey"},
                                                                                hidden
                                                                                 ]}.
 {mapping, "listener.http.$name.http_module.$module.auth.mode", "vmq_server.http_listener_modules_auth", [{datatype, string},

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- 'vmq_http_api_v2': Set apikey as new default authentication method
 - Bugfix: Remove 'vmq_http_pub' from default listener group and enforce apikey as default (#2222)
 - New feature: "null" message store that disables persisting messages
 - Add environment variable support for erlang configuration arguments


### PR DESCRIPTION
## Proposed Changes

vmq_http_v2_api enforces apikey as a default just as the v1 mgmt api. It is to some degree a breaking change.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
