### PR TITLE
Treat embedded topic-validation errors as protocol errors

### DIFF
--- a/apps/vmq_commons/src/vmq_parser.erl
+++ b/apps/vmq_commons/src/vmq_parser.erl
@@ -68,7 +68,8 @@
 parse(Data) ->
     parse(Data, ?MAX_PACKET_SIZE).
 
--spec parse(binary(), non_neg_integer()) -> {mqtt_frame(), binary()} | {error, atom()} | more.
+-spec parse(binary(), non_neg_integer()) ->
+    {mqtt_frame(), binary()} | {error, atom()} | {{error, atom()}, any()} | more.
 parse(Data, MaxSize) when MaxSize > ?MAX_PACKET_SIZE ->
     parse(Data, ?MAX_PACKET_SIZE);
 parse(<<Fixed:1/binary, 0:1, DataSize:7, Data/binary>>, MaxSize) ->

--- a/apps/vmq_commons/test/vmq_parser_SUITE.erl
+++ b/apps/vmq_commons/test/vmq_parser_SUITE.erl
@@ -31,7 +31,8 @@ all() ->
      not_enough_data_max_exceeded,
      not_enough_data_max_not_exceeded,
      parse_unparse_tests,
-     no_null_char_in_client  
+     no_null_char_in_client,
+     subscribe_invalid_wildcard_in_word
     ].
 
 %%--------------------------------------------------------------------
@@ -71,6 +72,21 @@ not_enough_data_max_not_exceeded(_Config) ->
 no_null_char_in_client(_Config) ->
     C = vmq_parser:gen_connect(<<1,0>>, []),
     {{error, invalid_utf8_string}, <<>>} = vmq_parser:parse(C).
+
+subscribe_invalid_wildcard_in_word(_Config) ->
+    %% A SUBSCRIBE whose topic filter contains a '+' wildcard in the middle
+    %% of a word is invalid per [MQTT-4.7.1-3] (the wildcard must occupy an
+    %% entire level). The parser surfaces this as a frame-level error embedded
+    %% in a {Frame, Rest} tuple, which the session FSM must treat as a protocol
+    %% error rather than feeding it to the state machine as an unexpected
+    %% message.
+    SubPlus = vmq_parser:gen_subscribe(123, "sport/tennis+", 0),
+    {{error, 'no_+_allowed_in_word'}, <<>>} = vmq_parser:parse(SubPlus),
+    SubHash = vmq_parser:gen_subscribe(124, "sport/tennis#", 0),
+    {{error, 'no_#_allowed_in_word'}, <<>>} = vmq_parser:parse(SubHash),
+    %% Same handling applies to UNSUBSCRIBE topic filters.
+    Unsub = vmq_parser:gen_unsubscribe(125, "sport/tennis+"),
+    {{error, 'no_+_allowed_in_word'}, <<>>} = vmq_parser:parse(Unsub).
 
 parse_unparse_tests(_Config) ->
     compare_frame("connect1", vmq_parser:gen_connect("test-client", [])),

--- a/apps/vmq_commons/test/vmq_parser_mqtt5_SUITE.erl
+++ b/apps/vmq_commons/test/vmq_parser_mqtt5_SUITE.erl
@@ -39,7 +39,8 @@ all() ->
      parse_unparse_pingresp_test,
      parse_unparse_disconnect_test,
      parse_unparse_auth_test,
-     no_null_char_in_client].
+     no_null_char_in_client,
+     subscribe_invalid_wildcard_in_word].
 
 parse_unparse_tests(_Config) ->
     Properties = #{p_session_expiry_interval => 12341234},
@@ -264,6 +265,27 @@ parse_unparse_properties_test(_Config) ->
 no_null_char_in_client(_Config) ->
     C = vmq_parser_mqtt5:gen_connect(<<1,0>>, []),
     {{error, invalid_utf8_string}, <<>>} = vmq_parser_mqtt5:parse(C).
