### PR TITLE
Enhancement: Do not load non-persistent subscriptions into routing ta…

### DIFF
--- a/apps/vmq_server/src/vmq_info.erl
+++ b/apps/vmq_server/src/vmq_info.erl
@@ -252,7 +252,7 @@ subscription_row_init(Row) ->
     SubscriberId = {maps:get('__mountpoint', Row), maps:get(client_id, Row)},
     Subs = vmq_reg:subscriptions_for_subscriber_id(SubscriberId),
     vmq_subscriber:fold(
-        fun({Topic, SubInfo, _Node}, Acc) ->
+        fun({Topic, SubInfo, _Node, _CS}, Acc) ->
             {QoS, SubOpts} =
                 case SubInfo of
                     {_, _} ->

--- a/apps/vmq_server/src/vmq_info.erl
+++ b/apps/vmq_server/src/vmq_info.erl
@@ -252,7 +252,7 @@ subscription_row_init(Row) ->
     SubscriberId = {maps:get('__mountpoint', Row), maps:get(client_id, Row)},
     Subs = vmq_reg:subscriptions_for_subscriber_id(SubscriberId),
     vmq_subscriber:fold(
-        fun({Topic, SubInfo, _Node, _CS}, Acc) ->
+        fun({Topic, SubInfo, _Node}, Acc) ->
             {QoS, SubOpts} =
                 case SubInfo of
                     {_, _} ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1082,8 +1082,8 @@ fold_subscriptions(FoldFun, Acc) ->
     fold_subscribers(
         fun({MP, _} = SubscriberId, Subs, AAcc) ->
             vmq_subscriber:fold(
-                fun({Topic, QoS, Node}, AAAcc) ->
-                    FoldFun({MP, Topic, {SubscriberId, QoS, Node}}, AAAcc)
+                fun({Topic, QoS, Node, CleanSession}, AAAcc) ->
+                    FoldFun({MP, Topic, {SubscriberId, QoS, Node, CleanSession}}, AAAcc)
                 end,
                 AAcc,
                 Subs

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1080,9 +1080,9 @@ subscribe_subscriber_changes() ->
 
 fold_subscriptions(FoldFun, Acc) ->
     fold_subscribers(
-        fun({MP, _} = SubscriberId, Subs, AAcc) ->
+        fun({MP, _} = SubscriberId, [{_, CleanSession, _}] = Subs, AAcc) ->
             vmq_subscriber:fold(
-                fun({Topic, QoS, Node, CleanSession}, AAAcc) ->
+                fun({Topic, QoS, Node}, AAAcc) ->
                     FoldFun({MP, Topic, {SubscriberId, QoS, Node, CleanSession}}, AAAcc)
                 end,
                 AAcc,

--- a/apps/vmq_server/src/vmq_reg_ordered_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_ordered_trie.erl
@@ -252,8 +252,11 @@ handle_info(
         queue:to_list(Q)
     ),
     NrOfSubscribers = ets:info(vmq_ordered_tree_subs, size),
+    NrOfRemoteSubscribers = ets:info(vmq_trie_remote_subs, size),
     persistent_term:put(subscribe_trie_ready, 1),
-    ?LOG_INFO("loaded ~p subscriptions into ~p", [NrOfSubscribers, ?MODULE]),
+    ?LOG_INFO("loaded ~p local subscriptions and ~p remote subscriptions into ~p", [
+        NrOfSubscribers, NrOfRemoteSubscribers, ?MODULE
+    ]),
     {noreply, State#state{status = ready, event_queue = undefined}};
 handle_info(Event, #state{status = init, event_queue = Q} = State) ->
     {noreply, State#state{event_queue = queue:in(Event, Q)}};
@@ -355,15 +358,23 @@ match_(Topic, [{NodeOrGroup, _} | Rest], Acc) ->
 match_(_, [], Acc) ->
     Acc.
 
-initialize_trie({MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node}}, Acc) ->
+initialize_trie(
+    {MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node, _CleanSession}}, Acc
+) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),
     add_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node}}, Acc) when Node =:= node() ->
+initialize_trie({_, _, {_, _, Node, CleanSession}}, Acc) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node, _CleanSession}}, Acc) when
+    Node =:= node()
+->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_subscriber(MP, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node}}, Acc) ->
+initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node, _CleanSession}}, Acc) ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_remote_subscriber(MP, Topic, Node),
     Acc.

--- a/apps/vmq_server/src/vmq_reg_ordered_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_ordered_trie.erl
@@ -359,6 +359,12 @@ match_(_, [], Acc) ->
     Acc.
 
 initialize_trie(
+    {_MP, [<<"$share">>, _Group | _Topic], {_SubscriberId, _SubInfo, Node, CleanSession}}, Acc
+) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie(
     {MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node, _CleanSession}}, Acc
 ) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -359,6 +359,12 @@ match_(_, [], Acc) ->
     Acc.
 
 initialize_trie(
+    {_MP, [<<"$share">>, _Group | _Topic], {_SubscriberId, _SubInfo, Node, CleanSession}}, Acc
+) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie(
     {MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node, _CleanSession}}, Acc
 ) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),

