### PR TITLE
Add listener address, port, and type to MQTT5 hook

### DIFF
--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -68,6 +68,9 @@
         | username()
         | {preauth, string() | undefined},
     conn_opts :: map(),
+    listener_addr :: undefined | tuple() | {local, string()},
+    listener_port :: undefined | non_neg_integer(),
+    listener_type :: undefined | atom(),
     keep_alive :: undefined | non_neg_integer(),
     keep_alive_tref :: undefined | reference(),
     clean_start = false :: flag(),
@@ -154,6 +157,9 @@ init(
             {_, PreAuth} -> {preauth, PreAuth}
         end,
     ConnOpts = proplists:get_value(conn_opts, Opts, undefined),
+    ListenerAddr = proplists:get_value(listener_addr, Opts, undefined),
+    ListenerPort = proplists:get_value(listener_port, Opts, undefined),
+    ListenerType = proplists:get_value(listener_type, Opts, undefined),
     AllowAnonymous = vmq_config:get_env(allow_anonymous, false),
     SharedSubPolicy = vmq_config:get_env(shared_subscription_policy, prefer_local),
     MaxClientIdSize = vmq_config:get_env(max_client_id_size, 23),
@@ -212,6 +218,9 @@ init(
         max_message_rate = MaxMessageRate,
         username = PreAuthUser,
         conn_opts = ConnOpts,
+        listener_addr = ListenerAddr,
+        listener_port = ListenerPort,
+        listener_type = ListenerType,
         max_client_id_size = MaxClientIdSize,
         keep_alive = KeepAlive,
         keep_alive_tref = undefined,
@@ -1363,15 +1372,31 @@ auth_on_register(Password, Props, State) ->
         cap_settings = CAPSettings,
         subscriber_id = SubscriberId,
         username = User,
-        conn_opts = ConnOpts
+        conn_opts = ConnOpts,
+        listener_addr = ListenerAddr,
+        listener_port = ListenerPort,
+        listener_type = ListenerType
     } = State,
     BasicHookArgs = [Peer, SubscriberId, User, Password, CleanStart, Props],
-    HookArgs =
+    ListenerInfo = #{
+        listener_addr => ListenerAddr,
+        listener_port => ListenerPort,
+        listener_type => ListenerType
+    },
+    ExtendedOpts =
         case ConnOpts of
-            M when is_map(M) -> lists:flatten([BasicHookArgs | [M]]);
-            _ -> BasicHookArgs
+            M when is_map(M) -> maps:merge(M, ListenerInfo);
+            _ -> ListenerInfo
         end,
-    case vmq_plugin:all_till_ok(auth_on_register_m5, HookArgs) of
+    HookArgs7 = lists:flatten([BasicHookArgs | [ExtendedOpts]]),
+    HookResult =
+        case vmq_plugin:all_till_ok(auth_on_register_m5, HookArgs7) of
+            {error, no_matching_hook_found} ->
+                vmq_plugin:all_till_ok(auth_on_register_m5, BasicHookArgs);
+            Res ->
+                Res
+        end,
+    case HookResult of
         ok ->
             {ok, queue_opts([], Props, State), #{}, State};
         {ok, Args0} ->

--- a/apps/vmq_server/src/vmq_ranch_config.erl
+++ b/apps/vmq_server/src/vmq_ranch_config.erl
@@ -138,7 +138,8 @@ start_listener(Type, Addr, Port, {SocketOpts, Opts}) ->
         Opts,
         vmq_config:get_env(nr_of_acceptors)
     ),
