### PR TITLE
Enhancement: Change key layout to optimise insert order

### DIFF
--- a/apps/vmq_server/src/vmq_subscriber_db.erl
+++ b/apps/vmq_server/src/vmq_subscriber_db.erl
@@ -51,7 +51,7 @@ fold(FoldFun, Acc) ->
         ?SUBSCRIBER_DB,
         fun
             ({_, ?TOMBSTONE}, AccAcc) -> AccAcc;
-            ({SubscriberId, Subs}, AccAcc) -> FoldFun({SubscriberId, Subs}, AccAcc)
+            ({{_Counter, SubscriberId}, Subs}, AccAcc) -> FoldFun({SubscriberId, Subs}, AccAcc)
         end,
         Acc
     ).

--- a/apps/vmq_swc/include/vmq_swc.hrl
+++ b/apps/vmq_swc/include/vmq_swc.hrl
@@ -24,7 +24,14 @@
 -type nodeclock() :: bvv().
 -type object() :: dcc().
 -type context() :: vv().
--type dotkeymap() :: vmq_swc_dkm:dkm().
+
+-record(dkm, {
+    latest :: ets:table(),
+    latest_candidates :: ets:table(),
+    gc_candidates :: ets:table()
+}).
+
+-type dotkeymap() :: #dkm{}.
 
 -define(DELETED, '$deleted').
 

--- a/apps/vmq_swc/src/vmq_swc.erl
+++ b/apps/vmq_swc/src/vmq_swc.erl
@@ -116,7 +116,6 @@ fold(SwcGroup, Fun, Acc, Prefix, Opts) ->
     ResolveMethod = get_option(resolver, Opts, fun max_resolver/1),
     AllowPut = get_option(allow_put, Opts, true),
     Config = config(SwcGroup),
-
     vmq_swc_store:fold_values(
         Config,
         fun
@@ -135,6 +134,8 @@ fold(SwcGroup, Fun, Acc, Prefix, Opts) ->
         Prefix
     ).
 
+maybe_resolve(_, _, {undefined, _}, _, _) ->
+    undefined;
 maybe_resolve(_Config, _PKey, {[Value], _Context}, _Method, _AllowPut) ->
     Value;
 maybe_resolve(Config, PKey, {Values, Context}, ResolverFun, AllowPut) ->

--- a/apps/vmq_swc/src/vmq_swc_db.erl
+++ b/apps/vmq_swc/src/vmq_swc_db.erl
@@ -61,8 +61,8 @@ get(Config, Type, Key) ->
     get(Config, Type, Key, []).
 
 -spec get(config(), type(), db_key(), opts()) -> {ok, db_value()} | not_found.
-get(#swc_config{db_backend = Backend} = Config, Type, Key, Opts) ->
-    vmq_swc_metrics:timed_measurement({?METRIC, read}, Backend, read, [Config, Type, Key, Opts]).
+get(#swc_config{db_backend = Backend} = Config, Type, PDKey, Opts) ->
+    vmq_swc_metrics:timed_measurement({?METRIC, read}, Backend, read, [Config, Type, PDKey, Opts]).
 
 -spec delete(config(), type(), db_key()) -> ok.
 delete(#swc_config{db_backend = Backend} = Config, Type, Key) ->

--- a/apps/vmq_swc/src/vmq_swc_dkm.erl
+++ b/apps/vmq_swc/src/vmq_swc_dkm.erl
@@ -80,19 +80,13 @@
 -define(CHECKOLD(OldId, Peers), lists:member(OldId, Peers)).
 -endif.
 
--record(dkm, {
-    latest = ets:new(?MODULE, [public]),
-    latest_candidates = ets:new(?MODULE, [public]),
-    gc_candidates = ets:new(?MODULE, [public])
-}).
-
--type dkm() :: #dkm{}.
-
--export_type([dkm/0]).
-
 -spec init() -> dotkeymap().
 init() ->
-    #dkm{}.
+    #dkm{
+        latest = ets:new(?MODULE, [public]),
+        latest_candidates = ets:new(?MODULE, [public]),
+        gc_candidates = ets:new(?MODULE, [public])
+    }.
 
 info(DKM, object_count) ->
     ets:info(DKM#dkm.latest, size);


### PR DESCRIPTION
Just a PoC (aka quick hack) at this point, probably some `lists:reverse` and `sext:decode/encodes` too many :)
The on-disk layout is incompatible with existing metadata stores, since the key layout is changed.
It should massively speed up inter-node synchronisation.
Should also address issues with increased CPU and/or RAM usage after a new node has joined. (let's see a bit)

I used the following batch and partition sizes for a bit of minimal testing:

```
vmq_swc.exchange_batch_size = 1000
vmq_swc.swc_groups = 10
```

Note: this is just an experiment to test insert speed, ie not final implementation. (since we need to keep key space finite, cannot use as is).