### PR TITLE
Disable retain_expiry check as a default

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -2327,7 +2327,7 @@
 %% when you never overwrite or consume retained messages; usually
 %% expired retained messages are cleaned up at the next delivery attempt.
 {mapping, "expire_retain_cache", "vmq_server.expire_retain_cache", [
-                                                             {default, 60},
-                                                             {commented, 60},
+                                                             {default, 0},
+                                                             {commented, 0},
                                                              {datatype, integer}
                                                             ]}.

--- a/apps/vmq_server/src/vmq_retain_srv.erl
+++ b/apps/vmq_server/src/vmq_retain_srv.erl
@@ -170,7 +170,7 @@ fold_expired() ->
 %% @end
 %%--------------------------------------------------------------------
 init([]) ->
-    ExpCleanup = vmq_config:get_env(expire_retain_cache, 60) * 1000,
+    ExpCleanup = vmq_config:get_env(expire_retain_cache, 0) * 1000,
     vmq_metadata:subscribe(?RETAIN_DB),
     vmq_metadata:fold(
         ?RETAIN_DB,


### PR DESCRIPTION
Set to 0, since it is not needed for most use cases. Also, the current default setting of 60 seconds can interfere with clustering in high volume of retained messages (millions). This is under review.