-    ProtocolOpts = protocol_opts_for_type(Type, Opts),
+    ListenerOpts = [{listener_addr, AAddr}, {listener_port, Port}, {listener_type, Type} | Opts],
+    ProtocolOpts = protocol_opts_for_type(Type, ListenerOpts),
     TransportMod = transport_for_type(Type),
     TransportOptions = maps:from_list(
         [
@@ -437,12 +438,18 @@ default_session_opts(Opts) ->
     MaxConnectionLifeTime = proplists:get_value(max_connection_lifetime, Opts, 0),
     AllowAnonymousOverride = proplists:get_value(allow_anonymous_override, Opts, false),
     BufferSizes = proplists:get_value(buffer_sizes, Opts, undefined),
+    ListenerAddr = proplists:get_value(listener_addr, Opts, undefined),
+    ListenerPort = proplists:get_value(listener_port, Opts, undefined),
+    ListenerType = proplists:get_value(listener_type, Opts, undefined),
     [
         {mountpoint, proplists:get_value(mountpoint, Opts, "")},
         {allowed_protocol_versions, AllowedProtocolVersions},
         {max_connection_lifetime, MaxConnectionLifeTime},
         {allow_anonymous_override, AllowAnonymousOverride},
-        {buffer_sizes, BufferSizes}
+        {buffer_sizes, BufferSizes},
+        {listener_addr, ListenerAddr},
+        {listener_port, ListenerPort},
+        {listener_type, ListenerType}
         | MaybeProxyDefaults2
     ].
 

--- a/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
+++ b/apps/vmq_webhooks/src/vmq_webhooks_plugin.erl
@@ -354,7 +354,20 @@ auth_on_register_m5(Peer, SubscriberId, UserName, Password, CleanStart, Props, O
             {encrypted, _} -> credentials_obfuscation:decrypt(Password);
             A -> A
         end,
-    all_till_ok(auth_on_register_m5, [
+    ListenerAddr =
+        case maps:get(listener_addr, Opts, undefined) of
+            undefined -> null;
+            {local, _} -> <<"local">>;
+            LAddr when is_tuple(LAddr) -> list_to_binary(inet:ntoa(LAddr))
+        end,
+    ListenerPort = nullify(maps:get(listener_port, Opts, undefined)),
+    ListenerType =
+        case maps:get(listener_type, Opts, undefined) of
+            undefined -> null;
+            LT -> atom_to_binary(LT, utf8)
+        end,
+    FilteredOpts = maps:without([listener_addr, listener_port, listener_type], Opts),
+    BaseArgs = [
         {addr, PPeer},
         {port, Port},
         {mountpoint, MP},
@@ -363,8 +376,16 @@ auth_on_register_m5(Peer, SubscriberId, UserName, Password, CleanStart, Props, O
         {password, nullify(PasswordPlain)},
         {clean_start, CleanStart},
         {properties, Props},
-        Opts
-    ]).
+        {listener_addr, ListenerAddr},
+        {listener_port, ListenerPort},
+        {listener_type, ListenerType}
+    ],
+    FullArgs =
+        case map_size(FilteredOpts) of
+            0 -> BaseArgs;
+            _ -> BaseArgs ++ [FilteredOpts]
+        end,
+    all_till_ok(auth_on_register_m5, FullArgs).
 
 -spec auth_on_publish(username(), subscriber_id(), qos(), topic(), payload(), flag()) ->
     'next' | 'ok' | {'error', any()} | {'ok', payload() | [auth_on_publish_hook:msg_modifier()]}.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 - Bugfix: closed connection count for mqtt listeners when there is an exception in the connection loop.
 - Enhancement: Disable `expire_retain_cache` as a default.
+- Add listener address, port, and type to auth_on_register and auth_on_register_m5
 
 ## VerneMQ 2.1.2
 


### PR DESCRIPTION
## Proposed Changes

I want to apply different authenticazion rules to incoming connections based on the listener the connection is coming from, so I need this info on hook requests.

I ran the tests: 
...
%%% vmq_info_SUITE ==> filtering_works: FAILED
%%% vmq_info_SUITE ==> timetrap_timeout
...
Failed 1 tests. Skipped 10 (10, 0) tests. Passed 501 tests. 

I don't think this is related to my changes.

(Done with support of Cloude Code)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [X] I have updated changelog (At the bottom of the release version)
- [X] I have squashed all my commits into one before merging
