### PR TITLE
Poll the local subs table before confirming subscriptions

### DIFF
--- a/apps/vmq_server/include/vmq_metrics.hrl
+++ b/apps/vmq_server/include/vmq_metrics.hrl
@@ -74,6 +74,7 @@
 -define(MQTT4_PUBLISH_ERROR, mqtt_publish_error).
 -define(MQTT4_SUBSCRIBE_ERROR, mqtt_subscribe_error).
 -define(MQTT4_UNSUBSCRIBE_ERROR, mqtt_unsubscribe_error).
+-define(MQTT_SUBSCRIBE_VISIBILITY_TIMEOUT, mqtt_subscribe_visibility_timeout).
 -define(MQTT4_CLIENT_KEEPALIVE_EXPIRED, mqtt4_client_keepalive_expired).
 -define(METRIC_QUEUE_SETUP, queue_setup).
 -define(METRIC_QUEUE_INITIALIZED_FROM_STORAGE, queue_initialized_from_storage).

--- a/apps/vmq_server/priv/vmq_server.schema
+++ b/apps/vmq_server/priv/vmq_server.schema
@@ -162,6 +162,22 @@
                                                              {datatype, integer}
                                                             ]}.
 
+%% @doc Maximum number of retries for waiting until a new subscription
+%% is visible in local routing ETS tables before sending SUBACK.
+{mapping, "max_subscription_retry", "vmq_server.max_subscription_retry", [
+                                                                            {default, 10},
+                                                                            {datatype, integer},
+                                                                            hidden
+                                                                           ]}.
+
+%% @doc Sleep interval in milliseconds between retries while waiting
+%% for subscription visibility in local routing ETS tables.
+{mapping, "subscription_retry_interval_ms", "vmq_server.subscription_retry_interval_ms", [
+                                                                                             {default, 100},
+                                                                                             {datatype, integer},
+                                                                                             hidden
+                                                                                            ]}.
+
 %% @doc Set the maximum size for client IDs. MQTT v3.1 specifies a
 %% limit of 23 characters
 {mapping, "max_client_id_size", "vmq_server.max_client_id_size", [

--- a/apps/vmq_server/src/vmq_metrics.erl
+++ b/apps/vmq_server/src/vmq_metrics.erl
@@ -1139,6 +1139,13 @@ counter_entries_def() ->
             mqtt_subscribe_error,
             <<"The number of times a SUBSCRIBE operation failed due to a netsplit.">>
         ),
+        m(
+            counter,
+            [],
+            ?MQTT_SUBSCRIBE_VISIBILITY_TIMEOUT,
+            mqtt_subscribe_visibility_timeout,
+            <<"The number of times SUBSCRIBE visibility checks timed out before SUBACK.">>
+        ),
 
         m(
             counter,
@@ -2173,7 +2180,8 @@ met2idx(mqtt_connack_unacceptable_protocol_sent) -> 192;
 met2idx(mqtt_connack_accepted_sent) -> 193;
 met2idx(?METRIC_SOCKET_CLOSE_TIMEOUT) -> 194;
 met2idx(?MQTT5_CLIENT_KEEPALIVE_EXPIRED) -> 195;
-met2idx(?MQTT4_CLIENT_KEEPALIVE_EXPIRED) -> 196.
+met2idx(?MQTT4_CLIENT_KEEPALIVE_EXPIRED) -> 196;
+met2idx(?MQTT_SUBSCRIBE_VISIBILITY_TIMEOUT) -> 197.
 
 -ifdef(TEST).
 clear_stored_rates() ->

--- a/apps/vmq_server/src/vmq_reg.erl
+++ b/apps/vmq_server/src/vmq_reg.erl
@@ -74,6 +74,8 @@
 }).
 
 -define(NR_OF_REG_RETRIES, 10).
