### PR TITLE
Optional feature for forced disconnect on unauthorized mqtt31 publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ plts_base/
 .tool-versions
 
 data/
+.idea/
 

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -282,8 +282,8 @@
                                                                   hidden]}.
 
 %% @doc Allows a session that changes from offline to online to override the maximum
-%% online message count (max_online_messages). All offlines messages will be added 
-%% to the online queue. 
+%% online message count (max_online_messages). All offlines messages will be added
+%% to the online queue.
 {mapping, "override_max_online_messages", "vmq_server.override_max_online_messages", [{default, off},
                                                   {datatype, flag}
                                                   ]}.
@@ -2247,3 +2247,10 @@
          true;
     (Name) -> vmq_schema_util:file_is_pem_content(Name)
  end}.
+
+%% @doc Disconnect v3.1 clients in case they are not authorized to publish. This breaks the MQTT 3.1 specification
+%% and is intended for old unpatchable MQTT 3.1 client devices.
+{mapping, "disconnect_on_unauthorized_publish_v3", "vmq_server.disconnect_on_unauthorized_publish_v3", [{default, off},
+                                                                                                        {datatype, flag},
+                                                                                                        hidden
+                                                                                                       ]}.

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -65,7 +65,8 @@ register_config_() ->
             "receive_max_broker",
             "suppress_lwt_on_session_takeover",
             "coordinate_registrations",
-            "mqtt_connect_timeout"
+            "mqtt_connect_timeout",
+            "disconnect_on_unauthorized_publish_v3"
         ],
     _ = [
         clique:register_config([Key], fun register_config_callback/2)

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -81,6 +81,9 @@
     %% present and default value if not present.
     def_opts :: map(),
 
+    %% disconnect on unauthorized publish, even for non MQTT 3.1.1 clients
+    disconnect_on_unauthorized_publish_v3 = false :: boolean(),
+
     %% TODO
     trace_fun :: undefined | any()
 }).
@@ -141,6 +144,9 @@ init(
         allow_subscribe = CAPSubscribe,
         allow_unsubscribe = CAPUnsubscribe
     },
+    DisconnectOnUnauthorizedPublishV3 = vmq_config:get_env(
+        disconnect_on_unauthorized_publish_v3, false
+    ),
     TraceFun = vmq_config:get_env(trace_fun, undefined),
     DOpts0 = set_defopt(suppress_lwt_on_session_takeover, false, #{}),
     DOpts1 = set_defopt(coordinate_registrations, ?COORDINATE_REGISTRATIONS, DOpts0),
@@ -169,6 +175,7 @@ init(
         cap_settings = CAPSettings,
         reg_view = RegView,
         def_opts = DOpts1,
+        disconnect_on_unauthorized_publish_v3 = DisconnectOnUnauthorizedPublishV3,
         trace_fun = TraceFun
     },
 
@@ -1032,13 +1039,15 @@ dispatch_publish_qos0(_MessageId, Msg, State) ->
         subscriber_id = SubscriberId,
         proto_ver = Proto,
         cap_settings = CAPSettings,
-        reg_view = RegView
+        reg_view = RegView,
+        disconnect_on_unauthorized_publish_v3 = DisconnectOnUnauthorizedPublishV3
     } = State,
     case publish(CAPSettings, RegView, User, SubscriberId, Msg) of
         {ok, _, SessCtrl} ->
             {[], SessCtrl};
-        {error, not_allowed} when ?IS_PROTO_4(Proto) ->
+        {error, not_allowed} when ?IS_PROTO_4(Proto); DisconnectOnUnauthorizedPublishV3 ->
             %% we have to close connection for 3.1.1
+            %% or if force disconnect on unauthorized publish, even for non MQTT 3.1.1 clients, is configured
             _ = vmq_metrics:incr_mqtt_error_auth_publish(),
             {error, not_allowed};
         {error, _Reason} ->
@@ -1057,14 +1066,16 @@ dispatch_publish_qos1(MessageId, Msg, State) ->
         subscriber_id = SubscriberId,
         proto_ver = Proto,
         cap_settings = CAPSettings,
-        reg_view = RegView
+        reg_view = RegView,
+        disconnect_on_unauthorized_publish_v3 = DisconnectOnUnauthorizedPublishV3
     } = State,
     case publish(CAPSettings, RegView, User, SubscriberId, Msg) of
         {ok, _, SessCtrl} ->
             _ = vmq_metrics:incr_mqtt_puback_sent(),
             {[#mqtt_puback{message_id = MessageId}], SessCtrl};
-        {error, not_allowed} when ?IS_PROTO_4(Proto) ->
+        {error, not_allowed} when ?IS_PROTO_4(Proto); DisconnectOnUnauthorizedPublishV3 ->
             %% we have to close connection for 3.1.1
+            %% or if force disconnect on unauthorized publish, even for non MQTT 3.1.1 clients, is configured
             _ = vmq_metrics:incr_mqtt_error_auth_publish(),
             {error, not_allowed};
         {error, not_allowed} ->
@@ -1089,7 +1100,8 @@ dispatch_publish_qos2(MessageId, Msg, State) ->
         proto_ver = Proto,
         cap_settings = CAPSettings,
         reg_view = RegView,
-        waiting_acks = WAcks
+        waiting_acks = WAcks,
+        disconnect_on_unauthorized_publish_v3 = DisconnectOnUnauthorizedPublishV3
     } = State,
     case maps:get({qos2, MessageId}, WAcks, not_found) of
         not_found ->
@@ -1104,8 +1116,9 @@ dispatch_publish_qos2(MessageId, Msg, State) ->
                         [Frame],
                         SessCtrl
                     };
