### PR TITLE
make internode cluster readiness check parallel

### DIFF
--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -321,6 +321,15 @@
                                                                           hidden
                                                                          ]}.
 
+%% @doc specifies the timeout in milliseconds for the parallel RPC used
+%% during cluster readiness checks. This is a total timeout for all nodes,
+%% not per-node. The previous sequential approach had no timeout (infinity).
+{mapping, "cluster_ready_rpc_timeout", "vmq_server.cluster_ready_rpc_timeout", [
+                                                                                 {default, 5000},
+                                                                                 {datatype, integer},
+                                                                                 hidden
+                                                                                ]}.
+
 %% @doc specifies the connect timeout.
 {mapping, "mqtt_connect_timeout", "vmq_server.mqtt_connect_timeout", [
                                                             {default, 5000},

--- a/apps/vmq_server/src/vmq_cluster.erl
+++ b/apps/vmq_server/src/vmq_cluster.erl
@@ -47,6 +47,7 @@
 -define(SERVER, ?MODULE).
 %% table is owned by vmq_cluster_mon
 -define(VMQ_CLUSTER_STATUS, vmq_status).
+-define(DEFAULT_RPC_TIMEOUT, 5000).
 
 -record(state, {}).
 -type state() :: #state{}.
@@ -217,19 +218,27 @@ check_ready(Nodes) ->
     ),
     ok.
 
-check_ready([Node | Rest], Acc) ->
-    IsReady =
-        case rpc:call(Node, erlang, whereis, [vmq_server_sup]) of
-            Pid when is_pid(Pid) -> true;
-            _ -> false
+check_ready(Nodes, _Acc) ->
+    %% Check all nodes in parallel with a single bounded timeout
+    %% instead of sequential rpc:call which takes up to N*5s.
+    Timeout = vmq_config:get_env(cluster_ready_rpc_timeout, ?DEFAULT_RPC_TIMEOUT),
+    Results = erpc:multicall(Nodes, erlang, whereis, [vmq_server_sup], Timeout),
+    Acc = lists:zipwith(
+        fun(Node, Result) ->
+            IsReady =
+                case Result of
+                    {ok, Pid} when is_pid(Pid) -> true;
+                    _ -> false
+                end,
+            ok = vmq_cluster_node_sup:ensure_cluster_node(Node),
+            %% We should only say we're ready if we've established a
+            %% connection to the remote node.
+            Status = vmq_cluster_node_sup:node_status(Node),
+            {Node, IsReady andalso lists:member(Status, [up, init])}
         end,
-    ok = vmq_cluster_node_sup:ensure_cluster_node(Node),
-    %% We should only say we're ready if we've established a
-    %% connection to the remote node.
-    Status = vmq_cluster_node_sup:node_status(Node),
-    IsReady1 = IsReady andalso lists:member(Status, [up, init]),
-    check_ready(Rest, [{Node, IsReady1} | Acc]);
-check_ready([], Acc) ->
+        Nodes,
+        Results
+    ),
     OldObj =
         case ets:lookup(?VMQ_CLUSTER_STATUS, ready) of
             [] -> {true, 0, 0};

--- a/apps/vmq_server/src/vmq_config_cli.erl
+++ b/apps/vmq_server/src/vmq_config_cli.erl
@@ -64,6 +64,7 @@ register_config_() ->
             "suppress_lwt_on_session_takeover",
             "coordinate_registrations",
             "mqtt_connect_timeout",
+            "cluster_ready_rpc_timeout",
             "disconnect_on_unauthorized_publish_v3",
             "subscriber_retain_mode"
         ],

--- a/apps/vmq_server/src/vmq_server.app.src
+++ b/apps/vmq_server/src/vmq_server.app.src
@@ -102,6 +102,7 @@
         ]},
         {outgoing_clustering_buffer_size, 10000},
         {remote_enqueue_timeout, 5000},
+        {cluster_ready_rpc_timeout, 5000},
         {outgoing_connect_options, []},
         {outgoing_connect_params_module, vmq_cluster_node},
         {outgoing_connect_timeout, 10000},

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - Bugfix: MQTT Session FSMs now send out SUBACKs for any error clause.
 - Enhancement: Don't log msg payload in pubauth errors.
 - Bugfix: active connections count for WS in metrics and listener info.
+- Enhancement: Parallel cluster readiness checks via erpc:multicall (5s total worst-case vs N*5s). New hidden setting: cluster_ready_rpc_timeout
 
 
 ## VerneMQ 2.1.1


### PR DESCRIPTION
## Proposed Changes

Change cluster node readiness check to be parallel rather than sequential. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if needed)
- [x] Any dependent changes have been merged and published in related repositories
- [x] I have updated changelog (At the bottom of the release version)
- [x] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
