### PR TITLE
Bugfix: MQTT session FSMs now send out SUBACKS for all error clauses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- Logging: Rejected/failed Subscribes are now logged as errors with SubscribedId and Peer info
+- Bugfix: MQTT Session FSMs now send out SUBACKs for any error clause
 - Enhancement: Don't log msg payload in pubauth errors.
 - Bugfix: active connections count for WS in metrics and listener info
 


### PR DESCRIPTION
Fixes https://github.com/vernemq/vernemq/issues/2453
Answers https://github.com/vernemq/vernemq/discussions/2455