+-define(DEFAULT_MAX_SUBSCRIPTION_RETRY, 10).
+-define(DEFAULT_SUBSCRIPTION_RETRY_INTERVAL_MS, 100).
 
 -spec subscribe(
     flag(),
@@ -93,6 +95,22 @@ subscribe_op(SubscriberId, Topics) ->
     OldSubs = subscriptions_for_subscriber_id(SubscriberId),
     Existing = subscriptions_exist(OldSubs, Topics),
     add_subscriber(lists:usort(Topics), OldSubs, SubscriberId),
+    AddedSubscriptions = added_subscriptions(Existing, Topics),
+    case wait_until_subscriptions_visible(SubscriberId, AddedSubscriptions) of
+        ok ->
+            ok;
+        {error, not_ready} ->
+            vmq_metrics:incr(mqtt_subscribe_visibility_timeout),
+            AddedTopics = [Topic || {Topic, _} <- AddedSubscriptions],
+            ?LOG_WARNING(
+                "SUBSCRIBE visibility timeout; subscriber_id=~p added_topics=~p",
+                [SubscriberId, AddedTopics]
+            )
+    end,
+    {ok, subscribe_qos_table(SubscriberId, Existing, Topics)}.
+
+-spec subscribe_qos_table(subscriber_id(), [boolean()], [subscription()]) -> [qos() | not_allowed].
+subscribe_qos_table(SubscriberId, Existing, Topics) ->
     {QoSTable, _Ign} =
         lists:foldl(
             fun
@@ -114,7 +132,100 @@ subscribe_op(SubscriberId, Topics) ->
             {[], (vmq_config:get_env(subscriber_retain_mode, immediate) == syncwait)},
             lists:zip(Existing, Topics)
         ),
-    {ok, lists:reverse(QoSTable)}.
+    lists:reverse(QoSTable).
+
+-spec added_subscriptions([boolean()], [subscription()]) -> [subscription()].
+added_subscriptions(Existing, Topics) ->
+    lists:foldl(
+        fun
+            ({false, {_Topic, QoS} = Subscription}, Acc) when is_integer(QoS) ->
+                [Subscription | Acc];
+            ({false, {_Topic, {QoS, SubOpts}} = Subscription}, Acc) when
+                is_integer(QoS), is_map(SubOpts)
+            ->
+                [Subscription | Acc];
+            (_, Acc) ->
+                Acc
+        end,
+        [],
+        lists:zip(Existing, Topics)
+    ).
+
+-spec wait_until_subscriptions_visible(subscriber_id(), [subscription()]) ->
+    ok | {error, not_ready}.
+wait_until_subscriptions_visible(_SubscriberId, []) ->
+    ok;
+wait_until_subscriptions_visible(SubscriberId, AddedSubscriptions) ->
+    MaxRetries = non_neg_integer_env(max_subscription_retry, ?DEFAULT_MAX_SUBSCRIPTION_RETRY),
+    RetryIntervalMs = non_neg_integer_env(
+        subscription_retry_interval_ms, ?DEFAULT_SUBSCRIPTION_RETRY_INTERVAL_MS
+    ),
+    wait_until_subscriptions_visible(
+        SubscriberId,
+        vmq_config:get_env(default_reg_view, vmq_reg_trie),
+        AddedSubscriptions,
+        MaxRetries,
+        RetryIntervalMs
+    ).
+
+wait_until_subscriptions_visible(
+    SubscriberId, RegView, AddedSubscriptions, Retries, RetryIntervalMs
+) ->
+    case subscriptions_visible(SubscriberId, RegView, AddedSubscriptions) of
+        true ->
+            ok;
+        false when Retries =< 0 ->
+            {error, not_ready};
+        false ->
+            timer:sleep(RetryIntervalMs),
+            wait_until_subscriptions_visible(
+                SubscriberId, RegView, AddedSubscriptions, Retries - 1, RetryIntervalMs
+            )
+    end.
+
+-spec subscriptions_visible(subscriber_id(), atom(), [subscription()]) -> boolean().
+subscriptions_visible(SubscriberId, RegView, AddedSubscriptions) ->
+    lists:all(
+        fun(Subscription) ->
+            subscription_visible(SubscriberId, RegView, Subscription)
+        end,
+        AddedSubscriptions
+    ).
+
+-spec subscription_visible(subscriber_id(), atom(), subscription()) -> boolean().
+subscription_visible(SubscriberId, vmq_reg_ordered_trie, Subscription) ->
+    subscription_visible(
+        vmq_ordered_tree_subs, vmq_ordered_subs_fanout, SubscriberId, Subscription
+    );
+subscription_visible(SubscriberId, _RegView, Subscription) ->
+    subscription_visible(vmq_trie_subs, vmq_trie_subs_fanout, SubscriberId, Subscription).
+
+subscription_visible(SubsTab, FanoutTab, {MP, _} = SubscriberId, {
+    [<<"$share">>, Group | Topic], SubInfo
+}) ->
+    Key = {MP, Group, node(), Topic},
+    Value = {node(), Group, SubscriberId, SubInfo},
+    ets_subscription_exists(SubsTab, FanoutTab, Key, Value);
+subscription_visible(SubsTab, FanoutTab, {MP, _} = SubscriberId, {Topic, SubInfo}) ->
+    Key = {MP, Topic},
+    Value = {SubscriberId, SubInfo},
+    ets_subscription_exists(SubsTab, FanoutTab, Key, Value).
+
+ets_subscription_exists(SubsTab, FanoutTab, Key, Value) ->
+    case lists:member({Key, Value}, ets:lookup(SubsTab, Key)) of
+        true ->
+            true;
+        false ->
+            ets:member(FanoutTab, {Key, Value})
+    end.
+
+non_neg_integer_env(Key, Default) ->
+    case vmq_config:get_env(Key, Default) of
+        V when is_integer(V), V >= 0 ->
+            V;
+        _ ->
+            Default
+    end.
 
 -spec unsubscribe(flag(), subscriber_id(), [topic()]) -> ok | {error, not_ready}.
 unsubscribe(false, SubscriberId, Topics) ->

--- a/apps/vmq_server/test/vmq_subscribe_SUITE.erl
+++ b/apps/vmq_server/test/vmq_subscribe_SUITE.erl
@@ -50,6 +50,7 @@ groups() ->
          subpub_qos0_test,
          subpub_qos1_test,
          subpub_qos2_test,
+         subpub_pipelined_after_subscribe_test,
          resubscribe_test,
          bridge_protocol_retain_as_publish_test,
          bridge_protocol_no_local_test],