--- a/apps/vmq_server/src/vmq_reg_trie.erl
+++ b/apps/vmq_server/src/vmq_reg_trie.erl
@@ -252,8 +252,11 @@ handle_info(
         queue:to_list(Q)
     ),
     NrOfSubscribers = ets:info(vmq_trie_subs, size),
+    NrOfRemoteSubscribers = ets:info(vmq_trie_remote_subs, size),
     persistent_term:put(subscribe_trie_ready, 1),
-    ?LOG_INFO("loaded ~p subscriptions into ~p", [NrOfSubscribers, ?MODULE]),
+    ?LOG_INFO("loaded ~p local subscriptions and ~p remote subscriptions into ~p", [
+        NrOfSubscribers, NrOfRemoteSubscribers, ?MODULE
+    ]),
     {noreply, State#state{status = ready, event_queue = undefined}};
 handle_info(Event, #state{status = init, event_queue = Q} = State) ->
     {noreply, State#state{event_queue = queue:in(Event, Q)}};
@@ -355,15 +358,23 @@ match_(Topic, [{NodeOrGroup, _} | Rest], Acc) ->
 match_(_, [], Acc) ->
     Acc.
 
-initialize_trie({MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node}}, Acc) ->
+initialize_trie(
+    {MP, [<<"$share">>, Group | Topic], {SubscriberId, SubInfo, Node, _CleanSession}}, Acc
+) ->
     add_complex_topic(MP, Topic, {Node, Group}, true),
     add_subscriber_group(MP, Node, Group, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node}}, Acc) when Node =:= node() ->
+initialize_trie({_, _, {_, _, Node, CleanSession}}, Acc) when
+    Node =:= node(), CleanSession == true
+->
+    Acc;
+initialize_trie({MP, Topic, {SubscriberId, SubInfo, Node, _CleanSession}}, Acc) when
+    Node =:= node()
+->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_subscriber(MP, Topic, SubscriberId, SubInfo),
     Acc;
-initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node}}, Acc) ->
+initialize_trie({MP, Topic, {_SubscriberId, _SubInfo, Node, _CleanSession}}, Acc) ->
     add_complex_topic(MP, Topic, Node, vmq_topic:contains_wildcard(Topic)),
     add_remote_subscriber(MP, Topic, Node),
     Acc.

--- a/apps/vmq_server/src/vmq_subscriber.erl
+++ b/apps/vmq_server/src/vmq_subscriber.erl
@@ -273,10 +273,10 @@ get_node_subs(Node, Subs) ->
 fold(Fun, Acc, Subs) ->
     lists:foldl(
         fun
-            ({Node, _, NSubs}, AccAcc) ->
+            ({Node, CleanSession, NSubs}, AccAcc) ->
                 lists:foldl(
                     fun({Topic, SubInfo}, AccAccAcc) ->
-                        Fun({Topic, SubInfo, Node}, AccAccAcc)
+                        Fun({Topic, SubInfo, Node, CleanSession}, AccAccAcc)
                     end,
                     AccAcc,
                     NSubs

--- a/apps/vmq_server/src/vmq_subscriber.erl
+++ b/apps/vmq_server/src/vmq_subscriber.erl
@@ -273,10 +273,10 @@ get_node_subs(Node, Subs) ->
 fold(Fun, Acc, Subs) ->
     lists:foldl(
         fun
-            ({Node, CleanSession, NSubs}, AccAcc) ->
+            ({Node, _CleanSession, NSubs}, AccAcc) ->
                 lists:foldl(
                     fun({Topic, SubInfo}, AccAccAcc) ->
-                        Fun({Topic, SubInfo, Node, CleanSession}, AccAccAcc)
+                        Fun({Topic, SubInfo, Node}, AccAccAcc)
                     end,
                     AccAcc,
                     NSubs

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Enhancement: Do not populate routing and subscription tables with non-persistent sessions when booting from disk.
+
 ## VerneMQ 2.0.1
 
 - Bugfix: make session keepalive timers not use OS timestamps to protect against OS clock jumps


### PR DESCRIPTION
If a VerneMQ node boots, it will reload all subscription info into routing tables/subscription tables.

For non-persistent Clients (clean_session=true), we currently also populate the tables. I fail to see a reason why we did this... if anyone remembers one, let me know :)

Note that this did not create wrong subscriptions (the Clients are offline and any re-connect will rewrite their information in the routing tables). 

EDIT: v5 reauthorize test fixed.
