### PR TITLE
Init feature: forwarding connection opts (SSL client cert) to auth pl…

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -1826,6 +1826,37 @@
                                                                                   hidden
                                                                                  ]}.
 
+%% @doc If 'listener.ssl.forward_connection_opts' is enabled, VerneMQ will
+%% forward the full client certificate to the authentication plugin (in the
+%% auth_on_register hooks).
+%% Configure on protocol level (for all listeners):
+%%
+%%     - listener.ssl.forward_connection_opts
+%%     - listener.wss.forward_connection_opts
+%%
+%% or on the listener level:
+%%
+%%     - listener.ssl.my_ssl_listener.forward_connection_opts
+%%     - listener.wss.my_wss_listener.forward_connection_opts
+{mapping, "listener.ssl.forward_connection_opts", "vmq_server.listeners", [
+                                                                            {default, off},
+                                                                            {datatype, flag},
+                                                                            {commented, off}
+                                                                           ]}.
+{mapping, "listener.ssl.$name.forward_connection_opts", "vmq_server.listeners", [
+                                                                                  {datatype, flag},
+                                                                                  hidden
+                                                                                 ]}.
+{mapping, "listener.wss.forward_connection_opts", "vmq_server.listeners", [
+                                                                            {default, off},
+                                                                            {datatype, flag},
+                                                                            hidden
+                                                                           ]}.
+{mapping, "listener.wss.$name.forward_connection_opts", "vmq_server.listeners", [
+                                                                                  {datatype, flag},
+                                                                                  hidden
+                                                                                 ]}.                                       
+
 %% @doc If listener.ssl.pskfile is enabled VerneMQ supports TLS connection based on
 %% pre-shared keys (PSK).
 %%

--- a/apps/vmq_server/src/vmq_listener_cli.erl
+++ b/apps/vmq_server/src/vmq_listener_cli.erl
@@ -156,7 +156,11 @@ vmq_listener_start_cmd() ->
             end}
         ]},
         {psk_support, [
-            {longname, "psk_support"}
+            {longname, "psk_support"},
+            {typecast, fun
+                ("true") -> true;
+                ("false") -> false
+            end}
         ]},
         {ciphers, [
             {longname, "ciphers"},
@@ -175,7 +179,20 @@ vmq_listener_start_cmd() ->
                 end
             end}
         ]},
-        {require_certificate, [{longname, "require_certificate"}]},
+        {require_certificate, [
+            {longname, "require_certificate"},
+            {typecast, fun
+                ("true") -> true;
+                ("false") -> false
+            end}
+        ]},
+        {forward_connection_opts, [
+            {longname, "forward_connection_opts"},
+            {typecast, fun
+                ("true") -> true;
+                ("false") -> false
+            end}
+        ]},
         {tls_version, [
             {longname, "tls_version"},
             {typecast, fun
@@ -186,8 +203,20 @@ vmq_listener_start_cmd() ->
                 (V) -> {error, {invalid_flag_value, {'tls-version', V}}}
             end}
         ]},