@@ -57,6 +58,7 @@ groups() ->
      {mqttv4, [shuffle,sequence], Tests},
      {mqttv5, [shuffle],
       [
+       subpub_pipelined_after_subscribe_mqtt5_test,
        subscribe_no_local_test,
        subscribe_illegal_opt,
        subscription_ids
@@ -415,6 +417,53 @@ subpub_qos2_test(_) ->
     ok = gen_tcp:send(Socket, Pubrec2),
     ok = packet:expect_packet(Socket, "pubrel2", Pubrel2),
     ok = gen_tcp:close(Socket).
+
+subpub_pipelined_after_subscribe_test(_Cfg) ->
+    TopicBase =
+        "subpub/pipelined/" ++ integer_to_list(erlang:unique_integer([positive])),
+    subpub_pipelined_after_subscribe_test(TopicBase, 20).
+
+subpub_pipelined_after_subscribe_test(_TopicBase, 0) ->
+    ok;
+subpub_pipelined_after_subscribe_test(TopicBase, N) ->
+    Suffix = integer_to_list(N),
+    ClientId = "subpub-pipelined-after-subscribe-" ++ Suffix,
+    Topic = TopicBase ++ "/" ++ Suffix,
+    Connect = packet:gen_connect(ClientId, [{keepalive, 60}]),
+    Connack = packet:gen_connack(0),
+    Subscribe = packet:gen_subscribe(2000 + N, Topic, 0),
+    Suback = packet:gen_suback(2000 + N, 0),
+    Publish = packet:gen_publish(Topic, 0, <<"message">>, []),
+    {ok, Socket} = packet:do_client_connect(Connect, Connack, []),
+    ok = gen_tcp:send(Socket, <<Subscribe/binary, Publish/binary>>),
+    ok = packet:expect_packet(Socket, "suback", Suback),
+    ok = packet:expect_packet(Socket, "publish", Publish),
+    ok = gen_tcp:close(Socket),
+    subpub_pipelined_after_subscribe_test(TopicBase, N - 1).
+
+subpub_pipelined_after_subscribe_mqtt5_test(_Cfg) ->
+    TopicBase =
+        "subpub/pipelined/mqtt5/" ++ integer_to_list(erlang:unique_integer([positive])),
+    subpub_pipelined_after_subscribe_mqtt5_test(TopicBase, 20).
+
+subpub_pipelined_after_subscribe_mqtt5_test(_TopicBase, 0) ->
+    ok;
+subpub_pipelined_after_subscribe_mqtt5_test(TopicBase, N) ->
+    Suffix = integer_to_list(N),
+    ClientId = "subpub-pipelined-after-subscribe-mqtt5-" ++ Suffix,
+    Topic = TopicBase ++ "/" ++ Suffix,
+    Connect = packetv5:gen_connect(ClientId, [{keepalive, 60}]),
+    Connack = packetv5:gen_connack(),
+    SubTopic = packetv5:gen_subtopic(Topic, 0),
+    Subscribe = packetv5:gen_subscribe(3000 + N, [SubTopic], #{}),
+    Suback = packetv5:gen_suback(3000 + N, [0], #{}),
+    Publish = packetv5:gen_publish(Topic, 0, <<"message">>, []),
+    {ok, Socket} = packetv5:do_client_connect(Connect, Connack, []),
+    ok = gen_tcp:send(Socket, <<Subscribe/binary, Publish/binary>>),
+    ok = packetv5:expect_frame(Socket, Suback),
+    ok = packetv5:expect_frame(Socket, Publish),
+    ok = gen_tcp:close(Socket),
+    subpub_pipelined_after_subscribe_mqtt5_test(TopicBase, N - 1).
 
 resubscribe_test(_) ->
     %% test that we can override a subscription


### PR DESCRIPTION
A minimal fix for https://github.com/vernemq/vernemq/issues/2412

This waits for RAM tables to have a subscription stored before the session sends out a SUBACK. Since it uses a polling approach, we'll have to test behaviour under considerable load. The added logs & metrics will allow conclusions.

Note that this only takes care of the local subscription table. Waiting/coordinating in a cluster will be a next step.
