### PR TITLE
Allows plugin subscribe to add subinfo flags

### DIFF
--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -1021,7 +1021,7 @@ direct_plugin_exports(LogName, Opts) ->
             %% - trade-consistency flag
             %% - reg_view
             %% - shared subscription policy
-            %% - user_proeprties
+            %% - user_properties
 
             UserProperties = maps:get(user_property, Opts_, undefined),
             Properties =
@@ -1054,6 +1054,12 @@ direct_plugin_exports(LogName, Opts) ->
                 MaybeWaitTillReady(),
                 CallingPid = self(),
                 subscribe(CAPSubscribe, {Mountpoint, ClientId}, [{Topic, 0}]);
+            %% accepts a tuple {Topic, SubInfo} where subinfo is a map e.g.
+            %% #{rap => True} to allow a more MQTTv5 like experience
+            ({[W | _] = Topic, SubInfo}) when is_binary(W) ->
+                MaybeWaitTillReady(),
+                CallingPid = self(),
+                subscribe(CAPSubscribe, {Mountpoint, ClientId}, [{Topic, {0, SubInfo}}]);
             (_) ->
                 {error, invalid_topic}
         end,


### PR DESCRIPTION
Allows plugin subscribe to add subinfo flags, e.g. #{rap => true}. This allows a more MQTTv5 like experience and allows plugins to also get the retain flag.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
