### PR TITLE
vmq_bridge will forward retain messages to connected bridge

### DIFF
--- a/apps/vmq_bridge/priv/vmq_bridge.schema
+++ b/apps/vmq_bridge/priv/vmq_bridge.schema
@@ -439,21 +439,34 @@
                                                     {0, Rest2}
                                             end
                                     end,
+                                    {Retain, Rest5} =
+                                    case Rest3 of
+                                        [] ->
+                                            {false, []};
+                                        [MaybeRetain|Rest6] ->
+                                            case lists:member(MaybeRetain, ["retain"]) of
+                                                true ->
+                                                    {true, Rest6};
+                                                false ->
+                                                    {false, Rest3}
+                                            end
+                                    end,
+
                                     Empty = fun("$empty") ->
                                                     "";
                                                (V) -> V
                                             end,
-                                    case Rest3 of
+                                    case Rest5 of
                                         [] ->
-                                            {Pattern, Direction, QoS, "", ""};
+                                            {Pattern, Direction, QoS, Retain, "", ""};
                                         [LocalPrefix, RemotePrefix] ->
-                                            {Pattern, Direction, QoS,
+                                            {Pattern, Direction, QoS, Retain,
                                              Empty(LocalPrefix), Empty(RemotePrefix)};
                                         _ ->
-                                            cuttlefish:invalid("should be a string of the form 'pattern [[[ out | in | both ] qos-level] local-prefix remote-prefix]'")
+                                            cuttlefish:invalid("should be a string of the form 'pattern [[[ out | in | both ] qos-level] retain] local-prefix remote-prefix]'")
                                     end;
                                 [] ->
-                                    {Pattern, out, 0, "", ""}
+                                    {Pattern, out, 0, false, "", ""}
                             end;
                         (_, _) ->
                             cuttlefish:invalid("should be a string of the form 'pattern [[[ out | in | both ] qos-level] local-prefix remote-prefix]'")

--- a/apps/vmq_bridge/src/vmq_bridge.erl
+++ b/apps/vmq_bridge/src/vmq_bridge.erl
@@ -221,12 +221,12 @@ handle_info(
     %% we have a matching subscription
     lists:foreach(
         fun
-            ({{in, T}, {LocalPrefix, RemotePrefix}}) ->
+            ({{in, T}, FwdRetain, {LocalPrefix, RemotePrefix}}) ->
                 case match(Topic, T) of
                     true ->
                         % ignore if we're ready or not.
                         PublishFun(swap_prefix(RemotePrefix, LocalPrefix, Topic), Payload, #{
-                            qos => QoS, retain => Retain
+                            qos => QoS, retain => Retain and FwdRetain
                         });
                     false ->
                         ok
@@ -244,7 +244,7 @@ handle_info(
     %% forward matching, locally published messages to the remote broker.
     lists:foreach(
         fun
-            ({{out, T}, QoS, {LocalPrefix, RemotePrefix}}) ->
+            ({{out, T}, QoS, FwdRetain, {LocalPrefix, RemotePrefix}}) ->
                 case match(Topic, T) of
                     true ->
                         ok = gen_mqtt_client:publish(
@@ -252,7 +252,7 @@ handle_info(
                             swap_prefix(LocalPrefix, RemotePrefix, Topic),
                             Payload,
                             QoS,
-                            IsRetained
+                            IsRetained and FwdRetain
                         );
                     false ->
                         ok
@@ -285,7 +285,7 @@ code_change(_OldVsn, State, _Extra) ->
 bridge_subscribe(
     remote = Type,
     Pid,
-    [{Topic, in, QoS, LocalPrefix, RemotePrefix} = BT | Rest],
+    [{Topic, in, QoS, FwdRetain, LocalPrefix, RemotePrefix} = BT | Rest],
     SubscribeFun,
     Acc
 ) ->
@@ -299,7 +299,7 @@ bridge_subscribe(
                 Rest,
                 SubscribeFun,
                 [
-                    {{in, RemoteTopic}, {
+                    {{in, RemoteTopic}, FwdRetain, {
                         validate_prefix(LocalPrefix), validate_prefix(RemotePrefix)
                     }}
                     | Acc
@@ -315,21 +315,26 @@ bridge_subscribe(
 bridge_subscribe(
     local = Type,
     Pid,
-    [{Topic, out, QoS, LocalPrefix, RemotePrefix} = BT | Rest],
+    [{Topic, out, QoS, FwdRetain, LocalPrefix, RemotePrefix} = BT | Rest],
     SubscribeFun,
     Acc
 ) ->
     case vmq_topic:validate_topic(subscribe, list_to_binary(Topic)) of
         {ok, TTopic} ->
             LocalTopic = add_prefix(validate_prefix(LocalPrefix), TTopic),
-            {ok, _} = SubscribeFun(LocalTopic),
+            LocalTopic0 =
+                case FwdRetain of
+                    true -> {LocalTopic, #{rap => true}};
+                    _ -> LocalTopic
+                end,
+            {ok, _} = SubscribeFun(LocalTopic0),
             bridge_subscribe(
                 Type,
                 Pid,
                 Rest,
                 SubscribeFun,
                 [
-                    {{out, LocalTopic}, QoS, {
+                    {{out, LocalTopic}, QoS, FwdRetain, {
                         validate_prefix(LocalPrefix), validate_prefix(RemotePrefix)
                     }}
                     | Acc
@@ -345,7 +350,7 @@ bridge_subscribe(
 bridge_subscribe(
     Type,
     Pid,
-    [{Topic, both, QoS, LocalPrefix, RemotePrefix} = BT | Rest],
+    [{Topic, both, QoS, FwdRetain, LocalPrefix, RemotePrefix} = BT | Rest],
     SubscribeFun,
     Acc
 ) ->
@@ -361,7 +366,7 @@ bridge_subscribe(
                         Rest,
                         SubscribeFun,
                         [
-                            {{in, RemoteTopic}, {
+                            {{in, RemoteTopic}, FwdRetain, {
                                 validate_prefix(LocalPrefix), validate_prefix(RemotePrefix)
                             }}
                             | Acc
@@ -369,14 +374,19 @@ bridge_subscribe(
                     );
                 local ->
                     LocalTopic = add_prefix(validate_prefix(LocalPrefix), TTopic),
-                    {ok, _} = SubscribeFun(LocalTopic),
+                    LocalTopic0 =
+                        case FwdRetain of
+                            true -> {LocalTopic, #{rap => true}};
+                            _ -> LocalTopic
+                        end,
+                    {ok, _} = SubscribeFun(LocalTopic0),
                     bridge_subscribe(
                         Type,
                         Pid,
                         Rest,
                         SubscribeFun,
                         [
-                            {{out, LocalTopic}, QoS, {
+                            {{out, LocalTopic}, QoS, FwdRetain, {
                                 validate_prefix(LocalPrefix), validate_prefix(RemotePrefix)
                             }}
                             | Acc

--- a/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
+++ b/apps/vmq_bridge/test/vmq_bridge_SUITE.erl
@@ -73,8 +73,8 @@ prefixes_test(Cfg) ->
       mqtt_version => mqtt_version(Cfg),
       inet_version => Inet,
       qos => 0,
-      topics => [{"bridge-in", in, 0, "local-in-prefix", "remote-in-prefix"},
-                 {"bridge-out", out, 0, "local-out-prefix", "remote-out-prefix"}]
+      topics => [{"bridge-in", in, 0, false, "local-in-prefix", "remote-in-prefix"},
+                 {"bridge-out", out, 0, false, "local-out-prefix", "remote-out-prefix"}]
      }),
     BridgePid = get_bridge_pid(Cfg),
     %% Start the 'broker' and let the bridge connect
@@ -108,7 +108,7 @@ remote_reconnect_qos1_test(Cfg) ->
     start_bridge_plugin(#{
       mqtt_version => mqtt_version(Cfg),
       qos => 1,
-      topics => [{"bridge/#", both, 1, "", ""}]
+      topics => [{"bridge/#", both, 1, false, "", ""}]
      }),
 
     Connect = packet:gen_connect("bridge-test", [{keepalive,60}, {clean_session, false},
@@ -147,7 +147,7 @@ remote_reconnect_qos2_test(Cfg) ->
     start_bridge_plugin(#{
       mqtt_version => mqtt_version(Cfg),
       qos => 2,
-      topics => [{"bridge/#", both, 2, "", ""}]
+      topics => [{"bridge/#", both, 2, false, "", ""}]
      }),
     Connect = packet:gen_connect("bridge-test", [{keepalive,60}, {clean_session, false},
                                             {proto_ver, mqtt_version(Cfg)}]),
@@ -199,7 +199,7 @@ bridge_reconnect_qos1_test(Cfg) ->
     start_bridge_plugin(#{
       mqtt_version => mqtt_version(Cfg),
       qos => 1,
-      topics => [{"bridge/#", both, 1, "", ""}]
+      topics => [{"bridge/#", both, 1, false, "", ""}]
      }),
     Connect = packet:gen_connect("bridge-test", [{keepalive,60}, {clean_session, false},
                                                  {proto_ver, mqtt_version(Cfg)}]),
@@ -241,7 +241,7 @@ bridge_reconnect_qos2_test(Cfg) ->
     start_bridge_plugin(#{
       mqtt_version => mqtt_version(Cfg),
       qos => 2,
-      topics => [{"bridge/#", both, 2, "", ""}]
+      topics => [{"bridge/#", both, 2, false, "", ""}]
      }),
     Connect = packet:gen_connect("bridge-test", [{keepalive,60}, {clean_session, false},
                                             {proto_ver, mqtt_version(Cfg)}]),
@@ -400,7 +400,7 @@ start_bridge_plugin(Opts) ->
     MqttVersion = maps:get(mqtt_version, Opts),
     QoS = maps:get(qos, Opts),
     Max = maps:get(max_outgoing_buffered_messages, Opts, 100),
-    Topics = maps:get(topics, Opts, [{"bridge/#", both, QoS, "", ""}]),
+    Topics = maps:get(topics, Opts, [{"bridge/#", both, QoS, false, "", ""}]),
     Inet = maps:get(inet_version, Opts, inet),
     Localhost = case Inet of
                   inet6 -> inet:ntoa({0,0,0,0,0,0,0,1});

--- a/apps/vmq_server/src/vmq_schema.erl
+++ b/apps/vmq_server/src/vmq_schema.erl
@@ -64,10 +64,8 @@ translate_listeners(Conf) ->
     end,
     SSLVersionsListVal = fun
         (_, SSLVersions, _) when is_list(SSLVersions) -> validate_sslversion(SSLVersions);
-        (_, undefined, undefined) ->
-            undefined;
-        (_, undefined, Def) ->
-            validate_sslversion(Def)
+        (_, undefined, undefined) -> undefined;
+        (_, undefined, Def) -> validate_sslversion(Def)
     end,
     %% Either "", meaning all known named curves are allowed]
     %% or a list like "[secp256r1,sect239k1,sect233k1]"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- vmq_bridge: Bridge can forward retained messages (#2391, #1420, #1691)
 - New configuration: Allow multiple TLS versions per SSL and WSS listener
 - Plugins: Plugins can subscribe to topics with additional subinfo allowing a more MQTTv5-like experience (#2390)
 


### PR DESCRIPTION
A new config setting 'retain' is used to indicate that the bridge should forward retained messages.

New configuration:
vmq_bridge.tcp.br0.topic.1 = /demo/+ out 1 retain

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1420 #1691 )
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ ] I have updated changelog (At the bottom of the release version)
- [ ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
