### PR TITLE
vmq_diversity: set SSL to 'off' as a default in MySQL2 plugin

### DIFF
--- a/apps/vmq_diversity/priv/vmq_diversity.schema
+++ b/apps/vmq_diversity/priv/vmq_diversity.schema
@@ -349,7 +349,7 @@
 %% @doc Specify if the MySOL driver should use TLS or not.
 {mapping, "vmq_diversity.mysql2.ssl", "vmq_diversity.db_config.mysql2.ssl",
  [{datatype, flag},
-  {default, on}
+  {default, off}
  ]}.
 
 %% @doc The cafile is used to define the path to a file containing


### PR DESCRIPTION
Fixes https://github.com/vernemq/vernemq/issues/2339
It's more user-friendly to switch SSL on, if you need it, rather than switch it off if you don't.