-        {use_identity_as_username, [{longname, "use_identity_as_username"}]},
-        {allow_anonymous_override, [{longname, "allow_anonymous_override"}]},
+        {use_identity_as_username, [
+            {longname, "use_identity_as_username"},
+            {typecast, fun
+                ("true") -> true;
+                ("false") -> false
+            end}
+        ]},
+        {allow_anonymous_override, [
+            {longname, "allow_anonymous_override"},
+            {typecast, fun
+                ("true") -> true;
+                ("false") -> false
+            end}
+        ]},
         {config_mod, [
             {longname, "config_mod"},
             {typecast, fun(M) -> list_to_existing_atom(M) end}

--- a/apps/vmq_server/src/vmq_ranch.erl
+++ b/apps/vmq_server/src/vmq_ranch.erl
@@ -136,12 +136,18 @@ peer_info_no_proxy(undefined, Socket, Transport, Opts) ->
     end;
 peer_info_no_proxy(Peer, Socket, Transport, Opts) ->
     UseCN = proplists:get_value(use_identity_as_username, Opts, false),
+    ForwardConnOpts = proplists:get_value(forward_connection_opts, Opts, false),
+    Opts1 =
+        case ForwardConnOpts of
+            true -> [{conn_opts, #{client_cert => vmq_ssl:client_cert(Socket)}} | Opts];
+            _ -> Opts
+        end,
     case {Transport, UseCN} of
         {ranch_ssl, true} ->
             CN = vmq_ssl:socket_to_common_name(Socket),
-            {ok, {Peer, [{preauth, CN} | Opts]}};
+            {ok, {Peer, [{preauth, CN} | Opts1]}};
         _ ->
-            {ok, {Peer, Opts}}
+            {ok, {Peer, Opts1}}
     end.
 
 start_accepting_messages(MaskedSocket, FsmState, FsmMod, Transport, Parent) ->

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -409,10 +409,15 @@ default_session_opts(Opts) ->
             false -> [];
             {_, V} -> [{use_identity_as_username, V}]
         end,
+    MaybeSSLDefaults2 =
+        case lists:keyfind(forward_connection_opts, 1, Opts) of
+            false -> MaybeSSLDefaults;
+            {_, Val} -> [{forward_connection_opts, Val} | MaybeSSLDefaults]
+        end,
     MaybeProxyDefaults =
         case lists:keyfind(proxy_protocol_use_cn_as_username, 1, Opts) of
-            false -> MaybeSSLDefaults;
-            {_, V1} -> [{proxy_protocol_use_cn_as_username, V1} | MaybeSSLDefaults]
+            false -> MaybeSSLDefaults2;
+            {_, V1} -> [{proxy_protocol_use_cn_as_username, V1} | MaybeSSLDefaults2]
         end,
     MaybeProxyDefaults2 =
         case lists:keyfind(proxy_xff_trusted_intermediate, 1, Opts) of

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -293,6 +293,9 @@ translate_listeners(Conf) ->
     {SSLIPs, SSLUseIdents} = lists:unzip(
         extract("listener.ssl", "use_identity_as_username", BoolVal, Conf)
     ),
+    {SSLIPs, SSLForwardClientCerts} = lists:unzip(
+        extract("listener.ssl", "forward_connection_opts", BoolVal, Conf)
+    ),
     {SSLIPs, SSLPSKSupport} = lists:unzip(
         extract("listener.ssl", "psk_support", BoolVal, Conf)
     ),
@@ -321,6 +324,9 @@ translate_listeners(Conf) ->
     ),
     {WS_SSLIPs, WS_SSLUseIdents} = lists:unzip(
         extract("listener.wss", "use_identity_as_username", BoolVal, Conf)
+    ),
+    {WS_SSLIPs, WS_SSLForwardClientCerts} = lists:unzip(
+        extract("listener.wss", "forward_connection_opts", BoolVal, Conf)
     ),
 
     % VMQS
@@ -449,6 +455,7 @@ translate_listeners(Conf) ->
             SSLRequireCerts,
             SSLVersions,
             SSLUseIdents,
+            SSLForwardClientCerts,
             SSLPSKSupport,
             SSLPSKFile,
             SSLPSKFileSeparator,
@@ -477,6 +484,7 @@ translate_listeners(Conf) ->
             WS_SSLRequireCerts,
             WS_SSLVersions,
             WS_SSLUseIdents,
+            WS_SSLForwardClientCerts,
             WS_SSLMaxLengths,
             WS_SSLHeaderLengths,
             WS_SSLAllowedProto
@@ -574,6 +582,7 @@ extract(Prefix, Suffix, Val, Conf) ->
             "require_certificate",
             "tls_version",
             "use_identity_as_username",
+            "forward_connection_opts",
             "psk_support",
             "pskfile",
             "pskfile_separator",

--- a/apps/vmq_server/src/vmq_ssl.erl
+++ b/apps/vmq_server/src/vmq_ssl.erl
@@ -18,8 +18,20 @@
 -export([
     socket_to_common_name/1,
     cert_to_common_name/1,
+    client_cert/1,
     opts/1
 ]).
+-export_type([client_cert/0]).
+
+-type client_cert() :: #'OTPCertificate'{}.
+
+client_cert(Socket) ->
+    case ssl:peercert(Socket) of
+        {error, no_peercert} ->
+            undefined;
+        {ok, Cert} ->
+            Cert
+    end.
 
 socket_to_common_name(Socket) ->
     case ssl:peercert(Socket) of

--- a/apps/vmq_server/src/vmq_websocket.erl
+++ b/apps/vmq_server/src/vmq_websocket.erl
@@ -84,13 +84,18 @@ init(Req, Opts) ->
             FsmState =
                 case Type of
                     mqttwss ->
+                        Cert = cowboy_req:cert(Req),
+                        Opts1 =
+                            case proplists:get_value(forward_connection_opts, Opts, false) of
+                                true -> [{conn_opts, #{client_cert => Cert}} | Opts];
+                                false -> Opts
+                            end,
                         case proplists:get_value(use_identity_as_username, Opts, false) of
                             false ->
-                                FsmMod:init(Peer, Opts);
+                                FsmMod:init(Peer, Opts1);
                             true ->
-                                Cert = cowboy_req:cert(Req),
                                 FsmMod:init(Peer, [
-                                    {preauth, vmq_ssl:cert_to_common_name(Cert)} | Opts
+                                    {preauth, vmq_ssl:cert_to_common_name(Cert)} | Opts1
                                 ])
                         end;
                     %mqttws

--- a/apps/vmq_server/test/vmq_ssl_SUITE.erl
+++ b/apps/vmq_server/test/vmq_ssl_SUITE.erl
@@ -21,9 +21,10 @@
          connect_identity_allow_anonymous_override_off_test/1,
          connect_psk_test/1,
          connect_psk_wrong_identity/1,
-         connect_no_auth_test_passwd/1]).
+         connect_no_auth_test_passwd/1,
+         connect_forward_conn_opts_test/1]).
 
--export([hook_preauth_success/5]).
+-export([hook_preauth_success/5, hook_conn_opts_handler/5, hook_conn_opts_handler/6]).
 
 %% ===================================================================
 %% common_test callbacks
@@ -47,8 +48,9 @@ init_per_testcase(Case, Config) ->
           lists:member(Case, all_cert_auth_identity_allow_anonymous_override_on()),
           lists:member(Case, all_cert_auth_identity_allow_anonymous_override_off()),
           lists:member(Case, all_psk_auth()),
-          lists:member(Case, all_no_auth_encrypted_keyfile())} of
-        {true, _, _, _, _, _, _, _, _, _, _} ->
+          lists:member(Case, all_no_auth_encrypted_keyfile()),
+          lists:member(Case, all_forward_conn_opts())} of
+        {true, _, _, _, _, _, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
@@ -56,7 +58,7 @@ init_per_testcase(Case, Config) ->
                                                            {certfile, ssl_path("server.crt")},
                                                            {keyfile, ssl_path("server.key")},
                                                            {tls_version, "tlsv1.2"}]);
