### PR TITLE
Make number of generic msg store buckets configurable

### DIFF
--- a/apps/vmq_generic_msg_store/priv/vmq_generic_msg_store.schema
+++ b/apps/vmq_generic_msg_store/priv/vmq_generic_msg_store.schema
@@ -1,14 +1,32 @@
 %% -*- mode: erlang -*-
 %% ex: ft=erlang
 
-{mapping, "leveldb_message_store.directory", "vmq_generic_msg_store.msg_store_opts.store_dir", [
+{mapping, "vmq_generic_msg_store.store_dir", "vmq_generic_msg_store.store_dir", [
                                                                             {default, "{{platform_data_dir}}/msgstore"},
                                                                             {datatype, directory},
                                                                             hidden
                                                                            ]}.
 
-{mapping, "generic_message_store_engine", "vmq_generic_msg_store.msg_store_engine", 
- [{default, vmq_storage_engine_leveldb},
+{mapping, "vmq_generic_msg_store.db_backend", "vmq_generic_msg_store.db_backend",
+ [{default, leveldb},
   {datatype, atom},
   hidden
  ]}.
+
+ {mapping, "vmq_generic_msg_store.nr_of_buckets", "vmq_generic_msg_store.nr_of_buckets",
+ [{default, 12},
+  {datatype, integer},
+  hidden
+ ]}.
+
+ {translation,
+ "vmq_generic_msg_store.db_backend",
+ fun(Conf) ->
+    Setting = cuttlefish:conf_get("vmq_generic_msg_store.db_backend", Conf),
+    case Setting of
+      leveldb -> vmq_storage_engine_leveldb;
+      rocksdb -> vmq_storage_engine_rocksdb;
+      leveled -> vmq_storage_engine_leveled
+    end
+  end
+}.

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.app.src
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.app.src
@@ -1,5 +1,5 @@
 {application, vmq_generic_msg_store, [
-    {description, "A VerneMQ plugin that sets up LevelDB as message storage"},
+    {description, "A VerneMQ plugin that sets up a local message storage"},
     {vsn, git},
     {registered, []},
     {mod, {vmq_generic_msg_store_app, []}},
@@ -16,9 +16,7 @@
             {vmq_generic_msg_store, msg_store_find, 2, [internal]},
             {vmq_generic_msg_store, msg_store_read, 2, [internal]}
         ]},
-        {msg_store_engine, vmq_storage_engine_leveldb},
         {msg_store_opts, [
-            {store_dir, "./data/msgstore"},
             {open_retries, 30},
             {open_retry_delay, 2000}
         ]}

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
@@ -184,9 +184,9 @@ init([InstanceId]) ->
     %% Initialize random seed
     rand:seed(exsplus, os:timestamp()),
 
-    {ok, EngineModule} = application:get_env(vmq_generic_msg_store, msg_store_engine),
+    {ok, EngineModule} = application:get_env(vmq_generic_msg_store, db_backend),
     Opts = application:get_env(vmq_generic_msg_store, msg_store_opts, []),
-    DataDir1 = proplists:get_value(store_dir, Opts, "data/msgstore"),
+    DataDir1 = application:get_env(vmq_generic_msg_store, store_dir, "data/msgstore"),
     DataDir2 = filename:join(DataDir1, integer_to_list(InstanceId)),
 
     process_flag(trap_exit, true),

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
@@ -184,7 +184,7 @@ init([InstanceId]) ->
     %% Initialize random seed
     rand:seed(exsplus, os:timestamp()),
 
-    {ok, EngineModule} = application:get_env(vmq_generic_msg_store, db_backend),
+    EngineModule = application:get_env(vmq_generic_msg_store, db_backend, vmq_storage_engine_leveldb),
     Opts = application:get_env(vmq_generic_msg_store, msg_store_opts, []),
     DataDir1 = application:get_env(vmq_generic_msg_store, store_dir, "data/msgstore"),
     DataDir2 = filename:join(DataDir1, integer_to_list(InstanceId)),

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.erl
@@ -184,7 +184,9 @@ init([InstanceId]) ->
     %% Initialize random seed
     rand:seed(exsplus, os:timestamp()),
 
-    EngineModule = application:get_env(vmq_generic_msg_store, db_backend, vmq_storage_engine_leveldb),
+    EngineModule = application:get_env(
+        vmq_generic_msg_store, db_backend, vmq_storage_engine_leveldb
+    ),
     Opts = application:get_env(vmq_generic_msg_store, msg_store_opts, []),
     DataDir1 = application:get_env(vmq_generic_msg_store, store_dir, "data/msgstore"),
     DataDir2 = filename:join(DataDir1, integer_to_list(InstanceId)),

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.hrl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store.hrl
@@ -2,4 +2,4 @@
 -include_lib("vmq_commons/include/vmq_types.hrl").
 
 -define(TBL_MSG_INIT, vmq_generic_msg_store_init_msg_idx).
--define(NR_OF_BUCKETS, 12).
+-define(NR_OF_BUCKETS, persistent_term:get({vmq_msg_store, bucks})).

--- a/apps/vmq_generic_msg_store/src/vmq_generic_msg_store_app.erl
+++ b/apps/vmq_generic_msg_store/src/vmq_generic_msg_store_app.erl
@@ -23,6 +23,8 @@
 %% API
 %%====================================================================
 start(_StartType, _StartArgs) ->
+    Buckets = application:get_env(vmq_generic_msg_store, nr_of_buckets, 12),
+    persistent_term:put({vmq_msg_store, bucks}, Buckets),
     vmq_generic_msg_store_sup:start_link().
 
 %%--------------------------------------------------------------------

--- a/apps/vmq_generic_msg_store/test/vmq_generic_msg_store_SUITE.erl
+++ b/apps/vmq_generic_msg_store/test/vmq_generic_msg_store_SUITE.erl
@@ -40,7 +40,7 @@ init_per_testcase(idx_compat_pre_test, Config) ->
 init_per_testcase(_Case, Config) ->
     StorageEngine = proplists:get_value(engine, Config),
     application:load(vmq_generic_msg_store),
-    application:set_env(vmq_generic_msg_store, msg_store_engine, StorageEngine),
+    application:set_env(vmq_generic_msg_store, db_backend, StorageEngine),
     application:ensure_all_started(vmq_generic_msg_store),
     Config.
 

--- a/apps/vmq_server/test/vmq_cluster_test_utils.erl
+++ b/apps/vmq_server/test/vmq_cluster_test_utils.erl
@@ -154,10 +154,9 @@ start_node(Name, _Config, Case) ->
                                                                 []}]}
                                                        ]]),
             ok = rpc:call(Node, application, set_env, [vmq_generic_msg_store,
-                                                       msg_store_opts,
-                                                       [{store_dir,
-                                                         NodeDir++"/msgstore"}]
-                                                      ]),
+                                                       store_dir,
+                                                       NodeDir ++ "/msgstore"]
+                                                      ),
             ok = rpc:call(Node, application, set_env, [vmq_plugin,
                                                        wait_for_proc,
                                                        vmq_server_sup]),

--- a/apps/vmq_server/test/vmq_test_utils.erl
+++ b/apps/vmq_server/test/vmq_test_utils.erl
@@ -31,7 +31,7 @@ setup() ->
     %                                                  {open_retries, 30},
     %                                                  {open_retry_delay, 2000}
     %                                                 ]),
-    application:set_env(vmq_generic_msg_store, msg_store_engine, vmq_storage_engine_leveldb),
+    application:set_env(vmq_generic_msg_store, db_backend, vmq_storage_engine_leveldb),
     LogDir = "log." ++ atom_to_list(node()),
     application:load(lager),
     application:set_env(lager, handlers, [


### PR DESCRIPTION
This also serves to align naming:

```
vmq_swc.data_dir
vmq_swc.db_backend

vmq_generic_msg_store.data_dir
vmq_generic_msg_store.db_backend
```