### PR TITLE
Expose max_header_value_length for http listeners

### DIFF
--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -364,6 +364,8 @@ protocol_opts(cowboy_clear, Type, Opts) when
         end,
     maps:merge(maps:from_list(MOpts), #{
         env => #{dispatch => dispatch(Type, Opts)},
+        max_request_line_length => 16384,
+        max_header_value_length => 16384,
         stream_handlers => [vmq_cowboy_websocket_h, cowboy_stream_h]
     });
 protocol_opts(cowboy_clear, _, Opts) ->

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- Increase default value of `max_header_value_length` and `max_request_line_length` for Websocket listeners to 16384 bytes
 - Add option for a default rule ("*") in database Lua scripts, so that Clients can fallback to default ACLs.
 
 ## VerneMQ 2.0 Release Candidate


### PR DESCRIPTION
## Proposed Changes

Fix for https://github.com/vernemq/vernemq/issues/2267 - expose max_header_value_length, so that websocket connection can be established from frontend applications with bigger cookies.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #2267)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

I have never done any work in Erlang, did not set up local dev env, changes are done by mirroring https://github.com/vernemq/vernemq/pull/2161
I will create another PR in docs repo to save other devs some time next time. 