-        {_, true, _, _, _, _, _, _, _, _, _} ->
+        {_, true, _, _, _, _, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
@@ -65,7 +67,7 @@ init_per_testcase(Case, Config) ->
                                                            {keyfile, ssl_path("server.key")},
                                                            {tls_version, "tlsv1.2"},
                                                            {require_certificate, true}]);
-        {_, _, true, _, _, _, _, _, _, _, _} ->
+        {_, _, true, _, _, _, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
@@ -74,7 +76,7 @@ init_per_testcase(Case, Config) ->
                                                            {keyfile, ssl_path("server.key")},
                                                            {tls_version, "tlsv1.3"},
                                                            {require_certificate, true}]);
-        {_, _, _, true, _, _, _, _, _, _, _} ->
+        {_, _, _, true, _, _, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
@@ -84,7 +86,7 @@ init_per_testcase(Case, Config) ->
                                                            {tls_version, "tlsv1.2"},
                                                            {require_certificate, true},
                                                            {crlfile, ssl_path("crl.pem")}]);
-        {_, _, _, _, true, _, _, _, _, _, _} ->
+        {_, _, _, _, true, _, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                 {nr_of_acceptors, 5},
@@ -94,7 +96,7 @@ init_per_testcase(Case, Config) ->
                 {tls_version, "tlsv1.3"},
                 {require_certificate, true},
                 {crlfile, ssl_path("crl.pem")}]);
