### PR TITLE
Trigger a non-zero script exit code if the cluster join command fails

### DIFF
--- a/apps/vmq_server/src/vmq_server_cli.erl
+++ b/apps/vmq_server/src/vmq_server_cli.erl
@@ -494,8 +494,7 @@ vmq_cluster_join_cmd() ->
                     vmq_cluster:recheck(),
                     [clique_status:text("Done")];
                 {error, Reason} ->
-                    Text = io_lib:format("Couldn't join cluster due to ~p~n", [Reason]),
-                    [clique_status:alert([clique_status:text(Text)])]
+                    {error, {{badrpc, Reason}, Node}}
             end
     end,
     clique:register_command(Cmd, KeySpecs, FlagSpecs, Callback).


### PR DESCRIPTION
Fixes https://github.com/vernemq/vernemq/issues/1971
This makes `clique` generate a non-zero exit code.
