### PR TITLE
Expose more info (props) when publishing to internal plugin client

### DIFF
--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -236,7 +236,7 @@ handle_info(
     ),
     {noreply, State};
 handle_info(
-    {deliver, Topic, Payload, _QoS, IsRetained, _IsDup},
+    {deliver, Topic, Payload, _QoS, IsRetained, _IsDup, _Info},
     #state{subs_local = Subscriptions, client_pid = ClientPid} = State
 ) ->
     %% forward matching, locally published messages to the remote broker.

--- a/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm_util.erl
@@ -65,11 +65,15 @@ plugin_receive_loop(PluginPid, PluginMod) ->
                                 routing_key = RoutingKey,
                                 payload = Payload,
                                 retain = IsRetain,
-                                dup = IsDup
+                                dup = IsDup,
+                                mountpoint = Mountpoint,
+                                properties = PropsMap,
+                                expiry_ts = ExpiryTS
                             }
                         }
                     ) ->
-                        PluginPid ! {deliver, RoutingKey, Payload, QoS, IsRetain, IsDup};
+                        Info = {Mountpoint, PropsMap, ExpiryTS},
+                        PluginPid ! {deliver, RoutingKey, Payload, QoS, IsRetain, IsDup, Info};
                     (Msg) ->
                         lager:warning("dropped message ~p for plugin ~p", [Msg, PluginMod]),
                         ok

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -1182,7 +1182,7 @@ direct_plugin_exports_test(Cfg) ->
     vmq_cluster_test_utils:wait_until(fun() -> TestSub(WTopic, true) end, 100, 10),
     {ok, {1, 0}} = PubFun3(WTopic, <<"msg1">>, #{}),
     receive
-        {deliver, WTopic, <<"msg1">>, 0, false, false} -> ok;
+        {deliver, WTopic, <<"msg1">>, 0, false, false, _Info} -> ok;
         Other -> throw({received_unexpected_msg, Other})
     after
         1000 ->


### PR DESCRIPTION
Internal plugin subscriber (direct_plugin_exports) use a receive loop, not a "typed" (MQTT v4 or v5) session.
Internal plugins still might want to implement behaviour that is dependent on publish properties, namely the v5 user_properties.
We therefore need to expose more information to the plugin, coming from an incoming PUBLISH.

This is a breaking change to internal plugin implementations but can be handled easily.
Plugins capturing PUBLISH frames will have to extend the captured `deliver` message, see `_Info` variable below. The plugin decides whether to ignore or handle this additional information.

```erlang
handle_info(
    {deliver, Topic, Payload, _QoS, IsRetained, _IsDup, _Info},
```