### PR TITLE
POC of no_overlap registry view

### DIFF
--- a/apps/vmq_server/src/vmq_reg_no_overlap_ordered_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_no_overlap_ordered_trie.erl
@@ -170,7 +170,7 @@ sort_subs(Subs) ->
         end,
         Subs
     ).
- 
+
 apply_sort(Map) ->
     % We sort the subs with descending QoS, then just select the first.
     % We can add more sort criteria if needed.


### PR DESCRIPTION
Did a PoC yesterday evening on a registry that does not deliver multiple messages in case of overlapping subscriptions, while keeping the original trie structure.

What I've done here is inefficient. Uses `maps:groups_from_list/2` to create a map with sorted subscriptions as values and the ClientID as key. This is likely not usable for huge fanout scenarios. All the sorting will happen on every incoming `PUBLISH`.

Only tested on single node. Opening for visibility and to restart discussions: https://github.com/vernemq/vernemq/discussions/2254

To use:

```
default_reg_view = vmq_reg_no_overlap_ordered_trie
```

EDIT: (note to self): it seems `rebar3 fmt` cannot format map comprehensions. And `maps:group_from_list/2` was only added in OTP 25.

