### PR TITLE
vmq_swc_store: Mirror event subscriptions in ETS for reloading

### DIFF
--- a/apps/vmq_swc/include/vmq_swc.hrl
+++ b/apps/vmq_swc/include/vmq_swc.hrl
@@ -3,6 +3,7 @@
 -define(DB_OBJ, obj).
 -define(DB_DKM, dkm).
 -define(DB_DEFAULT, default).
+-define(SUBS_REGISTRY, vmq_swc_subscriptions).
 
 -type key_prefix() :: atom().
 -type key_suffix() :: term().

--- a/apps/vmq_swc/src/vmq_swc_store.erl
+++ b/apps/vmq_swc/src/vmq_swc_store.erl
@@ -101,7 +101,7 @@
     sync_lock,
     auto_gc :: boolean(),
     periodic_gc :: boolean(),
-    subscriptions = #{},
+    subscriptions = #{} :: map(),
     broadcast_enabled :: boolean(),
     init_sync :: boolean(),
     iterator = undefined
@@ -176,7 +176,43 @@ fold_values(Config, Fun, Acc, FullPrefix) ->
     )
 ) -> ok.
 subscribe(#swc_config{store = StoreName}, FullPrefix, ConvertFun) ->
-    gen_server:call(StoreName, {subscribe, FullPrefix, ConvertFun, self()}, infinity).
+    Pid = self(),
+    subs_reg_upsert(StoreName, FullPrefix, Pid, ConvertFun),
+    case whereis(StoreName) of
+        undefined ->
+            %% Store isn't running yet, need to retry.
+            catch gen_server:cast(StoreName, {subscribe, FullPrefix, ConvertFun, Pid}),
+            _ = spawn(fun() -> retry_subscribe(StoreName, FullPrefix, ConvertFun, Pid) end),
+            ok;
+        _ ->
+            Res = catch gen_server:call(StoreName, {subscribe, FullPrefix, ConvertFun, Pid}, 200),
+            case Res of
+                ok -> ok;
+                _ ->
+                    catch gen_server:cast(StoreName, {subscribe, FullPrefix, ConvertFun, Pid}),
+                    ok
+            end
+    end.
+
+retry_subscribe(StoreName, FullPrefix, ConvertFun, Pid) ->
+    retry_subscribe(StoreName, FullPrefix, ConvertFun, Pid, 40).
+
+retry_subscribe(_StoreName, _FullPrefix, _ConvertFun, _Pid, 0) ->
+    ok;
+retry_subscribe(StoreName, FullPrefix, ConvertFun, Pid, N) ->
+    case whereis(StoreName) of
+        undefined ->
+            timer:sleep(50),
+            retry_subscribe(StoreName, FullPrefix, ConvertFun, Pid, N - 1);
+        _ ->
+            Res = catch gen_server:call(StoreName, {subscribe, FullPrefix, ConvertFun, Pid}, 200),
+            case Res of
+                ok -> ok;
+                _ ->
+                    catch gen_server:cast(StoreName, {subscribe, FullPrefix, ConvertFun, Pid}),
+                    ok
+            end
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Sync API, used by vmq_swc_exchange_fsm
@@ -432,7 +468,7 @@ init([
             [] -> {node(), <<"initial">>};
             [{old_actor, OLD_SWC_Actor}] -> {node(), OLD_SWC_Actor}
         end,
-    State = set_peers(Members2, #state{
+    State0 = set_peers(Members2, #state{
         id = SWC_ID,
         old_id = OLD_SWC_ID,
         peers = [],
@@ -446,7 +482,8 @@ init([
         broadcast_enabled = IsBroadcastEnabled,
         init_sync = Init1
     }),
-    {ok, State}.
+    State1 = restore_subscriptions(StoreName, State0),
+    {ok, State1}.
 
 handle_call(
     {batch, Batch},
@@ -495,12 +532,9 @@ handle_call(
     db_write(Config, [UpdateNodeClock_DBOp | DbOps]),
     r_o_w_cache_clear(Config),
     {reply, ok, cache_node_clock(State1)};
-handle_call(
-    {subscribe, FullPrefix, ConvertFun, Pid}, _From, #state{subscriptions = Subs0} = State0
-) ->
-    SubsForPrefix = maps:get(FullPrefix, Subs0, []),
-    Subs1 = maps:put(FullPrefix, [{Pid, ConvertFun} | SubsForPrefix], Subs0),
-    {reply, ok, State0#state{subscriptions = Subs1}};
+handle_call({subscribe, FullPrefix, ConvertFun, Pid}, _From, State0) ->
+    State1 = upsert_subscription(FullPrefix, Pid, ConvertFun, State0),
+    {reply, ok, State1};
 handle_call({lock, OwnerPid}, _From, #state{id = Id, sync_lock = SyncLock} = State0) ->
     {Peer, _Actor} = Id,
     case node(OwnerPid) == Peer of
@@ -769,6 +803,9 @@ handle_cast(
 handle_cast(init_dkm, #state{config = Config} = State) ->
     DKM = init_dotkeymap(Config),
     {noreply, State#state{dotkeymap = DKM}};
+handle_cast({subscribe, FullPrefix, ConvertFun, Pid}, State0) ->
+    State1 = upsert_subscription(FullPrefix, Pid, ConvertFun, State0),
+    {noreply, State1};
 handle_cast(Request, State) ->
     ?LOG_ERROR("Replica ~p: Received invalid cast ~p", [State#state.group, Request]),
     {noreply, State}.
@@ -1042,21 +1079,92 @@ strip_save_batch(
 event(Type, SKey, NewObj, OldObj, #state{subscriptions = Subscriptions}, OriginPid) ->
     {FullPrefix, Key} = sext:decode(SKey),
     OldValues = swc_kv:values(OldObj),
-    SubsForPrefix = maps:get(FullPrefix, Subscriptions, []),
-    lists:foreach(
+    SubsForPrefix = maps:get(FullPrefix, Subscriptions, #{}),
+    maps:foreach(
         fun
-            ({Pid, _}) when (FullPrefix == ?RETAIN_DB) andalso (Pid == OriginPid) ->
-                % When originator is vmq_retain_srv of this node, then the
-                % RETAIN_DB is already up-to-date. In this case we must skip the feedback notification event
-                % to prevent corrupting the RETAIN_DB. (= avoid overwriting possible newer updates)
-                skip;
-            ({Pid, ConvertFun}) when Type == deleted ->
-                Pid ! ConvertFun({deleted, FullPrefix, Key, OldValues});
-            ({Pid, ConvertFun}) when Type == updated ->
-                Pid ! ConvertFun({updated, FullPrefix, Key, OldValues, swc_kv:values(NewObj)})
+            (Pid, _) when (FullPrefix == ?RETAIN_DB) andalso (Pid == OriginPid) ->
+                %% When originator is vmq_retain_srv of this node, then the
+                %% RETAIN_DB is already up-to-date. In this case we must skip the feedback notification event
+                %% to prevent corrupting the RETAIN_DB. (= avoid overwriting possible newer updates)
+                ok;
+            (Pid, ConvertFun) when Type == deleted ->
+                safe_deliver_event(Pid, ConvertFun, {deleted, FullPrefix, Key, OldValues});
+            (Pid, ConvertFun) when Type == updated ->
+                safe_deliver_event(
+                    Pid,
+                    ConvertFun,
+                    {updated, FullPrefix, Key, OldValues, swc_kv:values(NewObj)}
+                )
         end,
         SubsForPrefix
     ).
+
+safe_deliver_event(Pid, ConvertFun, Event) ->
+    try
+        Pid ! ConvertFun(Event) %% so that ConvertFun does not crash the store
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "swc_store event subscriber ~p failed with ~p:~p. dropping event", [
+                    Pid, Class, Reason
+                ]
+            ),
+            ?LOG_DEBUG("swc_store event subscriber ~p stacktrace: ~p", [Pid, Stack]),
+            ok
+    end.
+
+subs_reg_key(StoreName, FullPrefix, Pid) ->
+    {StoreName, FullPrefix, Pid}.
+
+subs_reg_upsert(StoreName, FullPrefix, Pid, ConvertFun) ->
+    try
+        ets:insert(?SUBS_REGISTRY, {subs_reg_key(StoreName, FullPrefix, Pid), ConvertFun})
+    catch
+        _:_ -> ok
+    end.
+
+subs_reg_delete(StoreName, FullPrefix, Pid) ->
+    try
+        ets:delete(?SUBS_REGISTRY, subs_reg_key(StoreName, FullPrefix, Pid))
+    catch
+        _:_ -> ok
+    end.
+
+subs_reg_match_store(StoreName) ->
+    try
+        ets:match_object(?SUBS_REGISTRY, {{StoreName, '_', '_'}, '_'})
+    catch
+        _:_ -> []
+    end.
+
+restore_subscriptions(StoreName, State0) ->
+    Entries = subs_reg_match_store(StoreName),
+    {Reg1, Dead} =
+        lists:foldl(
+            fun
+                ({{_Store, FullPrefix, Pid}, ConvertFun}, {Acc, DeadAcc}) ->
+                    case is_process_alive(Pid) of
+                        true ->
+                            PrefixMap0 = maps:get(FullPrefix, Acc, #{}),
+                            PrefixMap1 = maps:put(Pid, ConvertFun, PrefixMap0),
+                            {maps:put(FullPrefix, PrefixMap1, Acc), DeadAcc};
+                        false ->
+                            {Acc, [{FullPrefix, Pid} | DeadAcc]}
+                    end
+            end,
+            {#{}, []},
+            Entries
+        ),
+    lists:foreach(fun({FullPrefix, Pid}) -> subs_reg_delete(StoreName, FullPrefix, Pid) end, Dead),
+    State0#state{subscriptions = Reg1}.
+
+upsert_subscription(FullPrefix, Pid, ConvertFun, #state{config = #swc_config{store = StoreName}} = State0) ->
+    subs_reg_upsert(StoreName, FullPrefix, Pid, ConvertFun),
+    Subs0 = State0#state.subscriptions,
+    PrefixMap0 = maps:get(FullPrefix, Subs0, #{}),
+    PrefixMap1 = maps:put(Pid, ConvertFun, PrefixMap0),
+    Subs1 = maps:put(FullPrefix, PrefixMap1, Subs0),
+    State0#state{subscriptions = Subs1}.
 
 process_write_op(
     OriginPid,

--- a/apps/vmq_swc/src/vmq_swc_store.erl
+++ b/apps/vmq_swc/src/vmq_swc_store.erl
@@ -1120,21 +1120,36 @@ subs_reg_upsert(StoreName, FullPrefix, Pid, ConvertFun) ->
     try
         ets:insert(?SUBS_REGISTRY, {subs_reg_key(StoreName, FullPrefix, Pid), ConvertFun})
     catch
-        _:_ -> ok
+        Class:Reason ->
+            ?LOG_WARNING(
+                "swc_store failed to insert internal subscriber to ETS (~p/~p): store=~p prefix=~p pid=~p",
+                [Class, Reason, StoreName, FullPrefix, Pid]
+            ),
+            ok
     end.
 
 subs_reg_delete(StoreName, FullPrefix, Pid) ->
     try
         ets:delete(?SUBS_REGISTRY, subs_reg_key(StoreName, FullPrefix, Pid))
     catch
-        _:_ -> ok
+        Class:Reason ->
+            ?LOG_WARNING(
+                "swc_store failed to delete internal subscriber from ETS (~p/~p): store=~p prefix=~p pid=~p",
+                [Class, Reason, StoreName, FullPrefix, Pid]
+            ),
+            ok
     end.
 
 subs_reg_match_store(StoreName) ->
     try
         ets:match_object(?SUBS_REGISTRY, {{StoreName, '_', '_'}, '_'})
     catch
-        _:_ -> []
+        Class:Reason ->
+            ?LOG_WARNING(
+                "swc_store failed to read internal subscriber from ETS (~p/~p): store=~p",
+                [Class, Reason, StoreName]
+            ),
+            []
     end.
 
 restore_subscriptions(StoreName, State0) ->

--- a/apps/vmq_swc/src/vmq_swc_sup.erl
+++ b/apps/vmq_swc/src/vmq_swc_sup.erl
@@ -22,6 +22,8 @@
 
 -behaviour(supervisor).
 
+-include("vmq_swc.hrl").
+
 %% API
 -export([start_link/0]).
 
@@ -44,6 +46,10 @@ start_link() ->
 %% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
 init([]) ->
     ets:new(vmq_swc_group_config, [named_table, public, {read_concurrency, true}]),
+    ets:new(
+        ?SUBS_REGISTRY,
+        [named_table, public, set, {read_concurrency, true}, {write_concurrency, true}]
+    ),
     MetricsWorker = #{
         id => vmq_swc_metrics,
         start => {vmq_swc_metrics, start_link, []}

--- a/apps/vmq_swc/test/vmq_swc_store_SUITE.erl
+++ b/apps/vmq_swc/test/vmq_swc_store_SUITE.erl
@@ -42,6 +42,10 @@ init_per_testcase(basic_store_test, Config) ->
     application:set_env(vmq_swc, dkm_dir, proplists:get_value(dkm_dir, Config)),
     ok = vmq_swc_plugin:plugin_start([basic]),
     Config;
+init_per_testcase(store_restart_test, Config) ->
+    init_per_testcase(basic_store_test, Config);
+init_per_testcase(bad_convertfun_test, Config) ->
+    init_per_testcase(basic_store_test, Config);
 init_per_testcase(partitioned_delete_test = Case, Config0) ->
     Config1 = [{sync_interval, {1000, 500}},{auto_gc, true}|Config0], % afa: why did we set sync_interval to 0 before?
     init_per_testcase_(Case, Config1, [electra, flail]);
@@ -62,6 +66,10 @@ init_per_testcase_(Case, Config, Nodenames) ->
 
 end_per_testcase(basic_store_test, _Config) ->
     application:stop(vmq_swc);
+end_per_testcase(store_restart_test, _Config) ->
+    application:stop(vmq_swc);
+end_per_testcase(bad_convertfun_test, _Config) ->
+    application:stop(vmq_swc);
 end_per_testcase(_, Config) ->
     PeerNodes = proplists:get_value(peer_nodes, Config),
     vmq_swc_test_utils:pmap(fun({Peer, Node}) -> vmq_swc_test_utils:stop_peer(Peer, Node) end,
@@ -77,6 +85,8 @@ all() ->
 
 groups() ->
     AllTests = [basic_store_test,
+                store_restart_test,
+                bad_convertfun_test,
                 read_write_delete_test,
                 partitioned_cluster_test,
                 partitioned_delete_test,
@@ -109,7 +119,68 @@ basic_store_test(_Config) ->
       fun(P) ->
               KVsForPrefix = vmq_swc:fold(basic, fun(K,V, Acc) -> [{K, V}|Acc] end, [], P, []),
               ?assertEqual(KVsForPrefix, maps:get(P, KVPairsByPrefix))
-      end, Prefixes).
+       end, Prefixes).
+
+store_restart_test(_Config) ->
+    Group = basic,
+    Config = vmq_swc:config(Group),
+    StoreName = list_to_atom("vmq_swc_store_" ++ atom_to_list(Group)),
+    Prefix = {test, subs},
+    Key = key1,
+    Value = val1,
+    ConvertFun = fun(Evt) -> {swc_evt, Evt} end,
+    ok = vmq_swc_store:subscribe(Config, Prefix, ConvertFun),
+    StorePid0 = whereis(StoreName),
+    ?assert(is_pid(StorePid0)),
+    exit(StorePid0, kill),
+    _StorePid1 = wait_until_pid(StoreName, StorePid0, 50),
+    %% trigger an event, should still be delivered after restart
+    ok = vmq_swc:put(Group, Prefix, Key, Value, []),
+    receive
+        {swc_evt, {updated, Prefix, Key, _OldVals, _NewVals}} -> ok
+    after 5000 ->
+        ct:fail(timeout)
+    end.
+
+bad_convertfun_test(_Config) ->
+    Group = basic,
+    Config = vmq_swc:config(Group),
+    StoreName = list_to_atom("vmq_swc_store_" ++ atom_to_list(Group)),
+    Prefix = {test, subs_crash},
+    Key = key2,
+    Value = val2,
+    BadFun = fun(_Evt) -> erlang:error(bad_convertfun) end,
+    GoodFun = fun(Evt) -> {good_evt, Evt} end,
+    ok = vmq_swc_store:subscribe(Config, Prefix, BadFun),
+    ok = vmq_swc_store:subscribe(Config, Prefix, GoodFun),
+    StorePid0 = whereis(StoreName),
+    MRef = monitor(process, StorePid0),
+    ok = vmq_swc:put(Group, Prefix, Key, Value, []),
+    receive
+        {good_evt, {updated, Prefix, Key, _OldVals, _NewVals}} -> ok
+    after 5000 ->
+        ct:fail(timeout)
+    end,
+    receive
+        {'DOWN', MRef, process, _, Reason} ->
+            ct:fail({store_crashed, Reason})
+    after 500 ->
+        demonitor(MRef, [flush]),
+        ok
+    end.
+
+wait_until_pid(Name, OldPid, 0) ->
+    Pid = whereis(Name),
+    case is_pid(Pid) andalso (Pid =/= OldPid) of
+        true -> Pid;
+        false -> ct:fail(store_not_restarted)
+    end;
+wait_until_pid(Name, OldPid, N) ->
+    Pid = whereis(Name),
+    case is_pid(Pid) andalso (Pid =/= OldPid) of
+        true -> Pid;
+        false -> ct:sleep(100), wait_until_pid(Name, OldPid, N - 1)
+    end.
 
 read_write_delete_test(Config) ->
     [Node1|OtherNodes] = Nodes = proplists:get_value(nodes, Config),    


### PR DESCRIPTION
Make store processes robust against event subscriber loss.