-        {_, _, _, _, _, true, _, _, _, _, _} ->
+        {_, _, _, _, _, true, _, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, false),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
@@ -107,7 +109,7 @@ init_per_testcase(Case, Config) ->
                                                            {use_identity_as_username, true}]),
             vmq_plugin_mgr:enable_module_plugin(
               auth_on_register, ?MODULE, hook_preauth_success, 5);
-        {_, _, _, _, _, _, true, _, _, _, _} ->
+        {_, _, _, _, _, _, true, _, _, _, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, false),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                 {nr_of_acceptors, 5},
@@ -120,7 +122,7 @@ init_per_testcase(Case, Config) ->
                 {use_identity_as_username, true}]),
             vmq_plugin_mgr:enable_module_plugin(
                 auth_on_register, ?MODULE, hook_preauth_success, 5);
-        {_, _, _, _, _, _, _, true, _, _, _} ->
+        {_, _, _, _, _, _, _, true, _, _, _,_} ->
                 {ok, _} = vmq_server_cmd:set_config(allow_anonymous, false),
                 {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                                {nr_of_acceptors, 5},
@@ -132,7 +134,7 @@ init_per_testcase(Case, Config) ->
                                                                {require_certificate, true},
                                                                {crlfile, ssl_path("crl.pem")},
                                                                {use_identity_as_username, true}]);
-        {_, _, _, _, _, _, _, _, true, _, _} ->
+        {_, _, _, _, _, _, _, _, true, _, _,_} ->
                 {ok, _} = vmq_server_cmd:set_config(allow_anonymous, false),
                 {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                                {nr_of_acceptors, 5},
@@ -144,14 +146,14 @@ init_per_testcase(Case, Config) ->
                                                                {require_certificate, true},
                                                                {crlfile, ssl_path("crl.pem")},
                                                                {use_identity_as_username, true}]);
-        {_, _, _, _, _, _, _, _, _, true, _} ->
+        {_, _, _, _, _, _, _, _, _, true, _,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                                                            {nr_of_acceptors, 5},
                                                            {psk_support, true},
                                                            {pskfile, ssl_path("test-psk.psk")},
                                                            {tls_version, "tlsv1.2"}]);
-        {_, _, _, _, _, _, _, _, _, _, true} ->
+        {_, _, _, _, _, _, _, _, _, _, true,_} ->
             {ok, _} = vmq_server_cmd:set_config(allow_anonymous, true),
             {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
                 {nr_of_acceptors, 5},
@@ -166,7 +168,21 @@ init_per_testcase(Case, Config) ->
                 {certfile, ssl_path("server.crt")},
                 {keyfile, ssl_path("server.encrypted.key")},
                 {keypasswd, "VerneMQ123Wrong"},
-                {tls_version, "tlsv1.2"}])
+                {tls_version, "tlsv1.2"}]);
+        {_, _, _, _, _, _, _, _, _, _, _,true} ->
+            {ok, _} = vmq_server_cmd:set_config(allow_anonymous, false),
+            {ok, _} = vmq_server_cmd:listener_start(1888, [{ssl, true},
+                        {nr_of_acceptors, 5},
+                        {cafile, ssl_path("all-ca.crt")},
+                        {certfile, ssl_path("server.crt")},
+                        {keyfile, ssl_path("server.key")},
+                        {tls_version, "tlsv1.2"},
+                        {require_certificate, true},
+                        {crlfile, ssl_path("crl.pem")},
+                        {use_identity_as_username, true},
+                        {forward_connection_opts, true}]),
+            ok = vmq_plugin_mgr:enable_module_plugin(
+                        auth_on_register, ?MODULE, hook_conn_opts_handler, 6)
     end,
     Config.
 
@@ -185,7 +201,8 @@ all() ->
     ++ all_cert_auth_identity_allow_anonymous_override_on()
     ++ all_cert_auth_identity_allow_anonymous_override_off()
     ++ all_psk_auth()