-                {error, not_allowed} when ?IS_PROTO_4(Proto) ->
+                {error, not_allowed} when ?IS_PROTO_4(Proto); DisconnectOnUnauthorizedPublishV3 ->
                     %% we have to close connection for 3.1.1
+                    %% or if force disconnect on unauthorized publish, even for non MQTT 3.1.1 clients, is configured
                     _ = vmq_metrics:incr_mqtt_error_auth_publish(),
                     {error, not_allowed};
                 {error, not_allowed} ->

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -34,6 +34,7 @@ end_per_group(_Group, _Config) ->
 init_per_testcase(Case, Config) ->
     vmq_test_utils:seed_rand(Config),
     vmq_server_cmd:set_config(allow_anonymous, true),
+    vmq_server_cmd:set_config(disconnect_on_unauthorized_publish_v3, false),
     vmq_server_cmd:set_config(retry_interval, 2),
     vmq_server_cmd:set_config(max_client_id_size, 100),
     vmq_server_cmd:set_config(topic_alias_max_client, 0),
@@ -84,6 +85,9 @@ groups() ->
                    not_allowed_publish_close_qos0_mqtt_3_1,
                    not_allowed_publish_close_qos1_mqtt_3_1,
                    not_allowed_publish_close_qos2_mqtt_3_1,
+                   not_allowed_publish_close_qos0_mqtt_3_1_forced_disconnect,
+                   not_allowed_publish_close_qos1_mqtt_3_1_forced_disconnect,
+                   not_allowed_publish_close_qos2_mqtt_3_1_forced_disconnect,
                    message_size_exceeded_close]},
      {mqttv4, [shuffle], [
                    not_allowed_publish_close_qos0_mqtt_3_1_1,
@@ -640,6 +644,41 @@ not_allowed_publish_close_qos2_mqtt_3_1(_) ->
     %% we receive proper pubrec
     ok = packet:expect_packet(Socket, "pubrec", Pubrec),
     gen_tcp:close(Socket).
+
+
+not_allowed_publish_close_qos0_mqtt_3_1_forced_disconnect(_) ->
+    vmq_server_cmd:set_config(disconnect_on_unauthorized_publish_v3, true),
+    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60}]),
+    Connack = packet:gen_connack(0),
+    Topic = "test/topic/not_allowed",
+    Publish = packet:gen_publish(Topic, 0, <<"message">>, []),
+    vmq_test_utils:reset_tables(),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    gen_tcp:send(Socket, Publish),
+    {error, closed} = gen_tcp:recv(Socket, 0, 1000).
+
+not_allowed_publish_close_qos1_mqtt_3_1_forced_disconnect(_) ->
+    vmq_server_cmd:set_config(disconnect_on_unauthorized_publish_v3, true),
+    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60}]),
+    Connack = packet:gen_connack(0),
+    Topic = "test/topic/not_allowed",
+    Publish = packet:gen_publish(Topic, 1, <<"message">>, [{mid, 1}]),
+    vmq_test_utils:reset_tables(),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    gen_tcp:send(Socket, Publish),
+    {error, closed} = gen_tcp:recv(Socket, 0, 1000).
+
+not_allowed_publish_close_qos2_mqtt_3_1_forced_disconnect(_) ->
+    vmq_server_cmd:set_config(disconnect_on_unauthorized_publish_v3, true),
+    Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60}]),
+    Connack = packet:gen_connack(0),
+    Topic = "test/topic/not_allowed",
+    Publish = packet:gen_publish(Topic, 2, <<"message">>, [{mid, 1}]),
+    vmq_test_utils:reset_tables(),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    gen_tcp:send(Socket, Publish),
+    {error, closed} = gen_tcp:recv(Socket, 0, 1000).
+
 
 not_allowed_publish_close_qos0_mqtt_3_1_1(_) ->
     Connect = packet:gen_connect("pattern-sub-test", [{keepalive, 60},

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - Add new command to vmq-admin to clear webhook cache (webhooks cache clear)
 - 'vmq_admin': Add commands allowing batch disconnects (vmq-admin session disconnect batch and vmq-admin session disconnect clients)
 - 'vmq_http_pub': Allow anonymous access (allow_anonymous = on)
+- New feature: Add configuration option disconnect_on_unauthorized_publish_v3 to force disconnect on unauthorized publish even for MQTT clients before v3.1.1
 
 
 ## VerneMQ 1.13.0


### PR DESCRIPTION
## Proposed Changes

For MQTT 3.1 there is a gap in the definition what do if authorization of a publish request fails, only the happy path is described and defines to answer with acknowledgements depending of the QoS level.
So for MQTT 3.1 clients with no possibility to update to MQTT 3.1.1 there is no way to figure out, if the message was accepted by the authentication or not. Only breaking MQTT 3.1 compatibility and forcing a disconnect may help to prevent sending the ACK to the client in case of an authentication failure. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

