### PR TITLE
vmq_bridge: Handle and log unknown internal messages in bridge process

### DIFF
--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -262,6 +262,18 @@ handle_info(
         end,
         Subscriptions
     ),
+    {noreply, State};
+handle_info(
+    Msg,
+    #state{
+        name = Name,
+        host = Host,
+        port = Port
+    } = State
+) ->
+    ?LOG_WARNING("Bridge ~s connected to ~s:~p received unexpected internal message ~p ~n", [
+        Name, Host, Port, Msg
+    ]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->


### PR DESCRIPTION
Reason: We've seen unexpected events like tcp_closed end up in the bridge