+
+subscribe_invalid_wildcard_in_word(_Config) ->
+    %% A SUBSCRIBE whose topic filter contains a '+' wildcard in the middle
+    %% of a word is invalid per [MQTT-4.7.1-3] (the wildcard must occupy an
+    %% entire level). The parser surfaces this as a frame-level error embedded
+    %% in a {Frame, Rest} tuple, which the session FSM must treat as a protocol
+    %% error rather than feeding it to the state machine as an unexpected
+    %% message.
+    SubPlus = vmq_parser_mqtt5:gen_subscribe(
+                123, [#mqtt5_subscribe_topic{topic = <<"sport/tennis+">>, qos = 0,
+                                       no_local = false, rap = false,
+                                       retain_handling = send_retain}], #{}),
+    {{error, 'no_+_allowed_in_word'}, <<>>} = vmq_parser_mqtt5:parse(SubPlus),
+    SubHash = vmq_parser_mqtt5:gen_subscribe(
+                124, [#mqtt5_subscribe_topic{topic = <<"sport/tennis#">>, qos = 0,
+                                       no_local = false, rap = false,
+                                       retain_handling = send_retain}], #{}),
+    {{error, 'no_#_allowed_in_word'}, <<>>} = vmq_parser_mqtt5:parse(SubHash),
+    %% Same handling applies to UNSUBSCRIBE topic filters.
+    Unsub = vmq_parser_mqtt5:gen_unsubscribe(125, [<<"sport/tennis+">>], #{}),
+    {{error, 'no_+_allowed_in_word'}, <<>>} = vmq_parser_mqtt5:parse(Unsub).
 
 parse_unparse_property(Property) ->
     Encoded = enc_property_(Property),

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -253,6 +253,13 @@ data_in(Data, SessionState, OutAcc) ->
             E;
         {error, Reason} ->
             {error, Reason, lists:reverse(OutAcc)};
+        {{error, Reason}, _Rest} ->
+            %% The parser embeds frame-level validation errors (e.g. an
+            %% invalid wildcard in a SUBSCRIBE topic) as the "frame" of a
+            %% {Frame, Rest} tuple. Treat them as protocol errors and close
+            %% the connection cleanly instead of feeding the error term to
+            %% the FSM as an unexpected message.
+            {error, Reason, lists:reverse(OutAcc)};
         {Frame, Rest} ->
             case in(Frame, SessionState, true) of
                 {stop, Reason, Out} ->

--- a/apps/vmq_server/src/vmq_mqtt5_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt5_fsm.erl
@@ -255,11 +255,21 @@ data_in(Data, SessionState, OutAcc) ->
             {error, Reason, lists:reverse(OutAcc)};
         {{error, Reason}, _Rest} ->
             %% The parser embeds frame-level validation errors (e.g. an
-            %% invalid wildcard in a SUBSCRIBE topic) as the "frame" of a
-            %% {Frame, Rest} tuple. Treat them as protocol errors and close
-            %% the connection cleanly instead of feeding the error term to
-            %% the FSM as an unexpected message.
-            {error, Reason, lists:reverse(OutAcc)};
+            %% invalid wildcard in a SUBSCRIBE topic filter) as the "frame"
+            %% of a {Frame, Rest} tuple, so they never reach the state
+            %% machine as a real frame. Handle them here as protocol errors
+            %% instead of feeding the error term to the FSM as an unexpected
+            %% message. For an established session we inform the client with
+            %% a DISCONNECT carrying an appropriate reason code; a DISCONNECT
+            %% must not precede the CONNACK, so in any other session state we
+            %% just close the connection.
+            case SessionState of
+                {connected, State} ->
+                    {stop, StopReason, Out} = terminate(frame_error_rcn(Reason), State),
+                    {stop, StopReason, lists:reverse([Out | OutAcc])};
+                _ ->
+                    {error, Reason, lists:reverse(OutAcc)}
+            end;
         {Frame, Rest} ->
             case in(Frame, SessionState, true) of
                 {stop, Reason, Out} ->