-    ++ all_no_auth_encrypted_keyfile().
+    ++ all_no_auth_encrypted_keyfile()
+    ++ all_forward_conn_opts().
 
 all_no_auth() ->
     [connect_no_auth_test,
@@ -229,6 +246,9 @@ all_psk_auth() ->
 
 all_no_auth_encrypted_keyfile() ->
     [connect_no_auth_test_passwd].
+
+all_forward_conn_opts() ->
+    [connect_forward_conn_opts_test].
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Actual Tests
@@ -426,10 +446,34 @@ connect_no_identity_test(_) ->
                                {verify, verify_peer},
                                {cacerts, load_cacerts()}])).
 
+connect_forward_conn_opts_test(_) ->
+    Connect = packet:gen_connect("connect-success-test", [{keepalive, 10}]),
+    Connack = packet:gen_connack(0),
+    {ok, SSock} = ssl:connect("localhost", 1888,
+                              [binary, {active, false}, {packet, raw},
+                               {verify, verify_peer},
+                               {cacerts, load_cacerts()},
+                               {certfile, ssl_path("client.crt")},
+                               {keyfile, ssl_path("client.key")}]),
+    ok = ssl:send(SSock, Connect),
+    ok = packet:expect_packet(ssl, SSock, "connack", Connack),
+    ok = ssl:close(SSock).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Hooks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 hook_preauth_success(_, {"", <<"connect-success-test">>}, <<"test client">>, undefined, _) -> ok.
+
+hook_conn_opts_handler(_, {"", <<"connect-success-test">>}, <<"test client">>, _, _, ConnOpts) when is_map(ConnOpts) ->
+    ClientCert = maps:get(client_cert, ConnOpts, undefined),
+    % just check whether the client cert is a binary (Pem)
+    case ClientCert of
+        C when is_binary(C) -> ok;
+        _ -> next
+    end;
+hook_conn_opts_handler(_,_,_,_,_,_) ->
+    next.
+hook_conn_opts_handler(_,_,_,_,_) -> next.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Helper

--- a/apps/vmq_webhooks/src/vmq_webhooks.app.src
+++ b/apps/vmq_webhooks/src/vmq_webhooks.app.src
@@ -20,6 +20,7 @@
         {pool_timeout, 60000},
         {vmq_plugin_hooks, [
             {vmq_webhooks_plugin, auth_on_register, 5, []},
+            {vmq_webhooks_plugin, auth_on_register, 6, []},
             {vmq_webhooks_plugin, auth_on_publish, 6, []},
             {vmq_webhooks_plugin, auth_on_subscribe, 3, []},
             {vmq_webhooks_plugin, on_register, 3, []},
@@ -29,6 +30,7 @@
             {vmq_webhooks_plugin, on_deliver, 7, []},
 
             {vmq_webhooks_plugin, auth_on_register_m5, 6, []},
+            {vmq_webhooks_plugin, auth_on_register_m5, 7, []},
             {vmq_webhooks_plugin, auth_on_publish_m5, 7, []},
             {vmq_webhooks_plugin, auth_on_subscribe_m5, 4, []},
             {vmq_webhooks_plugin, on_register_m5, 4, []},

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -311,7 +311,7 @@ auth_on_register(Peer, SubscriberId, UserName, Password, CleanSession, Opts) ->
         {username, nullify(UserName)},
         {password, nullify(PasswordPlain)},
         {clean_session, CleanSession},
-        Opts
+        Opts % this will have the form #{client_cert => Cert}
     ]).
 
 -spec auth_on_register_m5(peer(), subscriber_id(), username(), password(), boolean(), properties()) ->
@@ -1286,7 +1286,7 @@ encode_payload(_, Args, Opts) ->
                 ({client_id, V}) -> {client_id, V};
                 ({properties, V}) -> {properties, encode_props(V, Opts)};
                 ({payload, V}) -> {payload, b64encode(V, Opts)};
