### PR TITLE
Allow downgrade of warning "keepalive expired" from warning to info

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -131,6 +131,18 @@
                                                                             hidden
                                                                            ]}.
 
+%% @doc Client disconnect due to keepalive is by default a warning. In unstable networks
+%% it might be "expected" behaviour to have a lot of those warnings. This allows to 
+%% downgrade the warning to an info message.
+{mapping, "logging.keepalive_as_warning", "vmq_server.logging", [
+                                                            {datatype, flag},
+                                                            {default, on}
+                                                           ]}.
+
+{translation, "vmq_server.logging",
+ fun(Conf) ->
+    [{keep_alive_as_warning, cuttlefish:conf_get("logging.keepalive_as_warning", Conf, true)}]
+ end}.
 
 %% @doc Allows to select a new default reg_view.
 %% A view is a pre-defined way to route messages. Multiple views can be

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -828,9 +828,16 @@ connected(
     Now = os:timestamp(),
     case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
         true ->
-            lager:warning("client ~p with username ~p stopped due to keepalive expired", [
-                SubscriberId, UserName
-            ]),
+            case proplists:get_value(keepalive_as_warning, vmq_config:get_env(logging, []), true) of
+                false ->
+                    lager:info("client ~p with username ~p stopped due to keepalive expired", [
+                        SubscriberId, UserName
+                    ]);
+                _ ->
+                    lager:warning("client ~p with username ~p stopped due to keepalive expired", [
+                        SubscriberId, UserName
+                    ])
+            end,
             _ = vmq_metrics:incr(?MQTT5_CLIENT_KEEPALIVE_EXPIRED),
             terminate(?KEEP_ALIVE_TIMEOUT, State);
         false ->

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -533,11 +533,18 @@ connected(
     Now = os:timestamp(),
     case timer:now_diff(Now, Last) > (1500000 * KeepAlive) of
         true ->
-            lager:warning("client ~p with username ~p stopped due to keepalive expired", [
-                SubscriberId, UserName
-            ]),
+            case proplists:get_value(keepalive_as_warning, vmq_config:get_env(logging, []), true) of
+                false ->
+                    lager:info("client ~p with username ~p stopped due to keepalive expired", [
+                        SubscriberId, UserName
+                    ]);
+                _ ->
+                    lager:warning("client ~p with username ~p stopped due to keepalive expired", [
+                        SubscriberId, UserName
+                    ])
+            end,
             _ = vmq_metrics:incr(?MQTT4_CLIENT_KEEPALIVE_EXPIRED),
-            terminate(normal, State);
+            terminate(keep_alive_timeout, State);
         false ->
             set_keepalive_check_timer(KeepAlive),
             {State, []}

--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -183,6 +183,8 @@ teardown(#st{socket = Socket, fsm_mod = FsmMod, fsm_state = FsmState}, Reason) -
             lager:debug("session normally stopped", []);
         shutdown ->
             lager:debug("session stopped due to shutdown", []);
+        keep_alive_timeout ->
+            lager:debug("session stopped due to keep_alive_timeout", []);
         _ ->
             SubscriberId = apply(FsmMod, subscriber, [FsmState]),
             lager:warning("session for ~p stopped abnormally due to '~p'", [SubscriberId, Reason])

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- New feature: Allow downgrade of client stopped due to keepalive from warning to info message (logging.keepalive_as_warning = off)
 - Bugix: Persist QoS0 to disk in case of outgoing upgrade_qos (#2220)
 - 'vmq_http_api_v2': Set apikey as new default authentication method
 - Bugfix: Remove 'vmq_http_pub' from default listener group and enforce apikey as default (#2222)


### PR DESCRIPTION
## Proposed Changes
In unstable networks a loss of connectivity of the client will lead to a disconnect because of expired keepalives. In such environments it is expected behaviour to see a lot of keepalive expired message. This PR allows to downgrade the warning to an info message.

logging.keepalive_as_warning = off

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