@@ -2221,6 +2231,15 @@ gen_disconnect(RCN, Props) ->
 gen_disconnect_(RCN, Props) ->
     _ = vmq_metrics:incr({?MQTT5_DISCONNECT_SENT, RCN}),
     serialise_frame(#mqtt5_disconnect{reason_code = rcn2rc(RCN), properties = Props}).
+
+%% Map a parser frame-validation error to the MQTT 5.0 reason code sent in
+%% the DISCONNECT before the connection is closed.
+-spec frame_error_rcn(atom()) -> reason_code_name().
+frame_error_rcn('no_+_allowed_in_word') -> ?TOPIC_FILTER_INVALID;
+frame_error_rcn('no_#_allowed_in_word') -> ?TOPIC_FILTER_INVALID;
+frame_error_rcn('no_+_allowed_in_publish') -> ?TOPIC_NAME_INVALID;
+frame_error_rcn('no_#_allowed_in_publish') -> ?TOPIC_NAME_INVALID;
+frame_error_rcn(_) -> ?MALFORMED_PACKET.
 
 msg_expiration(#{p_message_expiry_interval := ExpireAfter}) ->
     {expire_after, ExpireAfter};

--- a/apps/vmq_server/src/vmq_mqtt_fsm.erl
+++ b/apps/vmq_server/src/vmq_mqtt_fsm.erl
@@ -212,6 +212,13 @@ data_in(Data, SessionState, OutAcc) ->
             E;
         {error, Reason} ->
             {error, Reason, serialise(OutAcc)};
+        {{error, Reason}, _Rest} ->
+            %% The parser embeds frame-level validation errors (e.g. an
+            %% invalid wildcard in a SUBSCRIBE topic) as the "frame" of a
+            %% {Frame, Rest} tuple. Treat them as protocol errors and close
+            %% the connection cleanly instead of feeding the error term to
+            %% the FSM as an unexpected message.
+            {error, Reason, serialise(OutAcc)};
         {Frame, Rest} ->
             case in(Frame, SessionState, true) of
                 {stop, Reason, Out} ->

--- a/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
+++ b/apps/vmq_server/test/vmq_mqtt5_SUITE.erl
@@ -50,7 +50,8 @@ groups() ->
      enhanced_auth_new_auth_method_fails,
      reauthenticate,
      reauthenticate_server_rejects,
-     unsubscribe_hook
+     unsubscribe_hook,
+     subscribe_invalid_wildcard
     ],
     [
      {mqtt, [shuffle], ConnectTests}
@@ -371,6 +372,24 @@ unsubscribe_hook(_Config) ->
         auth_on_register_m5, ?MODULE, auth_on_register_ok_hook, 6),
 
     ets:delete(?MODULE).
+
+subscribe_invalid_wildcard(_Config) ->
+    %% A SUBSCRIBE whose topic filter contains a '+' wildcard in the middle
+    %% of a word is invalid [MQTT-4.7.1-3]. The parser rejects it before the
+    %% frame reaches the state machine; for MQTT 5.0 the broker informs the
+    %% client with a DISCONNECT carrying reason code 0x8F (Topic Filter
+    %% invalid) and then closes the connection.
+    vmq_server_cmd:set_config(allow_anonymous, true),
+    vmq_config:configure_node(),
+    Connect = packetv5:gen_connect("subscribe-invalid-wildcard-test", [{keepalive, 10}]),
+    Connack = packetv5:gen_connack(),
+    {ok, Socket} = packetv5:do_client_connect(Connect, Connack, []),
+    Topic = packetv5:gen_subtopic("sport/tennis+", 0),
+    Sub = packetv5:gen_subscribe(7, [Topic], #{}),
+    ok = gen_tcp:send(Socket, Sub),
+    Disconnect = packetv5:gen_disconnect(?M5_TOPIC_FILTER_INVALID, #{}),
+    ok = packetv5:expect_frame(Socket, Disconnect),
+    {error, closed} = gen_tcp:recv(Socket, 0, 1000).
 
 %%%%% Helpers %%%%%
 auth_props(Method, Data) ->

--- a/apps/vmq_server/test/vmq_publish_SUITE.erl
+++ b/apps/vmq_server/test/vmq_publish_SUITE.erl
@@ -1123,6 +1123,8 @@ not_allowed_properties(_Config) ->
  
     Pub = packetv5:gen_publish(<<"bla">>, 0, <<"message">>, [{properties, #{p_server_ref => [1]}}]),
     ok = gen_tcp:send(PubSocket, Pub),
+    Disconnect = packetv5:gen_disconnect(?M5_MALFORMED_PACKET, #{}),
+    ok = packetv5:expect_frame(PubSocket, Disconnect),
     {error, closed} = gen_tcp:recv(PubSocket, 0, 1000).
   
 


### PR DESCRIPTION
A SUBSCRIBE/UNSUBSCRIBE whose topic filter contains a wildcard in the middle of a word (e.g. "sport/tennis+") is rejected by vmq_topic with {error, 'no_+_allowed_in_word'}. The parser surfaces this as the "frame" of a {Frame, Rest} tuple, so data_in/3 did not match its {error, Reason} clause and instead fed the error term to the FSM, which fell through to the connected/2 catch-all and terminated with the misleading nested reason {error,unexpected_message,{error,'no_+_allowed_in_word'}}, logged as an abnormal teardown.

Intercept {{error, Reason}, _Rest} in data_in/3 (MQTT 3.1.1 and 5.0) and handle it on the clean protocol-error path so the connection is closed with the plain reason instead of an unexpected_message.

Add parser SUITE tests documenting the {{error, Reason}, <<>>} shape for '+' and '#' wildcards in a word, for both SUBSCRIBE and UNSUBSCRIBE.


Claude-Session: https://claude.ai/code/session_012aksXd4UXShNd1WxwfqYcg

## Proposed Changes

Please describe the big picture of your changes here to communicate to the
VerneMQ team why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #XXXX)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ X ] Cosmetics (whitespace, styles...)
- [ ] DevOps (Build scripts, pipelines...)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ X ] I have read the [CODE_OF_CONDUCT.md](https://github.com/vernemq/vernemq/blob/main/CODE_OF_CONDUCT.md) document
- [ X ] All tests pass locally with my changes
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if needed)
- [ ] Any dependent changes have been merged and published in related repositories
- [ X ] I have updated changelog (At the bottom of the release version)
- [ X ] I have squashed all my commits into one before merging

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