-                ({conn_opts, #{client_cert := C} = _V}) -> {client_cert, b64encode(C, Opts)};
+                (#{client_cert := C} = _V) -> {client_cert, b64encode(C, Opts)};
                 (V) -> V
             end,
             Args

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -311,7 +311,8 @@ auth_on_register(Peer, SubscriberId, UserName, Password, CleanSession, Opts) ->
         {username, nullify(UserName)},
         {password, nullify(PasswordPlain)},
         {clean_session, CleanSession},
-        Opts % this will have the form #{client_cert => Cert}
+        % Opts will have the form #{client_cert => Cert}
+        Opts
     ]).
 
 -spec auth_on_register_m5(peer(), subscriber_id(), username(), password(), boolean(), properties()) ->

--- a/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_SUITE.erl
@@ -86,6 +86,7 @@ http() ->
 
 
      auth_on_register_test,
+     auth_on_register_opts_test,
      auth_on_publish_test,
      auth_on_publish_no_payload_test,
      auth_on_subscribe_test,
@@ -282,6 +283,12 @@ auth_on_register_test(_) ->
                       [?PEER, {?MOUNTPOINT, ?CHANGED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true]),
     {ok, [{username, <<"changed_username">>}]} = vmq_plugin:all_till_ok(auth_on_register,
                       [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?CHANGED_USERNAME, ?PASSWORD, true]),
+    deregister_hook(auth_on_register, ?ENDPOINT).
+
+auth_on_register_opts_test(_) ->
+    register_hook(auth_on_register, ?ENDPOINT),
+    ok = vmq_plugin:all_till_ok(auth_on_register,
+                        [?PEER, {?MOUNTPOINT, ?ALLOWED_CLIENT_ID}, ?USERNAME, ?PASSWORD, true, ?OPTS]),
     deregister_hook(auth_on_register, ?ENDPOINT).
 
 auth_on_publish_test(_) ->

--- a/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
+++ b/apps/vmq_webhooks/test/vmq_webhooks_test.hrl
@@ -19,3 +19,4 @@
 -define(PASSWORD, <<"test-password">>).
 -define(TOPIC, <<"test/topic">>).
 -define(PAYLOAD, <<"hello world">>).
+-define(OPTS, {conn_opts, #{client_cert => <<"client cert">>}}).

--- a/apps/vmq_webhooks/test/webhooks_handler.erl
+++ b/apps/vmq_webhooks/test/webhooks_handler.erl
@@ -96,7 +96,6 @@ process_cache_hook(<<"auth_on_subscribe_m5">>, #{username := SenderPid}) ->
     Pid ! cache_auth_on_subscribe_ok,
     {200, #{result => <<"ok">>}}.
 
-%% callbacks for each hook
 auth_on_register(#{peer_addr := ?PEER_BIN,
                    peer_port := ?PEERPORT,
                    client_id := <<"undefined_creds">>,

--- a/rebar.lock
+++ b/rebar.lock
@@ -96,7 +96,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1},
  {<<"vernemq_dev">>,
   {git,"https://github.com/vernemq/vernemq_dev.git",
-       {ref,"47daace526521114f8dc39ecee4db06497b0bdde"}},
+       {ref,"66ce2cc58ba2f79f748e1a77635582f27273e20d"}},
   0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
WIP

This adds a settable flag for SSL listeners:

`listener.ssl.my_listener.forward_connection_opts = on`

If on, this will forward connection info from the TLS layer to your authentication plugin. Currently, this is used to forward the full TLS client cert, so that your authn/authz plugin can use information from the client cert.

Cannot be used with Lua plugins atm.

Example:
Configure an SSL listener, with `forward_connection_opts` and `require_certificate` set to `on`:

```
listener.ssl.test = 127.0.0.1:8885
listener.ssl.test.cafile = ./ssl/all-ca.crt
listener.ssl.test.keyfile = ./ssl/server.key
listener.ssl.test.certfile = ./ssl/server.crt
listener.ssl.test.require_certificate = on
listener.ssl.test.forward_connection_opts = on
```
Webhooks example (Python hook). You can now grab the 64encoded client cert from `data`:

```python
def handle_auth_on_register(data):
    # Cache example
    web.header('cache-control', 'max-age=30')
    # only allow user 'joe' with password 'secret', reject all others.
    print ('cert:', data['client_cert'])
    if "joe" == data['username']:
        if "secret" == data['password']:
            return json.dumps({'result': 'ok'})  
    return json.dumps({'result': {'error': 'not allowed'}})
```